### PR TITLE
Explicit metadata parser

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/models/mcf.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/mcf.py
@@ -53,7 +53,7 @@ class MCFNode(BaseModel):
         return "\n".join(lines) + "\n\n"
 
 
-class Nodes(BaseModel):
+class MCFNodes(BaseModel):
     """Represents a collection of Nodes.
 
     Attributes:
@@ -74,7 +74,7 @@ class Nodes(BaseModel):
         self.nodes.append(MCFNode(**block))
         block.clear()
 
-    def load_from_mcf_file(self, file_name: str | PathLike) -> Nodes:
+    def load_from_mcf_file(self, file_name: str | PathLike) -> MCFNodes:
         """Parses MCF nodes from a file and populates the collection.
 
         Each node block is expected to start with
@@ -110,7 +110,7 @@ class Nodes(BaseModel):
 
         return self
 
-    def add(self, node: MCFNode) -> Nodes:
+    def add(self, node: MCFNode) -> MCFNodes:
         """Adds a new node to the collection.
 
         Args:
@@ -120,7 +120,7 @@ class Nodes(BaseModel):
 
         return self
 
-    def remove(self, node_id: str) -> Nodes:
+    def remove(self, node_id: str) -> MCFNodes:
         """Removes a node from the collection by its ID.
 
         Args:
@@ -136,7 +136,7 @@ class Nodes(BaseModel):
 
     def export_to_mcf_file(
         self, file_path: str | PathLike, *, overwrite: bool = True
-    ) -> Nodes:
+    ) -> MCFNodes:
         """Exports the MCF nodes to a file.
 
         Args:

--- a/src/bblocks/datacommons_tools/custom_data/schema_tools.py
+++ b/src/bblocks/datacommons_tools/custom_data/schema_tools.py
@@ -5,11 +5,11 @@ from typing import Any
 
 import pandas as pd
 
-from bblocks.datacommons_tools.custom_data.models.mcf import Nodes
+from bblocks.datacommons_tools.custom_data.models.mcf import MCFNodes
 from bblocks.datacommons_tools.custom_data.models.stat_vars import StatVarMCFNode
 
 
-def _rows_to_stat_var_nodes(data: pd.DataFrame) -> Nodes[StatVarMCFNode]:
+def _rows_to_stat_var_nodes(data: pd.DataFrame) -> MCFNodes[StatVarMCFNode]:
     """Convert a DataFrame into a collection of ``StatVarMCFNode`` objects.
 
     Empty/NA values are removed from each row before constructing the node.
@@ -27,7 +27,7 @@ def _rows_to_stat_var_nodes(data: pd.DataFrame) -> Nodes[StatVarMCFNode]:
         record = {k: v for k, v in record.items() if not pd.isna(v) and v != ""}
         nodes.append(StatVarMCFNode(**record))
 
-    return Nodes(nodes=nodes)
+    return MCFNodes(nodes=nodes)
 
 
 def csv_metadata_to_nodes(
@@ -35,7 +35,7 @@ def csv_metadata_to_nodes(
     *,
     column_to_property_mapping: dict[str, str] = None,
     csv_options: dict[str, Any] = None,
-) -> Nodes[StatVarMCFNode]:
+) -> MCFNodes[StatVarMCFNode]:
     """Read a CSV of StatVar metadata and return the corresponding MCF StatVar nodes.
 
     Args:


### PR DESCRIPTION
This PR adds a `Nodes` class for managing MCF nodes and new utility functions for converting CSV metadata into MCF nodes. It's another of the building blocks to fully support the explicit schema. The next (and last) stage will be to provide a higher-level API to interact with the different parts.

- `Nodes` represents and manages collections of MCF nodes. This includes methods for loading nodes from MCF files (`load_from_mcf_file`), adding/removing nodes (`add`, `remove`), and exporting nodes to files (`export_to_mcf_file`).
- Utility functions for CSV to MCF conversion (`/custom_data/schema_tools.py`): Added `_rows_to_stat_var_nodes` to convert DataFrame rows into `StatVarMCFNode` objects, and `csv_metadata_to_nodes` to map CSV metadata to MCF nodes with optional column-to-property mapping and CSV options.