### PR TITLE
Add support for variablePerRow files

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/dc_config.py
+++ b/src/bblocks/datacommons_tools/custom_data/dc_config.py
@@ -10,9 +10,9 @@ from pydantic import HttpUrl
 from bblocks.datacommons_tools.custom_data.models.config_file import Config
 from bblocks.datacommons_tools.custom_data.models.data_files import (
     ObservationProperties,
-    VariablePerColumnFile,
+    ImplicitSchemaFile,
     ColumnMappings,
-    VariablePerRowFile,
+    ExplicitSchemaFile,
 )
 from bblocks.datacommons_tools.custom_data.models.sources import Source
 from bblocks.datacommons_tools.custom_data.models.stat_vars import Variable
@@ -275,7 +275,7 @@ class DCConfigManager:
         self._data_override_check(file_name=file_name, override=override)
 
         # add the file to the config
-        self._config.inputFiles[file_name] = VariablePerColumnFile(
+        self._config.inputFiles[file_name] = ImplicitSchemaFile(
             entityType=entityType,
             ignoreColumns=ignoreColumns,
             provenance=provenance,
@@ -327,7 +327,7 @@ class DCConfigManager:
         self._data_override_check(file_name=file_name, override=override)
 
         # add the file to the config
-        self._config.inputFiles[file_name] = VariablePerRowFile(
+        self._config.inputFiles[file_name] = ExplicitSchemaFile(
             ignoreColumns=ignoreColumns,
             provenance=provenance,
             columnMappings=ColumnMappings(**columnMappings),

--- a/src/bblocks/datacommons_tools/custom_data/models/data_files.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/data_files.py
@@ -76,7 +76,7 @@ class InputFile(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class VariablePerColumnFile(InputFile):
+class ImplicitSchemaFile(InputFile):
     """Representation of the ColumnFile section of the config file
     This is what is known as the implicit schema.
 
@@ -97,7 +97,7 @@ class VariablePerColumnFile(InputFile):
     data_format: FileType = Field(default="variablePerColumn", alias="format")
 
 
-class VariablePerRowFile(InputFile):
+class ExplicitSchemaFile(InputFile):
     """Representation of the RowFile section of the config file
     This is what is known as the explicit schema.
 


### PR DESCRIPTION
This PR is focused only on adding support for variablePerRow files. However, it makes changes to how `InputFile`s are registered in order to have a neater separation of concerns, and for methods to have more predictable effects.

- `InputFile` becomes the base type for `VariablePerColumnFile` and `VariablePerRowFile`. This simplifies validation (no need to check for data format, because now that is explicitly 'chosen' by the type of file used. A `FileType` string enum is also defined to define which file formats are allowed (vs the same string Literal in various places).
- `.add_input_file` is removed in favour of more specific `.add_variablePerColumn_input_file` and `.add_variablePerRow_intput_file` methods. This more neatly separates concerns, simplifies validation, and makes it easier for users to figure out which arguments are required in which case. 
- Renames `add_variable` to `add_variable_with_implicit_schema` since that method deals with adding data that way. I'm a bit unsure about the name since other names call things 'PerRow' and 'PerColumn' in other places. Thoughts welcome.