### PR TITLE
Enable parsing groups from metadata

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/schema_tools.py
+++ b/src/bblocks/datacommons_tools/custom_data/schema_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, Literal
 
@@ -82,3 +83,80 @@ def csv_metadata_to_nodes(
         .rename(columns=column_to_property_mapping)
         .pipe(_rows_to_stat_var_nodes, node_type=node_type)
     )
+
+
+def to_camelCase(segment: str) -> str:
+    """
+    Turn a segment like 'Official Development Assistance' into 'officialDevelopmentAssistance'.
+    Keep all-upper or already-camel segments (e.g. DAC1, ODA) unchanged.
+    """
+    seg = segment.strip()
+
+    # All upper case
+    if re.fullmatch(r"[A-Z0-9]+", seg):
+        return seg
+
+    # Already camel case
+    if seg and seg[0].islower() and " " not in seg:
+        return seg
+
+    # Split by whitespace and join with camel case
+    words = re.split(r"\s+", seg)
+    return words[0].lower() + "".join(w.title() for w in words[1:])
+
+
+def build_stat_var_groups_from_strings(stat_vars, *, groups_namespace: str):
+    """
+    Build hierarchical StatVarGroup nodes from string-encoded group paths and attach them to StatVar nodes.
+
+    This function reads the `memberOf` attribute of each StatVar node in `stat_vars`, which is
+    expected to be a slash-separated string path describing its group hierarchy (e.g.,
+    "Economic/Employment/Unemployment"). It generates StatVarGroupMCFNode objects for each
+    group level, sets up their parent-child relationships, and updates the original StatVar
+    nodes to reference the deepest group DCID.
+
+    Args:
+        stat_vars: An MCFNodes container holding StatVarMCFNode objects. Each node must have a
+            `memberOf` attribute set to a path string indicating its group hierarchy.
+        groups_namespace: The namespace under which group DCIDs will be created (e.g.,
+            "one"). The resulting group DCIDs will have the form
+            "dcid: {groups_namespace}/g/{{groupSlug}}".
+
+    Returns:
+        The same MCFNodes container provided as `stat_vars`, extended in-place with newly
+        created StatVarGroupMCFNode objects representing each unique group. Each StatVarMCFNode's
+        `memberOf` will be updated to the DCID of its deepest group.
+    """
+
+    group_nodes, seen = [], set()
+    root = f"dcid: {groups_namespace}/g/"
+
+    for node_idx, node in enumerate(stat_vars.nodes):
+        # clean
+        raw = node.memberOf
+        raw = raw.lstrip("-").strip("/ ")
+        parts = [p for p in raw.split("/") if p]
+        slug_parts = [to_camelCase(part) for part in parts]
+
+        for idx, part in enumerate(parts):
+            group_node = root + f"{slug_parts[idx]}"
+
+            if idx == len(parts) - 1:
+                stat_vars.nodes[node_idx].memberOf = group_node
+
+            if group_node in seen:
+                continue
+            seen.add(group_node)
+
+            if idx == 0:
+                parent = "dcid: dc/g/Root"
+            else:
+                parent = root + f"{slug_parts[idx - 1]}"
+
+            group_nodes.append(
+                StatVarGroupMCFNode(Node=group_node, name=part, specializationOf=parent)
+            )
+
+    stat_vars.nodes.extend(group_nodes)
+
+    return stat_vars

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -1,4 +1,12 @@
-from bblocks.datacommons_tools.custom_data.schema_tools import csv_metadata_to_nodes
+from bblocks.datacommons_tools.custom_data.models.mcf import MCFNodes
+from bblocks.datacommons_tools.custom_data.models.stat_vars import (
+    StatVarMCFNode,
+    StatVarGroupMCFNode,
+)
+from bblocks.datacommons_tools.custom_data.schema_tools import (
+    csv_metadata_to_nodes,
+    build_stat_var_groups_from_strings,
+)
 
 
 def test_csv_metadata_to_nodes(tmp_path):
@@ -24,3 +32,80 @@ def test_csv_metadata_to_nodes(tmp_path):
     nodes_map = csv_metadata_to_nodes(str(csv_path), column_to_property_mapping=mapping)
     for node in nodes_map.nodes:
         assert hasattr(node, "searchDescription")
