### PR TITLE
Extend models

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/data_management.py
+++ b/src/bblocks/datacommons_tools/custom_data/data_management.py
@@ -934,9 +934,11 @@ class CustomDataManager:
         policy: DuplicatePolicy = "error",
         replace_loaded_config: bool = True,
     ) -> CustomDataManager:
-        """Merge all config files found under ``directory``. This will recursively
-        search for config files in subdirectories. It will merge them with whatever
-        config is already loaded in the manager.
+        """Merge all config files in a directory and its subdirectories
+
+        This method will recursively search for config files in a directory and its
+        subdirectories (to a depth of?) and merge them with the config already in the manager.
+        If no config exists in the manager, it will be created from the merged config files.
 
         Args:
             directory: The directory to search for config files.
@@ -989,7 +991,3 @@ class CustomDataManager:
             directory, policy=policy, replace_loaded_config=True
         )
         return manager
-
-#%%
-
-#%%

--- a/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
@@ -64,21 +64,25 @@ class StatVarMCFNode(MCFNode):
         statType: Type of statistical measurement represented by the variable.
         typeOf: Fixed type indicating this is a StatisticalVariable.
         memberOf: Optional DCID indicating group membership.
+        relevantVariable: Optional DCID of a related variable.
         searchDescription: Optional descriptions enhancing NL search capabilities.
         populationType: Optional DCID of the population entity type being measured.
         measuredProperty: Optional DCID of the property being measured.
         measurementQualifier: Optional qualifier describing measurement specifics.
         measurementDenominator: Optional denominator for ratio-type statistical measures.
