### PR TITLE
Optionally ignore columns (mcf metadata)

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/data_management.py
+++ b/src/bblocks/datacommons_tools/custom_data/data_management.py
@@ -371,6 +371,7 @@ class CustomDataManager:
         mcf_file_name: Optional[str] = DEFAULT_STARVAR_MCF_NAME,
         column_to_property_mapping: dict[str, str] = None,
         csv_options: dict[str, Any] = None,
+        ignore_columns: Optional[List[str]] = None,
         override: bool = False,
     ) -> CustomDataManager:
         """
@@ -383,6 +384,7 @@ class CustomDataManager:
                 ``StatVarMCFNode`` attribute names.
             csv_options: Extra keyword arguments forwarded verbatim to
                 ``pandas.read_csv``.
+            ignore_columns: List of columns to ignore in the CSV file.
             override: If True, overwrite the existing nodes if they exist. Defaults to False.
         """
         stat_vars = csv_metadata_to_nodes(

--- a/src/bblocks/datacommons_tools/custom_data/schema_tools.py
+++ b/src/bblocks/datacommons_tools/custom_data/schema_tools.py
@@ -35,6 +35,7 @@ def csv_metadata_to_nodes(
     *,
     column_to_property_mapping: dict[str, str] = None,
     csv_options: dict[str, Any] = None,
+    ignore_columns: list[str] = None,
 ) -> MCFNodes[StatVarMCFNode]:
     """Read a CSV of StatVar metadata and return the corresponding MCF StatVar nodes.
 
@@ -44,6 +45,7 @@ def csv_metadata_to_nodes(
             ``StatVarMCFNode`` attribute names.
         csv_options: Extra keyword arguments forwarded verbatim to
             ``pandas.read_csv``.
+        ignore_columns: Optional list of columns to ignore when reading the CSV.
 
     Returns:
         A ``Nodes`` container populated with ``StatVarMCFNode`` objects.
@@ -57,6 +59,7 @@ def csv_metadata_to_nodes(
 
     return (
         pd.read_csv(file_path, **csv_options)
+        .drop(columns=ignore_columns)
         .rename(columns=column_to_property_mapping)
         .pipe(_rows_to_stat_var_nodes)
     )


### PR DESCRIPTION
This pull request introduces functionality to ignore specified columns when processing CSV files in the `add_variables_to_mcf_from_csv` and `csv_metadata_to_nodes` methods.