### PR TITLE
Add storage inspection helpers

### DIFF
--- a/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
@@ -3,12 +3,20 @@ from bblocks.datacommons_tools.gcp_utilities.pipeline import (
     run_data_load,
     redeploy_service,
 )
+from bblocks.datacommons_tools.gcp_utilities.storage import (
+    list_bucket_files,
+    get_unregistered_csv_files,
+    delete_bucket_files,
+)
 from bblocks.datacommons_tools.gcp_utilities.settings import get_kg_settings, KGSettings
 
 __all__ = [
     "upload_to_cloud_storage",
     "run_data_load",
     "redeploy_service",
+    "list_bucket_files",
+    "get_unregistered_csv_files",
+    "delete_bucket_files",
     "get_kg_settings",
     "KGSettings",
 ]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,58 @@
+from unittest.mock import Mock
+
+from bblocks.datacommons_tools.gcp_utilities.storage import (
+    list_bucket_files,
+    get_unregistered_csv_files,
+    delete_bucket_files,
+)
+from bblocks.datacommons_tools.custom_data.models.config_file import Config
+from bblocks.datacommons_tools.custom_data.models.data_files import (
+    ImplicitSchemaFile,
+    ObservationProperties,
+)
+from bblocks.datacommons_tools.custom_data.models.sources import Source
+
+
+def _minimal_config() -> Config:
+    input_files = {
+        "a.csv": ImplicitSchemaFile(
+            provenance="prov",
+            entityType="Country",
+            observationProperties=ObservationProperties(),
+        )
+    }
+    sources = {"src": Source(url="http://s", provenances={"prov": "http://p"})}
+    return Config(inputFiles=input_files, sources=sources)
+
+
+def test_list_bucket_files():
+    bucket = Mock()
+    bucket.list_blobs.return_value = [Mock(name="folder/a.csv"), Mock(name="folder/b.csv")]
+    assert list_bucket_files(bucket, "folder") == ["folder/a.csv", "folder/b.csv"]
+    bucket.list_blobs.assert_called_once_with(prefix="folder")
+
+
+def test_get_unregistered_csv_files():
+    bucket = Mock()
+    bucket.list_blobs.return_value = [Mock(name="folder/a.csv"), Mock(name="folder/extra.csv")]
+    cfg = _minimal_config()
+    missing = get_unregistered_csv_files(bucket, "folder", cfg)
+    assert missing == ["extra.csv"]
+
+
+def test_delete_bucket_files():
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+
+    delete_bucket_files(bucket, ["a.csv", "b.csv"])
+
+    assert set(blobs.keys()) == {"a.csv", "b.csv"}
+    for b in blobs.values():
+        b.delete.assert_called_once()


### PR DESCRIPTION
## Summary
- add functions to list and remove files in GCS buckets
- validate CSVs in the bucket against the config
- expose helpers via gcp_utilities
- test coverage for new utilities

## Testing
- `pip install -e .[dev]` *(fails: Could not fetch poetry-core)*
- `python -m pytest -q` *(fails: No module named pytest)*