### PR TITLE
Remove stale content from GCS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.1] - 2026-02-19
+
+### Added
+- `--sync` flag for `upload` and `pipeline` CLI commands. When enabled, remote blobs
+  that no longer have a local counterpart are deleted after uploading.
+- `sync_directory_to_gcs` function in `storage.py` that composes upload + stale blob cleanup.
+- `sync` parameter on `upload_to_cloud_storage` in `pipeline.py`.
+
 ## [0.1.0] - 2025-02-13
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bblocks-datacommons-tools"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tools to work with Data Commons. Part of the bblocks projects."
 authors = [
     { name = "ONE Campaign" },

--- a/src/bblocks/datacommons_tools/cli/data_load_pipeline.py
+++ b/src/bblocks/datacommons_tools/cli/data_load_pipeline.py
@@ -32,6 +32,12 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Local directory to upload. Defaults to settings.LOCAL_PATH",
     )
     parser.add_argument(
+        "--sync",
+        action="store_true",
+        default=False,
+        help="Delete remote blobs that no longer have a local counterpart after uploading",
+    )
+    parser.add_argument(
         "--load-timeout",
         type=int,
         default=6000,
@@ -49,7 +55,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
 def run(args: argparse.Namespace) -> int:
     """Execute the ``pipeline`` command."""
     settings = load_settings_from_args(args)
-    upload_to_cloud_storage(settings=settings, directory=args.directory)
+    upload_to_cloud_storage(settings=settings, directory=args.directory, sync=args.sync)
     run_data_load(settings=settings, timeout=args.load_timeout)
     redeploy_service(settings=settings, timeout=args.deploy_timeout)
     return 0

--- a/src/bblocks/datacommons_tools/cli/upload.py
+++ b/src/bblocks/datacommons_tools/cli/upload.py
@@ -27,11 +27,17 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         type=Path,
         help="Local directory to upload. Defaults to settings.LOCAL_PATH",
     )
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        default=False,
+        help="Delete remote blobs that no longer have a local counterpart after uploading",
+    )
     parser.set_defaults(func=run)
 
 
 def run(args: argparse.Namespace) -> int:
     """Execute the ``upload`` command."""
     settings = load_settings_from_args(args)
-    upload_to_cloud_storage(settings=settings, directory=args.directory)
+    upload_to_cloud_storage(settings=settings, directory=args.directory, sync=args.sync)
     return 0

--- a/src/bblocks/datacommons_tools/gcp_utilities/pipeline.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/pipeline.py
@@ -18,24 +18,32 @@ from bblocks.datacommons_tools.gcp_utilities.jobs import (
     redeploy_cloud_run_service,
 )
 from bblocks.datacommons_tools.gcp_utilities.settings import KGSettings
-from bblocks.datacommons_tools.gcp_utilities.storage import upload_directory_to_gcs
+from bblocks.datacommons_tools.gcp_utilities.storage import (
+    upload_directory_to_gcs,
+    sync_directory_to_gcs,
+)
 
 
 def upload_to_cloud_storage(
-    settings: KGSettings, directory: PathLike | Path | None = None
+    settings: KGSettings,
+    directory: PathLike | Path | None = None,
+    sync: bool = False,
 ):
     """Upload data to Google Cloud Storage.
 
     Args:
         settings (KGSettings): The settings for the Knowledge Graph.
         directory (Path | None): The local directory to upload. If None, uses the default path.
+        sync (bool): If True, delete remote blobs that no longer have a local
+            counterpart after uploading. Defaults to False.
 
     """
 
     gcs_client = get_gcs_client(credentials=settings.gcp_credentials)
     bucket = gcs_client.get_bucket(settings.gcs_bucket_name)
 
