### PR TITLE
Quoted string fix

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,7 +6,12 @@
 ## v0.1.0 (in development)
 - Initial release of the `bblocks-datacommons-tools` package for external preview and testing
 
+## v0.0.8 (2025-09-03)
+- Removed white space between quoted items do defend against a bug with data loading on
+the DC side.
+
 ## v0.0.7 (2025-08-27)
+- Handle linebreaks and trailing spaces by removing them. This prevents errors when serialising
 to MCF which could (quietly) break the data loading job.
 
 ## v0.0.6 (2025-08-14)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-datacommons-tools"
-version = "0.0.7"
+version = "0.0.8"
 description = "Tools to work with Data Commons. Part of the bblocks projects."
 authors = [
     {name = "ONE Campaign"},

--- a/src/bblocks/datacommons_tools/custom_data/models/common.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/common.py
@@ -41,7 +41,7 @@ def mcf_quoted_str(value: str | list[str] | None) -> str | None:
         if len(value) < 2:
             return _ensure_quoted(value[0])
 
-        return ", ".join(_ensure_quoted(str(item)) for item in value)
+        return ",".join(_ensure_quoted(str(item)) for item in value)
 
     return _ensure_quoted(value)
 

--- a/src/bblocks/datacommons_tools/custom_data/models/mcf.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/mcf.py
@@ -72,7 +72,7 @@ class MCFNode(BaseModel):
 
         # Pull Node first, then sort for consistent ordering
         lines = [f"Node: {data.pop('Node')}"]
-        lines.extend(f"{k}:{v}" for k, v in data.items())
+        lines.extend(f"{k}: {v}" for k, v in data.items())
 
         return "\n".join(lines) + "\n\n"
 

--- a/src/bblocks/datacommons_tools/custom_data/models/mcf.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/mcf.py
@@ -72,7 +72,7 @@ class MCFNode(BaseModel):
 
         # Pull Node first, then sort for consistent ordering
         lines = [f"Node: {data.pop('Node')}"]
-        lines.extend(f"{k}: {v}" for k, v in data.items())
+        lines.extend(f"{k}:{v}" for k, v in data.items())
 
         return "\n".join(lines) + "\n\n"
 

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -28,7 +28,7 @@ def test_mcf_quoted_str_with_single_and_multiple_items():
     assert mcf_quoted_str(["x"]) == '"x"'
     # Multi-element list
     multi = mcf_quoted_str(["a", "b", "c"])
-    assert multi == '"a", "b", "c"'
+    assert multi == '"a","b","c"'
     # None input
     assert mcf_quoted_str(None) is None
 

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -13,10 +13,10 @@ def test_search_description_serialization_str_and_list():
         name="Var",
         searchDescription=["A string, or not", "B string, other"],
     )
-    assert 'searchDescription: "A string, or not", "B string, other"' in sv_str.mcf
+    assert 'searchDescription: "A string, or not","B string, other"' in sv_str.mcf
 
     sv_list = StatVarMCFNode(Node="dcid:n2", name="Var", searchDescription=["A", "B"])
-    assert 'searchDescription: "A", "B"' in sv_list.mcf
+    assert 'searchDescription: "A","B"' in sv_list.mcf
 
 
 def test_statvarnode_strips_whitespace_and_linebreaks():
@@ -36,7 +36,7 @@ def test_rows_to_stat_var_nodes_parses_comma_separated():
     )
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
-    assert 'searchDescription: "A", "B"' in mcf
+    assert 'searchDescription: "A","B"' in mcf
 
 
 def test_rows_to_stat_var_nodes_parses_spreadsheet_lists():
@@ -49,7 +49,7 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists():
     )
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
-    assert 'searchDescription: "A list, comma", "second element"' in mcf
+    assert 'searchDescription: "A list, comma","second element"' in mcf
 
 
 def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():


### PR DESCRIPTION
This pull request updates the `bblocks-datacommons-tools` package to version 0.0.8 and addresses a bug related to whitespace handling in quoted items, which improves data loading reliability on the Data Commons side.

Release and bug fix:

* Updated the package version to `0.0.8` in `pyproject.toml` and documented the release in `docs/docs/changelog.md`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-09e59dfec1d3fe554796ca3fe446e6e3f4076334ab224561ff3899b3c17b3e6cR9-R14)
* Removed whitespace between quoted items to prevent a bug with data loading on the Data Commons side.