### PR TITLE
Add optional data-completeness validation to export_all

### DIFF
--- a/src/bblocks/datacommons_tools/custom_data/data_management.py
+++ b/src/bblocks/datacommons_tools/custom_data/data_management.py
@@ -1014,11 +1014,33 @@ class CustomDataManager:
         for file, data in self._data.items():
             data.to_csv(Path(dir_path) / file, index=False)
 
+    def validate_all_input_files_have_data(self) -> CustomDataManager:
+        """Validate that every declared input file has a corresponding data entry.
+
+        Raises:
+            ValueError: If one or more input files declared in the config do not have
+                associated data registered in this manager.
+        """
+
+        missing = [
+            file_name
+            for file_name in self._config.inputFiles
+            if file_name not in self._data
+        ]
+        if missing:
+            raise ValueError(
+                f"The following input files declared in the config have no corresponding "
+                f"data: {missing}. Use add_data() or pass data= when registering the "
+                f"input file."
+            )
+        return self
+
     def export_all(
         self,
         dir_path: str | PathLike[str],
         override: bool = False,
         mcf_file_names: Optional[str | list[str]] = None,
+        validate_data: bool = False,
     ) -> None:
         """Export the config, MCF file, and data to a directory
 
@@ -1027,7 +1049,14 @@ class CustomDataManager:
             override: If True, overwrite the files if they exist. Defaults to False.
             mcf_file_names: Name of the MCF file(s) to export (must end in .mcf).
                 Defaults to None, which means no MCF file will be exported.
+            validate_data: If True, raise a ValueError before exporting if any input
+                file declared in the config does not have a corresponding data entry.
+                Defaults to False.
         """
+
+        # optionally validate that all input files have data
+        if validate_data:
+            self.validate_all_input_files_have_data()
 
         # export the config
         self.export_config(dir_path)

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -494,3 +494,51 @@ def test_rename_variable_and_source_methods():
         manager.rename_source("unknown", "x")
     with pytest.raises(ValueError):
         manager.rename_source("s2", "s2")
+
+
+def test_validate_all_input_files_have_data(tmp_path):
+    """Verify the optional data-completeness validation on export_all and the standalone method."""
+    manager = CustomDataManager()
+    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+
+    df = pd.DataFrame({"A": [1, 2]})
+
+    # Register one file WITH data and one WITHOUT data
+    manager.add_implicit_schema_file(
+        file_name="with_data.csv",
+        provenance="p1",
+        data=df,
+        entityType="Country",
+    )
+    manager.add_implicit_schema_file(
+        file_name="no_data.csv",
+        provenance="p1",
+        entityType="Country",
+    )
+
+    # Standalone validation method raises because no_data.csv has no data
+    with pytest.raises(ValueError, match="no_data.csv"):
+        manager.validate_all_input_files_have_data()
+
+    # export_all without validate_data=True should NOT raise (default off)
+    # It will raise because export_data needs at least one file — so just confirm
+    # validate_data=False doesn't surface the missing-data error
+    try:
+        manager.export_all(tmp_path, validate_data=False)
+    except ValueError as exc:
+        assert "no_data.csv" not in str(exc), (
+            "validate_data=False should not raise about missing data"
+        )
+
+    # export_all with validate_data=True should raise before writing anything
+    with pytest.raises(ValueError, match="no_data.csv"):
+        manager.export_all(tmp_path, validate_data=True)
+
+    # After adding data for the second file, validation passes
+    manager.add_data(df, "no_data.csv")
+    manager.validate_all_input_files_have_data()  # should not raise
+
+    manager.export_all(tmp_path, validate_data=True)  # should not raise
+    assert (tmp_path / "config.json").exists()
+    assert (tmp_path / "with_data.csv").exists()
+    assert (tmp_path / "no_data.csv").exists()


### PR DESCRIPTION
## Summary

- Adds `validate_all_input_files_have_data()` as a public method on `CustomDataManager` that raises `ValueError` if any input file declared in the config has no corresponding data loaded into the manager.
- Adds a `validate_data: bool = False` parameter to `export_all()` that calls the above validation before exporting, keeping the default behaviour unchanged (opt-in).
- Adds a focused test covering the error path (missing data), the default-off behaviour, and the happy path after all data is loaded.

## Test plan

- [ ] `uv run pytest tests/test_data_management.py -v` — all 17 tests pass
- [ ] `uv run pytest` — all 68 tests pass

Closes #9