### PR TITLE
add validator to config manager class

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/dc_config.py
+++ b/src/bblocks/datacommons_tools/custom_data/dc_config.py
@@ -355,6 +355,20 @@ class DCConfigManager:
         # export the data
         self.export_data(dir_path)
 
+    def validate_config(self) -> "DCConfigManager":
+        """Validate the config
+
+        This method checks the config for any issues and ensuring all the fields and values are valid. It rai
+        an error if there are any issues with the config.
+
+        Raises:
+            pydantic.ValidationError if the config is not valid
+        """
+
+        # validate the config
+        self._config.validate_config()
+        return self
+
     def __repr__(self) -> str:
         input_files_count = len(self._config.inputFiles)
         sources_count = len(self._config.sources)


### PR DESCRIPTION
This pull request introduces a new method to validate the configuration in the `DCConfigManager` class. The change adds functionality for checking the validity of the configuration and raises an error if any issues are found.

### Enhancements to configuration validation:

* [`src/bblocks/datacommons_tools/custom_data/dc_config.py`](diffhunk://#diff-7ac77f723d6751b95f7282a78c6aae85903c36690fe7d227c92e4c109f311881R358-R371): Added a `validate_config` method to the `DCConfigManager` class. This method ensures that the configuration is valid by invoking the `_config.validate_config()` method and raises a `pydantic.ValidationError` if any issues are detected.