+
+
+def make_sv(member_of: str) -> StatVarMCFNode:
+    """Helper to create a StatVarMCFNode with a given memberOf path."""
+    return StatVarMCFNode(
+        Node="dcid: dummy",
+        name="TestVar",
+        description="",
+        unit="",
+        measuredProperty="",
+        populationType="",
+        memberOf=member_of,
+    )
+
+
+def get_group_nodes(nodes: MCFNodes) -> list[StatVarGroupMCFNode]:
+    """Extract all StatVarGroupMCFNode instances from MCFNodes."""
+    return [n for n in nodes.nodes if isinstance(n, StatVarGroupMCFNode)]
+
+
+def get_statvar_nodes(nodes: MCFNodes) -> list[StatVarMCFNode]:
+    """Extract all StatVarMCFNode instances from MCFNodes."""
+    return [n for n in nodes.nodes if isinstance(n, StatVarMCFNode)]
+
+
+def test_single_level_group():
+    sv = make_sv("Category")
+    nodes = MCFNodes(nodes=[sv])
+
+    result = build_stat_var_groups_from_strings(nodes, groups_namespace="example.org")
+    groups = get_group_nodes(result)
+    assert (
+        len(groups) == 1
+    ), "Should create exactly one group node for single-level path"
+
+    group = groups[0]
+    assert group.Node == "dcid: example.org/g/category"
+    assert group.name == "Category"
+    assert group.specializationOf == "dcid: dc/g/Root"
+
+    statvars = get_statvar_nodes(result)
+    assert statvars[0].memberOf == group.Node
+
+
+def test_multi_level_group():
+    sv = make_sv("A/B/C")
+    nodes = MCFNodes(nodes=[sv])
+
+    result = build_stat_var_groups_from_strings(nodes, groups_namespace="ns")
+    groups = get_group_nodes(result)
+
+    assert len(groups) == 3
+    slug_map = {g.Node.split("/")[-1]: g for g in groups}
+
+    # Check each group's parent linkage
+    assert slug_map["A"].specializationOf == "dcid: dc/g/Root"
+    assert slug_map["B"].specializationOf == "dcid: ns/g/A"
+    assert slug_map["C"].specializationOf == "dcid: ns/g/B"
+
+    # Check StatVar points to deepest
+    statvars = get_statvar_nodes(result)
+    assert statvars[0].memberOf == "dcid: ns/g/C"
+
+
+def test_duplicate_paths_do_not_create_duplicates():
+    sv1 = make_sv("X/Y")
+    sv2 = make_sv("X/Y/Z")
+    nodes = MCFNodes(nodes=[sv1, sv2])
+
+    result = build_stat_var_groups_from_strings(nodes, groups_namespace="ns2")
+    groups = get_group_nodes(result)
+    # Expect three unique group nodes: X, Y, Z
+    assert len(groups) == 3
+    slugs = sorted(g.Node for g in groups)
+    assert "dcid: ns2/g/X" in slugs
+    assert "dcid: ns2/g/Y" in slugs
+    assert "dcid: ns2/g/Z" in slugs


### PR DESCRIPTION
This pull request introduces functionality for parsing hierarchical group paths from StatVar nodes into StatVarGroup nodes, updates the `add_variables_to_mcf_from_csv` method to support this feature, and adds corresponding utility functions and tests. 

### Enhancements to StatVar Group Handling:

* Added a new function `build_stat_var_groups_from_strings` in `schema_tools.py` to parse hierarchical group paths from the `memberOf` attribute of StatVar nodes, generate StatVarGroup nodes, and establish parent-child relationships. This function also updates the `memberOf` attribute to reference the deepest group DCID.
* Introduced a helper function `to_camelCase` in `schema_tools.py` to convert group names into camelCase format for generating group DCIDs.

### Updates to `add_variables_to_mcf_from_csv`:

* Added `parse_groups` and `group_namespace` parameters to the `add_variables_to_mcf_from_csv` function in `data_management.py`. These parameters enable parsing and namespace customization for StatVar groups. Validation logic was added to ensure `group_namespace` is only set if `parse_groups` is `True`. 

* Added new test cases in `test_schema_tools.py` to validate the functionality of `build_stat_var_groups_from_strings`, including tests for single-level groups, multi-level groups, and duplicate paths. 
