### PR TITLE
81 make input and output paths optional or remove

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -9,6 +9,7 @@
 ## v0.0.4 (2025-07-22)
 - Improved how groups strings are transformed to camelCase by dealing with
 additional special characters
+- Removed option to override input and output folders on the data load job.
 
 ## v0.0.3 (2025-07-18)
 - Fixes two bugs related to MFC files. It now enforces the `dcid:` prefix for Node and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-datacommons-tools"
-version = "0.0.3"
+version = "0.0.4"
 description = "Tools to work with Data Commons. Part of the bblocks projects."
 authors = [
     {name = "ONE Campaign"},

--- a/src/bblocks/datacommons_tools/gcp_utilities/jobs.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/jobs.py
@@ -24,8 +24,6 @@ def _build_env_vars(settings: KGSettings) -> list[EnvVar]:
     """Prepare the environment variables for Cloud Run tasks."""
     return [
         EnvVar({"name": "TIMESTAMP", "value": _utc_timestamp()}),
-        EnvVar({"name": "INPUT_DIR", "value": settings.full_gcs_input_path}),
-        EnvVar({"name": "OUTPUT_DIR", "value": settings.full_gcs_output_path}),
         EnvVar({"name": "DB_NAME", "value": settings.cloud_sql_db_name}),
     ]
 


### PR DESCRIPTION
This pull request includes updates to versioning, documentation, and code related to environment variables for Cloud Run tasks. The most significant changes involve removing the ability to override input and output directories in both the documentation and the codebase.

### Versioning Updates:
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the version number from `0.0.3` to `0.0.4` to reflect the new release.

### Documentation Updates:
* [`docs/docs/changelog.md`](diffhunk://#diff-09e59dfec1d3fe554796ca3fe446e6e3f4076334ab224561ff3899b3c17b3e6cR12): Removed the option to override input and output folders in the data load job from the changelog for version `v0.0.4`.

### Code Updates:
* [`src/bblocks/datacommons_tools/gcp_utilities/jobs.py`](diffhunk://#diff-11c3d57d15ed8ce08e3d795b793c915f3e9df14273b9daa8987ff8a3843bf571L27-L28): Removed environment variables `INPUT_DIR` and `OUTPUT_DIR` from the `_build_env_vars` function, aligning the code with the updated documentation.