### PR TITLE
Remove line breaks

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,10 @@
 ## v0.1.0 (in development)
 - Initial release of the `bblocks-datacommons-tools` package for external preview and testing
 
+## v0.0.7 (2025-08-27)
+- Handle linebreaks and trailing spaces by removing them. This prevents errors when serialising
+to MCF which could (quitely) break the data loading job.
+
 ## v0.0.6 (2025-08-14)
 - Node name is now an optional attribute. This enables easily appending data to existing Base DC Nodes.
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -7,8 +7,7 @@
 - Initial release of the `bblocks-datacommons-tools` package for external preview and testing
 
 ## v0.0.7 (2025-08-27)
-- Handle linebreaks and trailing spaces by removing them. This prevents errors when serialising
-to MCF which could (quitely) break the data loading job.
+to MCF which could (quietly) break the data loading job.
 
 ## v0.0.6 (2025-08-14)
 - Node name is now an optional attribute. This enables easily appending data to existing Base DC Nodes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-datacommons-tools"
-version = "0.0.6"
+version = "0.0.7"
 description = "Tools to work with Data Commons. Part of the bblocks projects."
 authors = [
     {name = "ONE Campaign"},

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -58,6 +58,19 @@ def test_mcfnode_allows_missing_name_and_serializes_without_it():
     assert not any(l.startswith("name:") for l in lines)
 
 
+def test_mcfnode_strips_linebreaks_and_trailing_spaces():
+    node = MCFNode(
+        Node="dcid:TestNode \n",  # newline and trailing space
+        name="My name\n ",
+        typeOf="dcid:TypeA \n",
+        extra_field="extra value \n",
+    )
+    assert node.Node == "dcid:TestNode"
+    assert node.name == "My name"
+    assert node.typeOf == "dcid:TypeA"
+    assert node.extra_field == "extra value"
+
+
 def test_mcfnodes_load_from_file_without_name(tmp_path):
     """
     Loading MCF where a block has no `name` should succeed.

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -19,6 +19,17 @@ def test_search_description_serialization_str_and_list():
     assert 'searchDescription: "A", "B"' in sv_list.mcf
 
 
+def test_statvarnode_strips_whitespace_and_linebreaks():
+    sv = StatVarMCFNode(
+        Node="dcid:n1\n",
+        name="Var \n",
+        searchDescription=["First line\n", "Second line "],
+    )
+    assert sv.Node == "dcid:n1"
+    assert sv.name == "Var"
+    assert sv.searchDescription == ["First line", "Second line"]
+
+
 def test_rows_to_stat_var_nodes_parses_comma_separated():
     df = pd.DataFrame(
         {"Node": ["dcid:n3"], "name": ["Var"], "searchDescription": ["A, B"]}


### PR DESCRIPTION
This pull request introduces a new patch release (v0.0.7) for the `bblocks-datacommons-tools` package, focusing on improving the robustness of MCF data serialization by automatically cleaning linebreaks and trailing spaces from string fields. This update helps prevent subtle data loading errors and includes new validation logic and corresponding tests.

* Added a `model_validator` to the `MCFNode` class in `mcf.py` that recursively strips linebreaks and trailing spaces from all string, list, and dict fields during model initialization. 
* Updated the `StatVarMCFNode` logic and added a test to verify that linebreaks and trailing spaces are also stripped from its fields, ensuring consistency across node types.
* Added tests for `MCFNode` and `StatVarMCFNode` to confirm that fields are correctly cleaned of whitespace and linebreaks, protecting against future regressions. [[1]](diffhunk://#diff-c1b07614c60cf792fbeab996beba1ae88f02003b36c517389901f797e214077aR61-R73) [[2]](diffhunk://#diff-b44cdd4b8ad0f8cb0c05cd92a7dc6bf7aa9c8ae79c0ed83d653302b7a1602c47R22-R32)
* Updated the changelog to document the new v0.0.7 release and describe the whitespace and linebreak cleaning feature.
* Bumped the version number in `pyproject.toml` from 0.0.6 to 0.0.7 to reflect the new release.

@lpicci96 FYI