### PR TITLE
Support new config options in CustomDataManager

### DIFF
--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -6,6 +6,10 @@
 ## v0.1.0 (in development)
 - Initial release of the `bblocks-datacommons-tools` package for external preview and testing
 
+## v0.0.9 (2025-09-17)
+- Added new configuration options, including `set_customIdNamespace`, `set_customSvgPrefix`,
+`set_defaultCustomRootStatVarGroupName` and `set_svHierarchyPropsBlocklist`.
+
 ## v0.0.8 (2025-09-03)
 - Removed white space between quoted items do defend against a bug with data loading on
 the DC side.

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -191,6 +191,25 @@ which allows you to group statistical variables by their properties.
 manager.set_groupStatVarsByProperty(True)
 ```
 
+You can control the generated StatVar and StatVarGroup identifiers in the `config.json` file.
+
+
+```python
+manager.set_customIdNamespace("ONE")
+manager.set_customSvgPrefix("ONE/g/")  # Optional – overrides the default of "geo/g/"
+manager.set_defaultCustomRootStatVarGroupName("ONE Data")
+```
+
+Finally, you can update the hierarchy blocklist used when generating StatVar groups
+from the config. Any duplicates you provide are ignored automatically:
+
+```python
+manager.set_svHierarchyPropsBlocklist([
+    "WhoCode",
+    "aggregationDimensions",
+])
+```
+
 
 
 ## Validating and exporting files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-datacommons-tools"
-version = "0.0.8"
+version = "0.0.9"
 description = "Tools to work with Data Commons. Part of the bblocks projects."
 authors = [
     {name = "ONE Campaign"},

--- a/src/bblocks/datacommons_tools/custom_data/data_management.py
+++ b/src/bblocks/datacommons_tools/custom_data/data_management.py
@@ -214,6 +214,10 @@ class CustomDataManager:
 
         include_input_subdirs = self._config.includeInputSubdirs
         group_statvars = self._config.groupStatVarsByProperty
+        root_group_name = self._config.defaultCustomRootStatVarGroupName
+        namespace = self._config.customIdNamespace
+        svg_prefix = self._config.customSvgPrefix
+        blocklist = self._config.svHierarchyPropsBlocklist
 
         return (
             f"<CustomDataManager config: "
@@ -221,7 +225,10 @@ class CustomDataManager:
             f"\n{sources_count} sources"
             f"\n{variables_count} variables"
             f"\nflags: includeInputSubdirs={include_input_subdirs}, "
-            f"groupStatVarsByProperty={group_statvars}>"
+            f"groupStatVarsByProperty={group_statvars}, "
+            f"defaultCustomRootStatVarGroupName={root_group_name}, "
+            f"customIdNamespace={namespace}, customSvgPrefix={svg_prefix}, "
+            f"svHierarchyPropsBlocklist={blocklist}>"
         )
 
     def set_includeInputSubdirs(self, set_value: bool) -> CustomDataManager:
@@ -232,6 +239,60 @@ class CustomDataManager:
     def set_groupStatVarsByProperty(self, set_value: bool) -> CustomDataManager:
         """Set the groupStatVarsByProperty attribute of the config"""
         self._config.groupStatVarsByProperty = set_value
+        return self
+
+    def set_defaultCustomRootStatVarGroupName(
+        self, name: Optional[str]
+    ) -> CustomDataManager:
+        """Set the default custom root StatVarGroup display name in the config."""
+
+        self._config.defaultCustomRootStatVarGroupName = name
+        return self
+
+    def set_customIdNamespace(
+        self, namespace: Optional[str], *, update_svg_prefix: bool = True
+    ) -> CustomDataManager:
+        """Set the namespace for generated custom Statistical Variables and groups.
+
+        Args:
+            namespace: Namespace token to use. Pass ``None`` to unset.
+            update_svg_prefix: Automatically set ``customSvgPrefix`` to
+                ``"<namespace>/g/"`` when the prefix isn't explicitly defined yet.
+                Defaults to ``True``.
+        """
+
+        self._config.customIdNamespace = namespace
+
+        if update_svg_prefix and namespace and not self._config.customSvgPrefix:
+            self._config.customSvgPrefix = f"{namespace}/g/"
+
+        return self
+
+    def set_customSvgPrefix(self, prefix: Optional[str]) -> CustomDataManager:
+        """Set the prefix used for generated custom StatVarGroup IDs."""
+
+        self._config.customSvgPrefix = prefix
+        return self
+
+    def set_svHierarchyPropsBlocklist(
+        self, blocklist: Optional[List[str]]
+    ) -> CustomDataManager:
+        """Set the StatVar hierarchy property blocklist.
+
+        Duplicate entries are removed while preserving the original order.
+        Pass ``None`` to unset the blocklist.
+        """
+
+        if blocklist is None:
+            self._config.svHierarchyPropsBlocklist = None
+        else:
+            seen: set[str] = set()
+            deduped: list[str] = []
+            for prop in blocklist:
+                if prop not in seen:
+                    seen.add(prop)
+                    deduped.append(prop)
+            self._config.svHierarchyPropsBlocklist = deduped
         return self
 
     def add_provenance(

--- a/src/bblocks/datacommons_tools/custom_data/models/config_file.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/config_file.py
@@ -16,13 +16,25 @@ class Config(BaseModel):
     Attributes:
         includeInputSubdirs: Include input subdirectories.
         groupStatVarsByProperty: Group stat vars by property.
+        defaultCustomRootStatVarGroupName: Display name for the custom root StatVarGroup.
+            Default: `"Custom Variables"`
+        customIdNamespace: Namespace token for generated ids for SVs and manual groups.
+            Default: `"custom"`.
+        customSvgPrefix: String prefix for generated custom StatVarGroup ids. If not set,
+            and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
         inputFiles: Dictionary of input files.
+        svHierarchyPropsBlocklist: Array of additional property dcids to exclude from hierarchy generation.
+            These are added to the internal blocklist used by Data Commons.
         variables: Dictionary of variables.
         sources: Dictionary of sources.
     """
 
     includeInputSubdirs: Optional[bool] = None
     groupStatVarsByProperty: Optional[bool] = None
+    defaultCustomRootStatVarGroupName: Optional[str] = None
+    customIdNamespace: Optional[str] = None
+    customSvgPrefix: Optional[str] = None
+    svHierarchyPropsBlocklist: Optional[list[str]] = None
     inputFiles: Dict[
         str,
         Annotated[


### PR DESCRIPTION
This PR closes #89. This pull request adds support for several new configuration options in the custom data management system, allowing users to control the generation of Statistical Variable (StatVar) and StatVarGroup identifiers, set display names, and manage property blocklists for hierarchy generation. It also updates the merging logic for config files and adds comprehensive tests for the new features.

**New configuration options and API methods:**

- Added new config fields to `Config`: `defaultCustomRootStatVarGroupName`, `customIdNamespace`, `customSvgPrefix`, and `svHierarchyPropsBlocklist`, with corresponding documentation and default behaviors.
- Implemented new setter methods in `CustomDataManager` for these config options, including logic for deduplicating blocklist entries and auto-generating the SVG prefix from the namespace.
- Updated the `__repr__` method of `CustomDataManager` to display the new configuration fields.

**Configuration file merging logic:**

- Refactored merging logic to support the new config fields, including a new `_merge_sequence_attribute` helper for merging and deduplicating sequence attributes like `svHierarchyPropsBlocklist`. [[1]](diffhunk://#diff-fb0ccedf3eaa07424e7797159e5a3d20fcd1c7acf460e1c130fd0d02298b0640L20-R37) [[2]](diffhunk://#diff-fb0ccedf3eaa07424e7797159e5a3d20fcd1c7acf460e1c130fd0d02298b0640R128-R152) [[3]](diffhunk://#diff-fb0ccedf3eaa07424e7797159e5a3d20fcd1c7acf460e1c130fd0d02298b0640L132-R168)

**Documentation updates:**

- Expanded the documentation to describe the new configuration options and how to use the new API methods for customizing StatVar/StatVarGroup generation and blocklist management.

**Testing improvements:**

- Added new and extended existing tests to cover the new configuration fields, their setters, and the merging logic, including edge cases for deduplication and override behavior. [[1]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20R66-R91) [[2]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20L304-R341) [[3]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20L314-R384) [[4]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20R395-R397) [[5]](diffhunk://#diff-2c2cfe437ba354239133256d7c10c8ea3aa70f429e14dcbe8de325cc60baee20R419-R443)
