### PR TITLE
Accept str lists mcf

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/models/common.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/common.py
@@ -1,6 +1,7 @@
+import csv
 from typing import Annotated
 
-from pydantic import PlainSerializer
+from pydantic import PlainSerializer, PlainValidator
 
 
 def _ensure_quoted(s: str) -> str:
@@ -38,13 +39,24 @@ def mcf_quoted_str(value: str | list[str] | None) -> str | None:
     return _ensure_quoted(value)
 
 
+def parse_str_or_list(value: str | list[str]) -> str | list[str]:
+    """Return a list when a comma-delimited string is provided."""
+    if isinstance(value, str):
+        parsed = next(csv.reader([value], skipinitialspace=True))
+        parsed = [v.strip() for v in parsed]
+        return parsed[0] if len(parsed) == 1 else parsed
+    return value
+
+
 QuotedStr = Annotated[
     str, PlainSerializer(_ensure_quoted, return_type=str | None, when_used="always")
 ]
 """A string annotated for serialisation into an MCF-compatible quoted format."""
 
-QuotedStrList = Annotated[
-    list[str],
+
+QuotedStrListOrStr = Annotated[
+    str | list[str],
+    PlainValidator(parse_str_or_list),
     PlainSerializer(mcf_quoted_str, return_type=str | None, when_used="always"),
 ]
-"""A list of strings annotated for serialisation into an MCF-compatible quoted format."""
+"""Accepts a string or list and serialises to quoted MCF format."""

--- a/src/bblocks/datacommons_tools/custom_data/models/common.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/common.py
@@ -39,6 +39,27 @@ def mcf_quoted_str(value: str | list[str] | None) -> str | None:
     return _ensure_quoted(value)
 
 
+def mcf_str(value: str | list[str] | None) -> str | None:
+    """Serialise a string or list of strings without adding quotes.
+
+    Args:
+        value: A string, list of strings, or None to serialise.
+
+    Returns:
+        A comma-delimited string or None if input is None.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, list):
+        if len(value) < 2:
+            return str(value[0])
+
+        return ", ".join(str(item) for item in value)
+
+    return value
+
+
 def parse_str_or_list(value: str | list[str]) -> str | list[str]:
     """Return a list when a comma-delimited string is provided."""
     if isinstance(value, str):
@@ -60,3 +81,11 @@ QuotedStrListOrStr = Annotated[
     PlainSerializer(mcf_quoted_str, return_type=str | None, when_used="always"),
 ]
 """Accepts a string or list and serialises to quoted MCF format."""
+
+
+StrOrListStr = Annotated[
+    str | list[str],
+    PlainValidator(parse_str_or_list),
+    PlainSerializer(mcf_str, return_type=str | None, when_used="always"),
+]
+"""Accepts a string or list and serialises to a comma-separated string."""

--- a/src/bblocks/datacommons_tools/custom_data/models/mcf.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/mcf.py
@@ -6,7 +6,7 @@ from typing import Optional, List
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr
 
-from bblocks.datacommons_tools.custom_data.models.common import QuotedStr
+from bblocks.datacommons_tools.custom_data.models.common import QuotedStr, StrOrListStr
 
 
 class MCFNode(BaseModel):
@@ -30,7 +30,7 @@ class MCFNode(BaseModel):
     description: Optional[QuotedStr] = None
     provenance: Optional[QuotedStr] = None
     shortDisplayName: Optional[QuotedStr] = None
-    subClassOf: Optional[str] = None
+    subClassOf: Optional[StrOrListStr] = None
 
     # Allow extra fields since MCF can have arbitrary properties and this
     # class is not comprehensive of all possible MCF properties.

--- a/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Dict, Literal
 
 from pydantic import BaseModel, ConfigDict, constr
 
-from bblocks.datacommons_tools.custom_data.models.common import QuotedStrListOrStr
+from bblocks.datacommons_tools.custom_data.models.common import QuotedStrListOrStr, StrOrListStr
 from bblocks.datacommons_tools.custom_data.models.mcf import MCFNode
 
 
@@ -36,7 +36,7 @@ class Variable(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     searchDescriptions: Optional[List[str]] = None
-    group: Optional[str] = None
+    group: Optional[StrOrListStr] = None
     properties: Optional[Dict[str, str]] = None
 
     model_config = ConfigDict(extra="forbid")
@@ -68,7 +68,7 @@ class StatVarMCFNode(MCFNode):
 
     statType: Optional[StatType] = StatType.MEASURED_VALUE
     typeOf: Literal["dcid:StatisticalVariable"] = "dcid:StatisticalVariable"
-    memberOf: Optional[str] = None
+    memberOf: Optional[StrOrListStr] = None
     searchDescription: Optional[QuotedStrListOrStr] = None
     populationType: Optional[str] = None
     measuredProperty: Optional[str] = None

--- a/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Dict, Literal
 
 from pydantic import BaseModel, ConfigDict, constr
 
-from bblocks.datacommons_tools.custom_data.models.common import QuotedStr, QuotedStrList
+from bblocks.datacommons_tools.custom_data.models.common import QuotedStrListOrStr
 from bblocks.datacommons_tools.custom_data.models.mcf import MCFNode
 
 
@@ -69,7 +69,7 @@ class StatVarMCFNode(MCFNode):
     statType: Optional[StatType] = StatType.MEASURED_VALUE
     typeOf: Literal["dcid:StatisticalVariable"] = "dcid:StatisticalVariable"
     memberOf: Optional[str] = None
-    searchDescription: Optional[QuotedStr | QuotedStrList] = None
+    searchDescription: Optional[QuotedStrListOrStr] = None
     populationType: Optional[str] = None
     measuredProperty: Optional[str] = None
     measurementQualifier: Optional[str] = None

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -1,6 +1,6 @@
 from bblocks.datacommons_tools.custom_data.models.common import (
     _ensure_quoted,
-    mcf_quoted_str,
+    mcf_quoted_str, parse_str_or_list,
 )
 
 
@@ -25,3 +25,7 @@ def test_mcf_quoted_str_with_single_and_multiple_items():
     assert multi == '"a", "b", "c"'
     # None input
     assert mcf_quoted_str(None) is None
+
+def test_parse_str_or_list_honours_quotes():
+    assert parse_str_or_list('"A, B"') == "A, B"
+    assert parse_str_or_list('"A, B", C') == ["A, B", "C"]

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -1,7 +1,11 @@
 from bblocks.datacommons_tools.custom_data.models.common import (
     _ensure_quoted,
-    mcf_quoted_str, parse_str_or_list,
+    mcf_quoted_str,
+    mcf_str,
+    parse_str_or_list,
+    StrOrListStr,
 )
+from pydantic import BaseModel
 
 
 def test_ensure_quoted_handles_quotes_and_whitespace():
@@ -11,6 +15,7 @@ def test_ensure_quoted_handles_quotes_and_whitespace():
     """
     assert _ensure_quoted("value") == '"value"'
     assert _ensure_quoted("'value'") == '"value"'
+
 
 def test_mcf_quoted_str_with_single_and_multiple_items():
     """
@@ -26,6 +31,27 @@ def test_mcf_quoted_str_with_single_and_multiple_items():
     # None input
     assert mcf_quoted_str(None) is None
 
+
 def test_parse_str_or_list_honours_quotes():
     assert parse_str_or_list('"A, B"') == "A, B"
     assert parse_str_or_list('"A, B", C') == ["A, B", "C"]
+
+
+def test_mcf_str_with_single_and_multiple_items():
+    assert mcf_str("abc") == "abc"
+    assert mcf_str(["x"]) == "x"
+    multi = mcf_str(["a", "b", "c"])
+    assert multi == "a, b, c"
+    assert mcf_str(None) is None
+
+
+def test_str_or_list_str_annotation_serialization():
+    class Dummy(BaseModel):
+        field: StrOrListStr
+
+    d1 = Dummy(field="A, B")
+    assert d1.field == ["A", "B"]
+    assert d1.model_dump()["field"] == "A, B"
+
+    d2 = Dummy(field=["x", "y"])
+    assert d2.model_dump()["field"] == "x, y"

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -37,8 +37,14 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists():
     assert 'searchDescription: "A list, comma", "second element"' in mcf
 
 
-def test_rows_to_stat_var_nodes_respects_quoted_commas():
-    df = pd.read_clipboard()
+def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
+    df = pd.DataFrame(
+        {
+            "Node": ["n3"],
+            "name": ["Var"],
+            "memberOf": ['["dcid:oneId", "dcid:twoId"]'],
+        }
+    )
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
-    assert 'searchDescription: "Single, part"' in mcf
+    assert 'memberOf: dcid:oneId, dcid:twoId' in mcf

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -1,0 +1,44 @@
+import pandas as pd
+
+from bblocks.datacommons_tools.custom_data.models.stat_vars import StatVarMCFNode
+from bblocks.datacommons_tools.custom_data.schema_tools import _rows_to_stat_var_nodes
+
+
+def test_search_description_serialization_str_and_list():
+    sv_str = StatVarMCFNode(Node="n1", name="Var", searchDescription="A")
+    assert 'searchDescription: "A"' in sv_str.mcf
+
+    sv_str = StatVarMCFNode(
+        Node="n1", name="Var", searchDescription=["A string, or not", "B string, other"]
+    )
+    assert 'searchDescription: "A string, or not", "B string, other"' in sv_str.mcf
+
+    sv_list = StatVarMCFNode(Node="n2", name="Var", searchDescription=["A", "B"])
+    assert 'searchDescription: "A", "B"' in sv_list.mcf
+
+
+def test_rows_to_stat_var_nodes_parses_comma_separated():
+    df = pd.DataFrame({"Node": ["n3"], "name": ["Var"], "searchDescription": ["A, B"]})
+    nodes = _rows_to_stat_var_nodes(df)
+    mcf = nodes.nodes[0].mcf
+    assert 'searchDescription: "A", "B"' in mcf
+
+
+def test_rows_to_stat_var_nodes_parses_spreadsheet_lists():
+    df = pd.DataFrame(
+        {
+            "Node": ["n3"],
+            "name": ["Var"],
+            "searchDescription": ['["A list, comma", "second element"]'],
+        }
+    )
+    nodes = _rows_to_stat_var_nodes(df)
+    mcf = nodes.nodes[0].mcf
+    assert 'searchDescription: "A list, comma", "second element"' in mcf
+
+
+def test_rows_to_stat_var_nodes_respects_quoted_commas():
+    df = pd.read_clipboard()
+    nodes = _rows_to_stat_var_nodes(df)
+    mcf = nodes.nodes[0].mcf
+    assert 'searchDescription: "Single, part"' in mcf


### PR DESCRIPTION
This pull request introduces enhancements to the handling and serialization of string and list data in the `datacommons_tools` package, along with corresponding updates to models and tests. The changes improve flexibility in processing input formats (e.g., single strings, comma-separated strings, or lists) and ensure proper serialization for MCF.

* Added `mcf_str` and `parse_str_or_list` utility functions to serialize strings/lists without quotes and parse comma-delimited strings into lists, respectively. (`src/bblocks/datacommons_tools/custom_data/models/common.py`)
* Introduced new type annotations:
  - [`QuotedStrListOrStr`](diffhunk://#diff-9216011c5618864689c5ed1221949f59bbdae04092e3addee0b2575e078bc31cR42-R91): Handles both strings and lists, serializing them into quoted MCF format.
  - [`StrOrListStr`](diffhunk://#diff-9216011c5618864689c5ed1221949f59bbdae04092e3addee0b2575e078bc31cR42-R91): Handles both strings and lists, serializing them into comma-separated strings.
* Updated `MCFNode` and `Variable` models to use `StrOrListStr` for fields like `subClassOf`, `group`, and `memberOf`, enabling them to accept both strings and lists. (`src/bblocks/datacommons_tools/custom_data/models/mcf.py`, `src/bblocks/datacommons_tools/custom_data/models/stat_vars.py`) [[1]](diffhunk://#diff-977b2ce18e3ee68e920ab2b02820efa4ec2a91399ac030892477015ee70212acL33-R33) [[2]](diffhunk://#diff-1d813dbf7378a629b696bfd19d5dc9bb0de6088c64b80782bbcec17f690e40feL39-R39) [[3]](diffhunk://#diff-1d813dbf7378a629b696bfd19d5dc9bb0de6088c64b80782bbcec17f690e40feL71-R72)
* Added `_parse_maybe_list` function to parse spreadsheet-style lists (e.g., `["item1", "item2"]`) into Python lists. (`src/bblocks/datacommons_tools/custom_data/schema_tools.py`)
* Updated `_rows_to_stat_var_nodes` to leverage `_parse_maybe_list`, ensuring proper handling of list-like input during node construction.