### PR TITLE
Read from bucket

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -10,6 +10,6 @@ be accessed as import bblocks.datacommons_tools
 - Follow Google Python style but align with the code style and preferences already established for this repo.
 
 ## Testing Instructions
-- The tests are inside the tests folder. From root you would therefore call pytest ./tests
+- The tests are inside the tests folder. From root you would therefore call poetry run pytest ./tests
 - Fix any test or type errors until the whole suite is green.
 - Add or update tests for the code you change, even if nobody asked.

--- a/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
@@ -3,12 +3,20 @@ from bblocks.datacommons_tools.gcp_utilities.pipeline import (
     run_data_load,
     redeploy_service,
 )
+from bblocks.datacommons_tools.gcp_utilities.storage import (
+    list_bucket_files,
+    get_unregistered_csv_files,
+    delete_bucket_files,
+)
 from bblocks.datacommons_tools.gcp_utilities.settings import get_kg_settings, KGSettings
 
 __all__ = [
     "upload_to_cloud_storage",
     "run_data_load",
     "redeploy_service",
+    "list_bucket_files",
+    "get_unregistered_csv_files",
+    "delete_bucket_files",
     "get_kg_settings",
     "KGSettings",
 ]

--- a/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
@@ -7,6 +7,7 @@ from bblocks.datacommons_tools.gcp_utilities.storage import (
     list_bucket_files,
     get_unregistered_csv_files,
     delete_bucket_files,
+    get_bucket_files,
 )
 from bblocks.datacommons_tools.gcp_utilities.settings import get_kg_settings, KGSettings
 
@@ -17,6 +18,7 @@ __all__ = [
     "list_bucket_files",
     "get_unregistered_csv_files",
     "delete_bucket_files",
+    "get_bucket_files",
     "get_kg_settings",
     "KGSettings",
 ]