+        footnote: Optional footnotes providing additional context or information.
     """
 
     statType: Optional[StatType] = StatType.MEASURED_VALUE
     typeOf: Literal["dcid:StatisticalVariable"] = "dcid:StatisticalVariable"
     memberOf: Optional[StrOrListStr] = None
+    relevantVariable: Optional[StrOrListStr] = None
     searchDescription: Optional[QuotedStrListOrStr] = None
     populationType: Optional[str] = None
     measuredProperty: Optional[str] = None
     measurementQualifier: Optional[str] = None
     measurementDenominator: Optional[str] = None
+    footnote: Optional[QuotedStrListOrStr] = None
 
 
 class StatVarGroupMCFNode(MCFNode):
@@ -102,3 +106,27 @@ class StatVarGroupMCFNode(MCFNode):
     Node: constr(strip_whitespace=True, pattern=r".*g/.*")
     typeOf: Literal["dcid:StatVarGroup"] = "dcid:StatVarGroup"
     specializationOf: constr(strip_whitespace=True, pattern=r"^dcid:.*g/.*")
+
+
+class StatVarPeerGroupMCFNode(MCFNode):
+    """Represents a Statistical Variable Peer Group node in Metadata Common Format (MCF).
+    A StatVarPeerGroup represents a group of StatisticalVariable nodes that are comparable peers.
+
+    Attributes:
+        # Additional Attributes specific to StatVarPeerGroup
+        Node: Node identifier, must contain '/svpg'.
+        typeOf: Fixed type indicating this is a StatVarPeerGroup.
+        member: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
+
+         # Inherits from MCFNode
+        name: The human-readable name for the Node.
+        dcid: Optional DCID for uniquely identifying the Node.
+        description: Optional human-readable description.
+        provenance: Optional provenance information.
+        shortDisplayName: Optional human-readable short name for display.
+        subClassOf: Optional DCID indicating the 'parent' Node class.
+    """
+
+    Node: constr(strip_whitespace=True, pattern=r".*svpg/.*")
+    typeOf: Literal["dcid:StatVarGroup"] = "dcid:StatVarPeerGroup"
+    member: StrOrListStr

--- a/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
@@ -3,7 +3,10 @@ from typing import Optional, List, Dict, Literal
 
 from pydantic import BaseModel, ConfigDict, constr
 
-from bblocks.datacommons_tools.custom_data.models.common import QuotedStrListOrStr, StrOrListStr
+from bblocks.datacommons_tools.custom_data.models.common import (
+    StrOrListStr,
+    QuotedStrListOrStr,
+)
 from bblocks.datacommons_tools.custom_data.models.mcf import MCFNode
 
 

--- a/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
@@ -3,10 +3,12 @@ from typing import Optional, List, Dict, Literal
 
 from pydantic import BaseModel, ConfigDict, constr
 
+
 from bblocks.datacommons_tools.custom_data.models.common import (
-    StrOrListStr,
     QuotedStrListOrStr,
+    StrOrListStr,
 )
+
 from bblocks.datacommons_tools.custom_data.models.mcf import MCFNode
 
 

--- a/src/bblocks/datacommons_tools/custom_data/models/topics.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/topics.py
@@ -1,0 +1,34 @@
+from typing import Literal
+
+from pydantic import constr
+
+from bblocks.datacommons_tools.custom_data.models.common import StrOrListStr
+from bblocks.datacommons_tools.custom_data.models.mcf import MCFNode
+
+
+class TopicMCFNode(MCFNode):
+    """Represents a Topic node in Metadata Common Format (MCF).
+    A Topic represents a broad topic in the real-world such as economy, poverty,
+    crime, etc. Typically used to associated variables (StatisticalVariable)
+    related to a common concept.
+
+    Attributes:
+        # Additional Attributes specific to StatVarPeerGroup
+        Node: Node identifier, must contain '/topic'.
+        typeOf: Fixed type indicating this is a Topic.
+        relevantVariable: Variable or list of variables relevant to a topic.
+            Contains a list of ordered values. Must start with 'dcid:'
+
+
+         # Inherits from MCFNode
+        name: The human-readable name for the Node.
+        dcid: Optional DCID for uniquely identifying the Node.
+        description: Optional human-readable description.
+        provenance: Optional provenance information.
+        shortDisplayName: Optional human-readable short name for display.
+        subClassOf: Optional DCID indicating the 'parent' Node class.
+    """
+
+    Node: constr(strip_whitespace=True, pattern=r".*topic/.*")
+    typeOf: Literal["dcid:StatVarGroup"] = "dcid:Topic"
+    relevantVariable: StrOrListStr

--- a/src/bblocks/datacommons_tools/custom_data/schema_tools.py
+++ b/src/bblocks/datacommons_tools/custom_data/schema_tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import json
 import re
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Literal
 
@@ -12,7 +13,19 @@ from bblocks.datacommons_tools.custom_data.models.mcf import MCFNodes, MCFNode
 from bblocks.datacommons_tools.custom_data.models.stat_vars import (
     StatVarMCFNode,
     StatVarGroupMCFNode,
+    StatVarPeerGroupMCFNode,
 )
+from bblocks.datacommons_tools.custom_data.models.topics import TopicMCFNode
+
+
+class NodeTypes(StrEnum):
+    """Enumeration of node types used in Data Commons."""
+
+    NODE = "Node"
+    STAT_VAR = "StatVar"
+    STAT_VAR_GROUP = "StatVarGroup"
+    TOPIC = "Topic"
+    STAT_VAR_PEER_GROUP = "StatVarPeerGroup"
 
 
 def _parse_maybe_list(s: str | Any) -> str | list[str]:
@@ -32,10 +45,9 @@ def _parse_maybe_list(s: str | Any) -> str | list[str]:
 
 
 def _rows_to_stat_var_nodes(
-    data: pd.DataFrame,
-    node_type: Literal["Node", "StatVar", "StatVarGroup"] = "StatVar",
+    data: pd.DataFrame, node_type: str | NodeTypes = "StatVar"
 ) -> MCFNodes[StatVarMCFNode]:
-    """Convert a DataFrame into a collection of ``StatVarMCFNode`` objects.
+    """Convert a DataFrame into a collection of Node objects (of the type selected).
 
     Empty/NA values are removed from each row before constructing the node.
 
@@ -44,8 +56,13 @@ def _rows_to_stat_var_nodes(
         node_type: The type of node to create. Default is "StatVar".
 
     Returns:
-        A ``Nodes`` container with one ``StatVarMCFNode`` per row.
+        A ``Nodes`` container with one Node of the selected type per row.
     """
+
+    if isinstance(node_type, str):
+        node_type = NodeTypes(node_type)
+
+    node_type = str(node_type)
 
     records = data.to_dict(orient="records")
     nodes = []
