### PR TITLE
Update MCF property order

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/models/mcf.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/mcf.py
@@ -48,7 +48,7 @@ class MCFNode(BaseModel):
 
         # Pull Node first, then sort for consistent ordering
         lines = [f"Node: {data.pop('Node')}"]
-        lines.extend(f"{k}: {v}" for k, v in sorted(data.items()))
+        lines.extend(f"{k}: {v}" for k, v in data.items())
 
         return "\n".join(lines) + "\n\n"
 

--- a/tests/goldens/custom_nodes.mcf
+++ b/tests/goldens/custom_nodes.mcf
@@ -1,7 +1,7 @@
 Node: var/one
-description: "Test var"
-memberOf: one/g/group1
 name: "Test Var"
-statType: dcid:measuredValue
 typeOf: dcid:StatisticalVariable
+description: "Test var"
+statType: dcid:measuredValue
+memberOf: one/g/group1
 

--- a/tests/goldens/sample_csv_nodes.mcf
+++ b/tests/goldens/sample_csv_nodes.mcf
@@ -1,13 +1,13 @@
 Node: foo
+name: "FooVar"
+typeOf: dcid:StatisticalVariable
 dcid: dcid:foo
 description: "A foo var"
-name: "FooVar"
 statType: dcid:measuredValue
-typeOf: dcid:StatisticalVariable
 
 Node: bar
-dcid: dcid:bar
 name: "BarVar"
-statType: dcid:measuredValue
 typeOf: dcid:StatisticalVariable
+dcid: dcid:bar
+statType: dcid:measuredValue
 

--- a/tests/goldens/sample_node.mcf
+++ b/tests/goldens/sample_node.mcf
@@ -1,8 +1,8 @@
 Node: X/foo
+name: "Some Name"
+typeOf: dcid:StatisticalVariable
 dcid: dcid:foo
 description: "Foo description"
-name: "Some Name"
 provenance: "Some foo provenance"
 shortDisplayName: "F"
 subClassOf: dcid:Parent
-typeOf: dcid:StatisticalVariable

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -2,22 +2,21 @@ import pytest
 
 from bblocks.datacommons_tools.custom_data.models.mcf import MCFNodes, MCFNode
 
+
 def test_mcfnode_mcf_output_order_and_formatting():
     """
     Ensures MCFNode.mcf outputs properties sorted alphabetically
     after 'Node:' line.
     """
     node = MCFNode(
-        Node="TestNode",
-        name='"My Name"',
-        typeOf="TypeA",
-        description='"Desc"',
+        Node="TestNode", name='"My Name"', typeOf="TypeA", description='"Desc"'
     )
     lines = node.mcf.strip().splitlines()
     assert lines[0] == "Node: TestNode"
-    assert lines[1] == 'description: "Desc"'
-    assert lines[2] == 'name: "My Name"'
-    assert lines[3] == "typeOf: TypeA"
+    assert lines[1] == 'name: "My Name"'
+    assert lines[2] == "typeOf: TypeA"
+    assert lines[3] == 'description: "Desc"'
+
 
 def test_mcfnodes_add_override_and_remove():
     """

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -68,9 +68,9 @@ def test_single_level_group():
     ), "Should create exactly one group node for single-level path"
 
     group = groups[0]
-    assert group.Node == "dcid: example.org/g/category"
+    assert group.Node == "dcid:example.org/g/category"
     assert group.name == "Category"
-    assert group.specializationOf == "dcid: dc/g/Root"
+    assert group.specializationOf == "dcid:dc/g/Root"
 
     statvars = get_statvar_nodes(result)
     assert statvars[0].memberOf == group.Node
@@ -87,13 +87,13 @@ def test_multi_level_group():
     slug_map = {g.Node.split("/")[-1]: g for g in groups}
 
     # Check each group's parent linkage
-    assert slug_map["A"].specializationOf == "dcid: dc/g/Root"
-    assert slug_map["B"].specializationOf == "dcid: ns/g/A"
-    assert slug_map["C"].specializationOf == "dcid: ns/g/B"
+    assert slug_map["A"].specializationOf == "dcid:dc/g/Root"
+    assert slug_map["B"].specializationOf == "dcid:ns/g/A"
+    assert slug_map["C"].specializationOf == "dcid:ns/g/B"
 
     # Check StatVar points to deepest
     statvars = get_statvar_nodes(result)
-    assert statvars[0].memberOf == "dcid: ns/g/C"
+    assert statvars[0].memberOf == "dcid:ns/g/C"
 
 
 def test_duplicate_paths_do_not_create_duplicates():
@@ -106,6 +106,6 @@ def test_duplicate_paths_do_not_create_duplicates():
     # Expect three unique group nodes: X, Y, Z
     assert len(groups) == 3
     slugs = sorted(g.Node for g in groups)
-    assert "dcid: ns2/g/X" in slugs
-    assert "dcid: ns2/g/Y" in slugs
-    assert "dcid: ns2/g/Z" in slugs
+    assert "dcid:ns2/g/X" in slugs
+    assert "dcid:ns2/g/Y" in slugs
+    assert "dcid:ns2/g/Z" in slugs


### PR DESCRIPTION
This pull request modifies the behavior of the `mcf` method in `MCFNode` to preserve the input order of properties instead of sorting them alphabetically. Corresponding test cases and golden files have been updated to reflect this change. 

### Functional Changes:
* Updated the `mcf` method in `MCFNode` to retain the order of properties as they appear in the input, rather than sorting them alphabetically. (`src/bblocks/datacommons_tools/custom_data/models/mcf.py`)

### Test Updates:
* Adjusted the test `test_mcfnode_mcf_output_order_and_formatting` to validate the new behavior of preserving property order in the `mcf` output. (`tests/test_models_mcf.py`)

### Golden File Updates:
* Updated `tests/goldens/custom_nodes.mcf`, `tests/goldens/sample_csv_nodes.mcf`, and `tests/goldens/sample_node.mcf` to align with the new property order in the `mcf` output. These changes ensure consistency with the updated method behavior. [[1]](diffhunk://#diff-c208cdb279191d8ada57cc2d90fae6fff55c5068d62325ff9c106cbf98956438L2-R6) [[2]](diffhunk://#diff-9f0ceb85a1804fe8fde762e25488d5725adb1f9e87900ce2a01ee11784a5feb7R2-R12) [[3]](diffhunk://#diff-e731a05825c1029a7234f97f376d13ce8860d2a7add74b8c7a1175ddaa6bce00R2-L8)