### PR TITLE
expose manager object in custom data namespace

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/__init__.py
+++ b/src/bblocks/datacommons_tools/custom_data/__init__.py
@@ -1,0 +1,5 @@
+from bblocks.datacommons_tools.custom_data.data_management import CustomDataManager
+
+__all__ = [
+    "CustomDataManager",
+]


### PR DESCRIPTION
This pull request introduces a small change to the `src/bblocks/datacommons_tools/custom_data/__init__.py` file by adding an import for `CustomDataManager` and including it in the `__all__` list for module exports.