@@ -54,6 +71,8 @@ def _rows_to_stat_var_nodes(
         "Node": MCFNode,
         "StatVar": StatVarMCFNode,
         "StatVarGroup": StatVarGroupMCFNode,
+        "Topic": TopicMCFNode,
+        "StatVarPeerGroup": StatVarPeerGroupMCFNode,
     }
 
     for record in records:

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -2,10 +2,10 @@ from pydantic import BaseModel
 
 from bblocks.datacommons_tools.custom_data.models.common import (
     _ensure_quoted,
-    mcf_str,
-    StrOrListStr,
     mcf_quoted_str,
+    mcf_str,
     parse_str_or_list,
+    StrOrListStr,
 )
 
 

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -1,11 +1,12 @@
+from pydantic import BaseModel
+
 from bblocks.datacommons_tools.custom_data.models.common import (
     _ensure_quoted,
-    mcf_quoted_str,
     mcf_str,
-    parse_str_or_list,
     StrOrListStr,
+    mcf_quoted_str,
+    parse_str_or_list,
 )
-from pydantic import BaseModel
 
 
 def test_ensure_quoted_handles_quotes_and_whitespace():
@@ -32,11 +33,6 @@ def test_mcf_quoted_str_with_single_and_multiple_items():
     assert mcf_quoted_str(None) is None
 
 
-def test_parse_str_or_list_honours_quotes():
-    assert parse_str_or_list('"A, B"') == "A, B"
-    assert parse_str_or_list('"A, B", C') == ["A, B", "C"]
-
-
 def test_mcf_str_with_single_and_multiple_items():
     assert mcf_str("abc") == "abc"
     assert mcf_str(["x"]) == "x"
@@ -55,3 +51,8 @@ def test_str_or_list_str_annotation_serialization():
 
     d2 = Dummy(field=["x", "y"])
     assert d2.model_dump()["field"] == "x, y"
+
+
+def test_parse_str_or_list_honours_quotes():
+    assert parse_str_or_list('"A, B"') == "A, B"
+    assert parse_str_or_list('"A, B", C') == ["A, B", "C"]

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -44,10 +44,3 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
     assert "memberOf: dcid:oneId, dcid:twoId" in mcf
-
-
-def test_rows_to_stat_var_nodes_respects_quoted_commas():
-    df = pd.read_clipboard()
-    nodes = _rows_to_stat_var_nodes(df)
-    mcf = nodes.nodes[0].mcf
-    assert 'searchDescription: "Single, part"' in mcf

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -39,12 +39,15 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists():
 
 def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
     df = pd.DataFrame(
-        {
-            "Node": ["n3"],
-            "name": ["Var"],
-            "memberOf": ['["dcid:oneId", "dcid:twoId"]'],
-        }
+        {"Node": ["n3"], "name": ["Var"], "memberOf": ['["dcid:oneId", "dcid:twoId"]']}
     )
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
-    assert 'memberOf: dcid:oneId, dcid:twoId' in mcf
+    assert "memberOf: dcid:oneId, dcid:twoId" in mcf
+
+
+def test_rows_to_stat_var_nodes_respects_quoted_commas():
+    df = pd.read_clipboard()
+    nodes = _rows_to_stat_var_nodes(df)
+    mcf = nodes.nodes[0].mcf
+    assert 'searchDescription: "Single, part"' in mcf


### PR DESCRIPTION
This pull request introduces new MCF node types (`StatVarPeerGroupMCFNode` and `TopicMCFNode`), updates to existing models, and improvements to schema tools and test coverage. 

### New Features:

* Added `StatVarPeerGroupMCFNode` class to represent statistical variable peer groups.
* Introduced `TopicMCFNode` class to represent broad topics 
* Added `NodeTypes` enumeration to define node types (`Node`, `StatVar`, `StatVarGroup`, `Topic`, and `StatVarPeerGroup`) for better type safety in schema tools. 
* Updated `StatVarMCFNode` class to include new optional attributes: `relevantVariable` and `footnote`. 
* Extended `_rows_to_stat_var_nodes` function to support the new `Topic` and `StatVarPeerGroup` node types, leveraging the `NodeTypes` enumeration for type selection. 