-    upload_directory_to_gcs(
+    upload_fn = sync_directory_to_gcs if sync else upload_directory_to_gcs
+    upload_fn(
         bucket=bucket,
         directory=directory,
         gcs_folder_name=settings.gcs_input_folder_path,

--- a/src/bblocks/datacommons_tools/gcp_utilities/storage.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/storage.py
@@ -106,6 +106,54 @@ def upload_directory_to_gcs(
     )
 
 
+def sync_directory_to_gcs(
+    bucket: Bucket, directory: Path, gcs_folder_name: str | None = None
+) -> None:
+    """Upload a local directory then delete stale remote blobs.
+
+    This function first uploads all local files (via
+    :func:`upload_directory_to_gcs`) and then removes any blobs under
+    ``gcs_folder_name`` that no longer have a local counterpart.
+
+    Args:
+        bucket (Bucket): GCS bucket instance.
+        directory (Path): Local directory to upload.
+        gcs_folder_name (str | None): Name of the base folder in the GCS
+            bucket. If ``None``, the bucket root is used.
+    """
+    upload_directory_to_gcs(bucket, directory, gcs_folder_name)
+
+    # Build the set of expected remote paths from local files
+    expected: set[str] = set()
+    for local_path in _iter_local_files(directory):
+        if local_path.suffix not in _VALID_EXTENSIONS:
+            continue
+        relative = local_path.relative_to(directory)
+        remote_path = (
+            f"{gcs_folder_name}/{relative}" if gcs_folder_name else str(relative)
+        )
+        expected.add(remote_path)
+
+    # List current remote blobs
+    prefix = gcs_folder_name or None
+    try:
+        remote = set(list_bucket_files(bucket, prefix))
+    except FileNotFoundError:
+        remote = set()
+
+    stale = remote - expected
+    if stale:
+        logger.info(
+            f"Found {len(stale)} stale blob(s) under "
+            f"'{gcs_folder_name or 'root'}', deleting..."
+        )
+        delete_bucket_files(bucket, list(stale))
+    else:
+        logger.info(
+            f"No stale blobs found under '{gcs_folder_name or 'root'}'"
+        )
+
+
 def list_bucket_files(bucket: Bucket, gcs_folder_name: str | None = None) -> list[str]:
     """Return the list of blob names in ``gcs_folder_name``.
 

--- a/src/bblocks/datacommons_tools/gcp_utilities/storage.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/storage.py
@@ -93,9 +93,7 @@ def upload_directory_to_gcs(
             logger.warning(f"Skipping unsupported file type: {local_path}")
             continue
         relative = local_path.relative_to(directory).as_posix()
-        remote_path = (
-            f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
-        )
+        remote_path = f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
         bucket.blob(remote_path).upload_from_filename(str(local_path))
         logger.info(f"Uploaded {local_path} to {remote_path}")
         files_uploaded += 1
@@ -129,9 +127,7 @@ def sync_directory_to_gcs(
         if local_path.suffix not in _VALID_EXTENSIONS:
             continue
         relative = local_path.relative_to(directory).as_posix()
-        remote_path = (
-            f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
-        )
+        remote_path = f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
         expected.add(remote_path)
 
     # List current remote blobs

--- a/src/bblocks/datacommons_tools/gcp_utilities/storage.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/storage.py
@@ -149,9 +149,7 @@ def sync_directory_to_gcs(
         )
         delete_bucket_files(bucket, list(stale))
     else:
-        logger.info(
-            f"No stale blobs found under '{gcs_folder_name or 'root'}'"
-        )
+        logger.info(f"No stale blobs found under '{gcs_folder_name or 'root'}'")
 
 
 def list_bucket_files(bucket: Bucket, gcs_folder_name: str | None = None) -> list[str]:

--- a/src/bblocks/datacommons_tools/gcp_utilities/storage.py
+++ b/src/bblocks/datacommons_tools/gcp_utilities/storage.py
@@ -92,9 +92,9 @@ def upload_directory_to_gcs(
         if local_path.suffix not in _VALID_EXTENSIONS:
             logger.warning(f"Skipping unsupported file type: {local_path}")
             continue
-        relative = local_path.relative_to(directory)
+        relative = local_path.relative_to(directory).as_posix()
         remote_path = (
-            f"{gcs_folder_name}/{relative}" if gcs_folder_name else str(relative)
+            f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
         )
         bucket.blob(remote_path).upload_from_filename(str(local_path))
         logger.info(f"Uploaded {local_path} to {remote_path}")
@@ -128,9 +128,9 @@ def sync_directory_to_gcs(
     for local_path in _iter_local_files(directory):
         if local_path.suffix not in _VALID_EXTENSIONS:
             continue
-        relative = local_path.relative_to(directory)
+        relative = local_path.relative_to(directory).as_posix()
         remote_path = (
-            f"{gcs_folder_name}/{relative}" if gcs_folder_name else str(relative)
+            f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
         )
         expected.add(remote_path)
 

--- a/tests/test_cli_gcp.py
+++ b/tests/test_cli_gcp.py
@@ -18,7 +18,9 @@ def test_upload_command_invokes_pipeline(tmp_path: Path) -> None:
         )
         assert exit_code == 0
         get.assert_called_once_with(source="json", file=Path("s.json"))
-        upload.assert_called_once_with(settings=get.return_value, directory=directory, sync=False)
+        upload.assert_called_once_with(
+            settings=get.return_value, directory=directory, sync=False
+        )
 
 
 def test_dataload_command_invokes_pipeline() -> None:
@@ -73,7 +75,9 @@ def test_pipeline_command_runs_all(tmp_path: Path) -> None:
         )
         assert exit_code == 0
         get.assert_called_once_with(source="json", file=Path("s.json"))
-        upload.assert_called_once_with(settings=get.return_value, directory=directory, sync=False)
+        upload.assert_called_once_with(
+            settings=get.return_value, directory=directory, sync=False
+        )
         load.assert_called_once_with(settings=get.return_value, timeout=7)
         red.assert_called_once_with(settings=get.return_value, timeout=3)
 

--- a/tests/test_cli_gcp.py
+++ b/tests/test_cli_gcp.py
@@ -18,7 +18,7 @@ def test_upload_command_invokes_pipeline(tmp_path: Path) -> None:
         )
         assert exit_code == 0
         get.assert_called_once_with(source="json", file=Path("s.json"))
-        upload.assert_called_once_with(settings=get.return_value, directory=directory)
+        upload.assert_called_once_with(settings=get.return_value, directory=directory, sync=False)
 
 
 def test_dataload_command_invokes_pipeline() -> None:
@@ -73,7 +73,7 @@ def test_pipeline_command_runs_all(tmp_path: Path) -> None:
         )
         assert exit_code == 0
         get.assert_called_once_with(source="json", file=Path("s.json"))
-        upload.assert_called_once_with(settings=get.return_value, directory=directory)
+        upload.assert_called_once_with(settings=get.return_value, directory=directory, sync=False)
         load.assert_called_once_with(settings=get.return_value, timeout=7)
         red.assert_called_once_with(settings=get.return_value, timeout=3)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,6 +1,4 @@
-import os
-from pathlib import Path
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
 import pytest
 
@@ -58,7 +56,7 @@ def test_upload_directory_to_gcs(tmp_path):
 
     upload_directory_to_gcs(bucket, tmp_path, "prefix")
 
-    expected_keys = {"prefix/a.csv", "prefix/b.json", f"prefix/sub/c.mcf"}
+    expected_keys = {"prefix/a.csv", "prefix/b.json", "prefix/sub/c.mcf"}
     assert set(blobs.keys()) == expected_keys
     for b in blobs.values():
         b.upload_from_filename.assert_called_once()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,6 @@
-from unittest.mock import Mock
+import os
+from pathlib import Path
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -6,6 +8,8 @@ import pandas as pd
 
 from bblocks.datacommons_tools.gcp_utilities.storage import (
     list_bucket_files,
+    upload_directory_to_gcs,
+    sync_directory_to_gcs,
     get_unregistered_csv_files,
     get_missing_csv_files,
     delete_bucket_files,
@@ -29,6 +33,153 @@ def _minimal_config(key: str = "a.csv") -> Config:
     }
     sources = {"src": Source(url="http://s", provenances={"prov": "http://p"})}
     return Config(inputFiles=input_files, sources=sources)
+
+
+def test_upload_directory_to_gcs(tmp_path):
+    (tmp_path / "a.csv").write_text("col\n1\n")
+    (tmp_path / "b.json").write_text("{}")
+    (tmp_path / "skip.txt").write_text("nope")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "c.mcf").write_text("Node: dcid:x\n")
+    # json in subdir should be skipped
+    (sub / "d.json").write_text("{}")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    upload_directory_to_gcs(bucket, tmp_path, "prefix")
+
+    expected_keys = {"prefix/a.csv", "prefix/b.json", f"prefix/sub/c.mcf"}
+    assert set(blobs.keys()) == expected_keys
+    for b in blobs.values():
+        b.upload_from_filename.assert_called_once()
+
+
+def test_upload_directory_to_gcs_no_prefix(tmp_path):
+    (tmp_path / "a.csv").write_text("col\n1\n")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    upload_directory_to_gcs(bucket, tmp_path)
+
+    assert set(blobs.keys()) == {"a.csv"}
+
+
+def test_sync_directory_to_gcs_with_stale_blobs(tmp_path):
+    (tmp_path / "a.csv").write_text("col\n1\n")
+    (tmp_path / "b.json").write_text("{}")
+
+    bucket = Mock()
+    upload_blobs: dict[str, Mock] = {}
+    delete_blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        # Track whether this is an upload or delete call based on context
+        if name not in upload_blobs:
+            upload_blobs[name] = b
+        else:
+            delete_blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    # Remote has a stale blob "prefix/old.csv" plus the two that still exist
+    blob_a = Mock()
+    blob_a.name = "prefix/a.csv"
+    blob_b = Mock()
+    blob_b.name = "prefix/b.json"
+    blob_old = Mock()
+    blob_old.name = "prefix/old.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_b, blob_old]
+
+    sync_directory_to_gcs(bucket, tmp_path, "prefix")
+
+    # Upload should have been called for a.csv and b.json
+    assert "prefix/a.csv" in upload_blobs
+    assert "prefix/b.json" in upload_blobs
+
+    # The stale blob should have been deleted
+    bucket.blob.assert_any_call("prefix/old.csv")
+    # Find the mock that was created for the delete call
+    all_blob_calls = [c.args[0] for c in bucket.blob.call_args_list]
+    assert "prefix/old.csv" in all_blob_calls
+
+
+def test_sync_directory_to_gcs_no_stale_blobs(tmp_path):
+    (tmp_path / "a.csv").write_text("col\n1\n")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    # Remote matches local exactly
+    blob_a = Mock()
+    blob_a.name = "prefix/a.csv"
+    bucket.list_blobs.return_value = [blob_a]
+
+    sync_directory_to_gcs(bucket, tmp_path, "prefix")
+
+    # Only the upload blob should have been created, no delete calls
+    assert "prefix/a.csv" in blobs
+    # The blob for upload was called, but delete was never called on it
+    # (delete_bucket_files is not called when there are no stale blobs)
+    blob_calls = [c.args[0] for c in bucket.blob.call_args_list]
+    # Only "prefix/a.csv" from the upload
+    assert blob_calls == ["prefix/a.csv"]
+
+
+def test_sync_directory_to_gcs_no_prefix(tmp_path):
+    (tmp_path / "a.csv").write_text("col\n1\n")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    blob_a = Mock()
+    blob_a.name = "a.csv"
+    blob_old = Mock()
+    blob_old.name = "old.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_old]
+
+    sync_directory_to_gcs(bucket, tmp_path)
+
+    # old.csv should be deleted
+    all_blob_calls = [c.args[0] for c in bucket.blob.call_args_list]
+    assert "old.csv" in all_blob_calls
 
 
 def test_list_bucket_files_with_prefix():

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "bblocks-datacommons-tools"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "google-cloud-run" },


### PR DESCRIPTION
This pull request adds a new `--sync` option to the `upload` and `pipeline` CLI commands, enabling users to delete remote blobs that no longer have a local counterpart after uploading. The implementation introduces a new `sync_directory_to_gcs` function, updates the upload logic to support the sync option, and adds comprehensive tests for the new behavior.

**CLI Enhancements:**

* Added a `--sync` flag to both the `upload` and `pipeline` commands, allowing users to remove remote blobs that are not present locally after an upload. [[1]](diffhunk://#diff-c38dbf61fec79a2c027597c9bd2101b8696bc266ebb58f172633a66a79c207f0R34-R39) [[2]](diffhunk://#diff-a116d295fdec3439ebbfeafd36d8f4df9d680d7a180350ecfd8a1873a4d965e6R30-R42)
* Updated the CLI command handlers to pass the `sync` parameter to `upload_to_cloud_storage`. [[1]](diffhunk://#diff-c38dbf61fec79a2c027597c9bd2101b8696bc266ebb58f172633a66a79c207f0L52-R58) [[2]](diffhunk://#diff-a116d295fdec3439ebbfeafd36d8f4df9d680d7a180350ecfd8a1873a4d965e6R30-R42)

**Core Functionality:**

* Introduced the `sync_directory_to_gcs` function in `storage.py`, which uploads local files and deletes stale remote blobs, and updated `upload_to_cloud_storage` to use this when `sync` is enabled. [[1]](diffhunk://#diff-dc6ab0eba07acf361047c5cd0978707af68846eb7c21fc1303a28ec18c41c61aL21-R46) [[2]](diffhunk://#diff-429cac2b9073749078a3974ea5c549480999d98e642bf36e991ee93d8535ffa9R109-R156)

**Testing Improvements:**

* Added and updated tests to cover the new sync logic, including scenarios with and without stale blobs, and ensured the correct invocation of the sync parameter in CLI tests. [[1]](diffhunk://#diff-6fde2ce98f0dee9fc89cae4910c611e0446a618699e50b25831eff471583c93cL21-R21) [[2]](diffhunk://#diff-6fde2ce98f0dee9fc89cae4910c611e0446a618699e50b25831eff471583c93cL76-R76) [[3]](diffhunk://#diff-97a131ad6711fd2807ed014b7f48f566d7e07b56f29631077d6495bed8c4f459L1-R12) [[4]](diffhunk://#diff-97a131ad6711fd2807ed014b7f48f566d7e07b56f29631077d6495bed8c4f459R38-R184)

**Documentation and Versioning:**

* Updated `CHANGELOG.md` to document the new features, and bumped the package version to `0.1.1` in `pyproject.toml`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R10) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3)