--- a/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/__init__.py
@@ -6,6 +6,7 @@ from bblocks.datacommons_tools.gcp_utilities.pipeline import (
 from bblocks.datacommons_tools.gcp_utilities.storage import (
     list_bucket_files,
     get_unregistered_csv_files,
+    get_missing_csv_files,
     delete_bucket_files,
     get_bucket_files,
 )
@@ -17,6 +18,7 @@ __all__ = [
     "redeploy_service",
     "list_bucket_files",
     "get_unregistered_csv_files",
+    "get_missing_csv_files",
     "delete_bucket_files",
     "get_bucket_files",
     "get_kg_settings",

--- a/src/bblocks/datacommons_tools/gcp_utilities/storage.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/storage.py
@@ -110,7 +110,7 @@ def get_unregistered_csv_files(
     blob_names = list_bucket_files(bucket=bucket, gcs_folder_name=gcs_folder_name)
     csv_files = [Path(name).name for name in blob_names if Path(name).suffix == ".csv"]
 
-    registered = set(config.inputFiles.keys())
+    registered = set(config.get("inputFiles", {}).keys())
     return [name for name in csv_files if name not in registered]
 
 

--- a/src/bblocks/datacommons_tools/gcp_utilities/storage.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/storage.py
@@ -196,13 +196,15 @@ def get_missing_csv_files(
     return missing
 
 
-def delete_bucket_files(bucket: Bucket, blob_names: Iterable[str]) -> None:
+def delete_bucket_files(bucket: Bucket, blob_names: list[str] | str) -> None:
     """Delete the specified blobs from ``bucket``.
 
     Args:
         bucket (Bucket): GCS bucket instance.
         blob_names (Iterable[str]): Names of the blobs to delete.
     """
+    if isinstance(blob_names, str):
+        blob_names = [blob_names]
 
     for name in blob_names:
         bucket.blob(name).delete()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -16,9 +16,9 @@ from bblocks.datacommons_tools.custom_data.models.data_files import (
 from bblocks.datacommons_tools.custom_data.models.sources import Source
 
 
-def _minimal_config() -> Config:
+def _minimal_config(key: str = "a.csv") -> Config:
     input_files = {
-        "a.csv": ImplicitSchemaFile(
+        key: ImplicitSchemaFile(
             provenance="prov",
             entityType="Country",
             observationProperties=ObservationProperties(),
@@ -58,6 +58,20 @@ def test_get_unregistered_csv_files():
     cfg = _minimal_config()
     missing = get_unregistered_csv_files(bucket, cfg, "folder")
     assert missing == ["extra.csv"]
+
+
+def test_get_unregistered_csv_files_with_prefix_removed():
+    bucket = Mock()
+    blob_a = Mock()
+    blob_a.name = "prefix/sub/a.csv"
+    blob_extra = Mock()
+    blob_extra.name = "prefix/sub/b.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_extra]
+
+    cfg = _minimal_config("sub/a.csv")
+    missing = get_unregistered_csv_files(bucket, cfg, "prefix")
+
+    assert missing == ["sub/b.csv"]
 
 
 def test_delete_bucket_files():

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock
+
+from bblocks.datacommons_tools.gcp_utilities.storage import (
+    list_bucket_files,
+    get_unregistered_csv_files,
+    delete_bucket_files,
+)
+from bblocks.datacommons_tools.custom_data.models.config_file import Config
+from bblocks.datacommons_tools.custom_data.models.data_files import (
+    ImplicitSchemaFile,
+    ObservationProperties,
+)
+from bblocks.datacommons_tools.custom_data.models.sources import Source
+
+
+def _minimal_config() -> Config:
+    input_files = {
+        "a.csv": ImplicitSchemaFile(
+            provenance="prov",
+            entityType="Country",
+            observationProperties=ObservationProperties(),
+        )
+    }
+    sources = {"src": Source(url="http://s", provenances={"prov": "http://p"})}
+    return Config(inputFiles=input_files, sources=sources)
+
+
+def test_list_bucket_files():
+    bucket = Mock()
+    blob_a = Mock()
+    blob_a.name = "folder/a.csv"
+    blob_b = Mock()
+    blob_b.name = "folder/b.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_b]
+    assert list_bucket_files(bucket, "folder") == ["folder/a.csv", "folder/b.csv"]
+    bucket.list_blobs.assert_called_once_with(prefix="folder")
+
+
+def test_get_unregistered_csv_files():
+    bucket = Mock()
+    blob_a = Mock()
+    blob_a.name = "folder/a.csv"
+    blob_extra = Mock()
+    blob_extra.name = "folder/extra.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_extra]
+    cfg = _minimal_config()
+    missing = get_unregistered_csv_files(bucket, "folder", cfg)
+    assert missing == ["extra.csv"]
+
+
+def test_delete_bucket_files():
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+
+    delete_bucket_files(bucket, ["a.csv", "b.csv"])
+
+    assert set(blobs.keys()) == {"a.csv", "b.csv"}
+    for b in blobs.values():
+        b.delete.assert_called_once()


### PR DESCRIPTION
This pull request introduces enhancements to the `bblocks.datacommons_tools` module, focusing on Google Cloud Storage (GCS) utilities.

### Enhancements to GCS Utilities:

* **New GCS Utility Functions**: Added functions in `storage.py` for listing bucket files, identifying unregistered/missing CSV files, deleting files, and fetching file contents. These utilities improve the module's ability to interact with GCS efficiently. [[1]](diffhunk://#diff-429cac2b9073749078a3974ea5c549480999d98e642bf36e991ee93d8535ffa9R36-R80) [[2]](diffhunk://#diff-429cac2b9073749078a3974ea5c549480999d98e642bf36e991ee93d8535ffa9L49-R253)
* **Improved Directory Upload**: Enhanced the `upload_directory_to_gcs` function to handle optional folder names and maintain directory structure when uploading files to GCS. [[1]](diffhunk://#diff-429cac2b9073749078a3974ea5c549480999d98e642bf36e991ee93d8535ffa9R36-R80) [[2]](diffhunk://#diff-429cac2b9073749078a3974ea5c549480999d98e642bf36e991ee93d8535ffa9L49-R253)

### Codebase Updates:

* **Module Initialization**: Updated `__init__.py` to include the newly added GCS utility functions in the module's public API.
* **Documentation Update**: Modified the testing instructions in `Agents.md` to use `poetry` for running tests, aligning with the project's updated tooling.
