### PR TITLE
Allow optional name

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,9 @@
 ## v0.1.0 (in development)
 - Initial release of the `bblocks-datacommons-tools` package for external preview and testing
 
+## v0.0.6 (2025-08-14)
+- Node name is now an optional attribute. This enables easily appending data to existing Base DC Nodes.
+
 ## v0.0.5 (2025-08-14)
 - Nodes can now contain a single `dcid` or a list of `dcids`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-datacommons-tools"
-version = "0.0.5"
+version = "0.0.6"
 description = "Tools to work with Data Commons. Part of the bblocks projects."
 authors = [
     {name = "ONE Campaign"},

--- a/src/bblocks/datacommons_tools/custom_data/models/mcf.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/mcf.py
@@ -30,7 +30,7 @@ class MCFNode(BaseModel):
     """
 
     Node: Dcid
-    name: QuotedStr
+    name: Optional[QuotedStr] = None
     typeOf: DcidOrListDcid
     dcid: Optional[Dcid] = None
     description: Optional[QuotedStr] = None


### PR DESCRIPTION
This pull request makes `name` an optional attribute for the `MCFNode` model, allowing for easier appending of data to existing Base DC Nodes. It also updates the package version and adds tests to ensure the new behavior works as expected.

### Model changes

* Made the `name` attribute in the `MCFNode` class optional by changing its type to `Optional[QuotedStr] = None`. This enables nodes to be created without a name, supporting use cases where appending to existing nodes is needed.

### Testing improvements

* Added tests to verify that nodes without a `name` attribute serialize correctly and can be loaded from MCF files without errors.

### Documentation and metadata

* Added a changelog entry for version `v0.0.6` describing the new optional `name` feature.
* Updated the package version in `pyproject.toml` from `0.0.5` to `0.0.6`.