### PR TITLE
Feature: Merge config files

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -4,12 +4,14 @@
 - This repo is for a package which is part of the `bblocks` namespace. The package would
 be accessed as import bblocks.datacommons_tools
 - Code should be formatted with black
+- Poetry is used to manage dependencies
 
 ## Linting instructions
 - Format all code with black
 - Follow Google Python style but align with the code style and preferences already established for this repo.
+- This repo uses Google-style docstrings. All functions and methods should have docstrings.
 
 ## Testing Instructions
-- The tests are inside the tests folder. From root you would therefore call poetry run pytest ./tests
+- The tests are inside the tests folder. From root you would therefore call `poetry run pytest ./tests`
 - Fix any test or type errors until the whole suite is green.
 - Add or update tests for the code you change, even if nobody asked.

--- a/src/bblocks/datacommons_tools/custom_data/config_utils.py
+++ b/src/bblocks/datacommons_tools/custom_data/config_utils.py
@@ -1,0 +1,178 @@
+"""Utilities for merging config files."""
+
+from pathlib import Path
+from typing import Iterator, Literal, Any
+
+from bblocks.datacommons_tools.custom_data.models.config_file import Config
+from bblocks.datacommons_tools.custom_data.models.sources import Source
+from bblocks.datacommons_tools.logger import logger
+
+DuplicatePolicy = Literal["error", "override", "ignore"]
+
+
+def iter_config_files(directory: Path, pattern: str = "config.json") -> Iterator[Path]:
+    """Yield all ``config.json`` files under ``directory`` recursively."""
+    for path in directory.rglob(pattern):
+        if path.is_file():
+            yield path
+
+
+def _merge_boolean_attrs(
+    existing: Config, new: Config, policy: DuplicatePolicy
+) -> None:
+    """Merge simple attributes that are booleans or None."""
+    for attr in ("includeInputSubdirs", "groupStatVarsByProperty"):
+        _merge_attribute(existing, new, attr, policy)
+
+
+def _merge_source(
+    target_sources: dict[str, Source],
+    name: str,
+    source: Source,
+    policy: DuplicatePolicy,
+) -> None:
+    """Merge a *Source* entry and its nested structures."""
+    if name not in target_sources:
+        logger.info(f"Added source '{name}'")
+        target_sources[name] = source
+        return
+
+    target = target_sources[name]
+    if target.url != source.url:
+        _handle_conflict(
+            field=f"URL for source '{name}'",
+            target_value=target,
+            source_value=source,
+            policy=policy,
+        )
+        if policy == "override":
+            target.url = source.url
+
+    _merge_dict(
+        target_dict=target.provenances,
+        source_dict=source.provenances,
+        policy=policy,
+        context=f"provenance of source '{name}'",
+    )
+
+
+def _handle_conflict(
+    field: str, target_value: Any, source_value: Any, policy: DuplicatePolicy
+) -> None:
+    """Log or raise depending on *policy* when a conflict is detected."""
+    if policy == "override":
+        logger.warning(f"Overriding {field}: {target_value} -> {source_value}")
+    elif policy == "ignore":
+        logger.info(f"Ignoring {field}: {target_value} -> {source_value}")
+    else:
+        raise ValueError(f"Conflicting {field}: {target_value!r} vs {source_value!r}")
+
+
+def _merge_dict(
+    target_dict: dict[Any, Any],
+    source_dict: dict[Any, Any],
+    policy: DuplicatePolicy,
+    context: str,
+) -> None:
+    """Merge two mapping-like structures, according to *policy*."""
+    for key, src_val in source_dict.items():
+        if key not in target_dict:
+            target_dict[key] = src_val
+            continue
+
+        tgt_val = target_dict[key]
+        if tgt_val == src_val:
+            continue
+
+        _handle_conflict(
+            field=f"{context} '{key}'",
+            target_value=tgt_val,
+            source_value=src_val,
+            policy=policy,
+        )
+        if policy == "override":
+            target_dict[key] = src_val
+
+
+def _merge_attribute(
+    existing: Config, new: Config, attribute: str, policy: DuplicatePolicy
+) -> None:
+    """Merge a single attribute, handling collisions with *policy*."""
+    src_val = getattr(new, attribute)
+    if src_val is None:
+        return
+
+    tgt_val = getattr(existing, attribute)
+    if tgt_val is None or tgt_val == src_val:
+        setattr(existing, attribute, src_val if tgt_val is None else tgt_val)
+        return
+
+    _handle_conflict(
+        field=attribute, target_value=tgt_val, source_value=src_val, policy=policy
+    )
+    if policy == "override":
+        setattr(existing, attribute, src_val)
+
+
+def merge_configs(
+    existing: Config, new: Config, *, policy: DuplicatePolicy = "error"
+) -> None:
+    """Merge ``new`` into ``existing`` in-place.
+
+    Args:
+        existing: target config.
+        new: the config to be merged with *existing*.
+        policy: How to resolve collisions.
+
+    Raises:
+        ValueError: If policy is `"error" and conflicting
+            values are encountered.
+    """
+    # Merge attributes that are booleans or None
+    _merge_boolean_attrs(existing=existing, new=new, policy=policy)
+
+    # Merge the input file list
+    _merge_dict(
+        target_dict=existing.inputFiles,
+        source_dict=new.inputFiles,
+        policy=policy,
+        context="Input file",
+    )
+
+    # Merge the variables
+    if new.variables:
+        if not existing.variables:
+            existing.variables = {}
+        _merge_dict(
+            target_dict=existing.variables,
+            source_dict=new.variables,
+            policy=policy,
+            context="Variable",
+        )
+
+    # Merge the sources
+    for name, src in new.sources.items():
+        _merge_source(
+            target_sources=existing.sources, name=name, source=src, policy=policy
+        )
+
+
+def merge_configs_from_directory(
+    directory: str | Path, *, policy: DuplicatePolicy = "error"
+) -> Config:
+    """Return a ``Config`` merging all configs found under ``directory``.
+
+    Args:
+        directory: Directory to search for config files.
+        policy: How to resolve collisions.
+    Raises:
+        ValueError: If policy is `"error"` and conflicting
+            values are encountered.
+
+    """
+    base = Config(inputFiles={}, sources={})
+    for path in iter_config_files(Path(directory)):
+        logger.info(f"Merging config file {path}")
+        config = Config.from_json(str(path))
+        merge_configs(existing=base, new=config, policy=policy)
+    return base

--- a/src/bblocks/datacommons_tools/custom_data/data_management.py
+++ b/src/bblocks/datacommons_tools/custom_data/data_management.py
@@ -910,6 +910,10 @@ class CustomDataManager:
             config: The config to merge. This can be a Config object, a dictionary,
                 or a path to a JSON file.
             policy: How to resolve collisions. Can be "error", "override", or "ignore".
+                Defaults to "error". If "error", an error is raised if there are any
+                collisions. If "override", the new config will override the existing
+                config. If "ignore", the new config's value will be ignored if there are any
+                collisions.
 
         """
 
@@ -937,6 +941,11 @@ class CustomDataManager:
         Args:
             directory: The directory to search for config files.
             policy: How to resolve collisions. Can be "error", "override", or "ignore".
+            How to resolve collisions. Can be "error", "override", or "ignore".
+                Defaults to "error". If "error", an error is raised if there are any
+                collisions. If "override", the new config will override the existing
+                config. If "ignore", the new config's value will be ignored if there are any
+                collisions.
 
         """
 
@@ -980,3 +989,7 @@ class CustomDataManager:
             directory, policy=policy, replace_loaded_config=True
         )
         return manager
+
+#%%
+
+#%%


### PR DESCRIPTION
This PR makes it possible to merge config files, including by looking at config files inside a directory.

### Enhancements to Configuration Management

* Added a new module `config_utils` with utilities for merging configuration files, handling conflicts, and recursively iterating over configuration files in directories. These utilities include methods like `merge_configs`, `merge_configs_from_directory`, and `_merge_source` to handle complex merging scenarios. (`src/bblocks/datacommons_tools/custom_data/config_utils.py`)

* Extended the `CustomDataManager` class with methods for merging configurations (`merge_config` and `merge_configs_from_directory`) and creating instances from directory-based configurations (`from_config_files_in_directory`). These methods support conflict resolution policies such as "error," "override," and "ignore." (`src/bblocks/datacommons_tools/custom_data/data_management.py`)

### Tests

* Added new tests in `test_data_management.py` to validate the functionality of merging configurations from directories, handling duplicate configurations, and ensuring proper behavior of the new methods. (`tests/test_data_management.py`) [[1]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20R298-R354) [[2]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20R7-R11)