### PR TITLE
Remove deprecated implicit (schemaless) schema support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [Unreleased]
+
+### Removed
+- `add_implicit_schema_file` method on `CustomDataManager`.
+- `add_variable_to_config` method on `CustomDataManager`.
+- `ImplicitSchemaFile`, `ObservationProperties`, and `Variable` model classes.
+
+### Changed
+- `Config.inputFiles` is now `Dict[str, ExplicitSchemaFile]` — the implicit
+  (`variablePerColumn`) path is no longer supported. Loading a legacy config that contains
+  `"format": "variablePerColumn"` now raises a clear `ValueError` with a migration message
+  instead of a generic Pydantic `ValidationError`.
+- `ExplicitSchemaFile` now rejects unknown keys (`extra="forbid"`).
+
+**Migration:** replace `add_implicit_schema_file` calls with `add_explicit_schema_file` and
+supply a `columnMappings` argument. See the
+[Data Commons custom data documentation](https://docs.datacommons.org/custom_dc/custom_data.html)
+for the explicit-schema format.
+
 ## [0.1.1] - 2026-02-19
 
 ### Added

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -2,6 +2,11 @@
 
 ## v1.0.0 (in development)
 - Stable release of the `bblocks-datacommons-tools` package
+- **Breaking:** removed implicit-schema support — `add_implicit_schema_file`,
+  `add_variable_to_config`, and the `ImplicitSchemaFile` / `ObservationProperties` / `Variable`
+  model classes are gone. Loading a legacy `variablePerColumn` config now raises `ValueError`.
+  Migrate by using `add_explicit_schema_file` with `columnMappings`; see
+  [Data Commons custom data docs](https://docs.datacommons.org/custom_dc/custom_data.html).
 
 ## v0.1.0 (in development)
 - Initial release of the `bblocks-datacommons-tools` package for external preview and testing

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -1,45 +1,38 @@
 # Data Commons Schemas
 
-You can choose to structure your data for Data Commons using either an **implicit** or **explicit** schema, each
-serving different needs and levels of complexity.
+Data Commons uses the **explicit schema** to map your data to the knowledge graph. Each CSV file
+must include a column mapping that tells the importer which columns represent entities, time
+periods, and statistical variable values.
 
-## Implicit schema
+# Explicit schema
 
-The implicit schema is the simpler way of importing data into Data Commons. It
-does not require that you write MCF files, but it is more constraining on the structure of your data. 
-You don't need to specify details about the variables or specify entities in `DCID` format (they will be
-automatically resolved). Naming conventions are loose, and the Data Commons importer will automatically generate `DCIDs`
-for your variables based on the column names in your CSV files if they are not specified in the `config.json`.
+With the explicit schema your data must follow the variable-per-row format, where each row
+represents a single observation. Each CSV file is registered with a `columnMappings` block that
+describes the role of each column.
 
-Using the implicit schema is convenient for simple and small datasets when loading the data quickly is more important 
-than having a fully detailed schema.
+### Example explicit schema workflow
 
-### Example implicit schema workflow
+Here is a simple example of a workflow using the explicit schema.
 
-Here is a very simple example of a workflow using the implicit schema.
-
-Let's say we have some data on GDP for different countries that we want to import into Data Commons. We don't 
-have any other data in the knowledge graph (so we are starting from scratch). The data comes from the IMF World
-Economic Outlook, and we have already done the hard work of cleaning and formatting it as a pandas DataFrame:
+Let's say we have some data on GDP for different countries that we want to import into Data Commons.
+The data comes from the IMF World Economic Outlook, and we have already cleaned and formatted it:
 
 ```python
+import pandas as pd
+
 df = pd.DataFrame({
-    "Country": ["USA", "Canada", "Mexico"],
-    "Year": [2020, 2020, 2020],
-    "gdp": [21000000, 1700000, 1200000]
+    "country": ["USA", "Canada", "Mexico"],
+    "year": [2020, 2020, 2020],
+    "variable": ["Amount_EconomicActivity_GrossDomesticProduction_Nominal"] * 3,
+    "value": [21000000, 1700000, 1200000],
+    "unit": ["USDollar"] * 3,
 })
 ```
 
-This dataframe is structured for the implicit schema where there is a variable per columns - in this
-case `gdp` - and the other columns are used to specify the entity "Country" and the time period "Year". The entities
-and the time period don't need to be `DCIDs` or follow any convention, but the columns must always be specified in the
-sequence:
+This DataFrame uses the explicit (variable-per-row) format. The `columnMappings` block will tell
+the importer which columns map to entities, dates, variable DCIDs, and observation values.
 
-ENTITY, OBSERVATION_DATE, STATISTICAL_VARIABLE1, STATISTICAL_VARIABLE2, ...
-
-Now let's use the `CustomDataManager` to prepare the data for import into Data Commons:
-
-First we need to create a `CustomDataManager` instance:
+First, create a `CustomDataManager` instance:
 
 ```python
 from bblocks.datacommons_tools import CustomDataManager
@@ -47,66 +40,43 @@ from bblocks.datacommons_tools import CustomDataManager
 manager = CustomDataManager()
 ```
 
-This creates a new `CustomDataManager` instance with a blank `config.json` file.
-
-We are forward looking data engineers, so we know that our data will grow over time. So we might want to organise the
-files in subdirectories. Let's allow subdirectories in the `config.json` file:
+Add the source and provenance:
 
 ```python
-manager.set_includeInputSubdirs(True)
+manager.add_provenance(
+    provenance_name="World Economic Outlook (WEO)",
+    provenance_url="https://www.imf.org/en/Publications/WEO",
+    source_name="International Monetary Fund (IMF)",
+    source_url="https://www.imf.org/en/Home",
+)
 ```
 
-Next, let's add the source and the provenance of the data to the `config.json` file.
+Register the data file with its column mappings:
 
 ```python
-manager.add_provenance(provenance_name="World Economic Outlook (WEO)",
-                       provenance_url="https://www.imf.org/en/Publications/WEO",
-                       source_name="International Monetary Fund (IMF)",
-                       source_url="https://www.imf.org/en/Home"
-                       )
+from bblocks.datacommons_tools.custom_data.models.data_files import ColumnMappings
+
+manager.add_explicit_schema_file(
+    file_name="economy/gdp.csv",
+    provenance="World Economic Outlook (WEO)",
+    data=df,
+    columnMappings=ColumnMappings(
+        entityColumn="country",
+        observationDateColumn="year",
+        variableColumn="variable",
+        observationValueColumn="value",
+        observationProperties={"unit": "USDollar"},
+    ),
+)
 ```
 
-Now let's register the variable `gdp` in the `config.json` file. This is optional but recommended, as it allows you to
-add details about the variable. If this is not done, the Data Commons importer will automatically generate a 
-`DCID` for the variable based on the data file.
-
-```python
-manager.add_variable_to_config(statVar="gdp",
-                               name="Gross Domestic Product",
-                               description="Gross Domestic Product (GDP) is the total value of all goods and services produced in a country in a given year.",
-                               group="Economy",
-                               )
-```
-
-Now we can add the data and the data file to the manager object. This will update the `config.json` file with the
-data file information and keep track of the data in the `CustomDataManager` instance.
-
-```python
-manager.add_implicit_schema_file(file_name="ecomomy/gdp.csv",  # store the data in the gdp file in the ecomomy subdirectory
-                                 provenance="World Economic Outlook (WEO)", 
-                                 data=df, # pandas DataFrame with the GDP data
-                                 entityType="Country",
-                                 observationProperties={"unit": "USDollar"} # specify the unit of the variable
-                                 )
-```
-
-We have added the provenance and source, registered the variable, and added the data file with the GDP data. Now
-we are ready to export the files and import them into Data Commons.
+Export all files:
 
 ```python
 manager.export_all("output_directory")
 ```
 
-The `config.json` and the data file as a CSV file in the `economy` subdirectory will be created in 
-the `output_directory`.
+The `config.json` and the data CSV will be created in `output_directory`.
 
-Now you are ready to import your implicit schema data into Data Commons! Next, read about the explicit schema
-or jump to [loading the data into Data Commons](./loading-data.md).
-
-# Explicit schema
-
-[//]: # (<--- TODO: Add about explicit schema here --->)
-
-### Example explicit schema workflow
-
-[//]: # (<--- TODO: add explicit workflow --->)
+For more detail on the explicit schema format, see the
+[Data Commons custom data documentation](https://docs.datacommons.org/custom_dc/custom_data.html).

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -29,9 +29,8 @@ At a top level, you should be familiar with:
 [JSON configuration](https://docs.datacommons.org/custom_dc/custom_data.html#step-2-write-the-json-config-file) 
 file that specifies how to map and resolve data to the
 Data Commons schema knowledge graph.
-- **The data files**: CSV files containing the data formatted for a specified schema, either 
-[implicit](https://docs.datacommons.org/custom_dc/custom_data.html#prepare-your-data-using-implicit-schema) 
-or [explicit](https://docs.datacommons.org/custom_dc/custom_data.html#explicit).
+- **The data files**: CSV files containing the data formatted for the
+[explicit schema](https://docs.datacommons.org/custom_dc/custom_data.html#explicit).
 - **Meta Content Framework 
 ([MCF](https://docs.datacommons.org/custom_dc/custom_data.html#step-1-define-statistical-variables-in-mcf)) files**: files that provide additional flexibility form modeling data for the knowledge
 graph.
@@ -79,40 +78,27 @@ manager.add_provenance(
 )
 ```
 
-```python title="Register an indicator"
-manager.add_variable_to_config(
-    statVar="climateFinanceProvidedCommitments",
-    name="Climate Finance Commitments (bilateral)",
-    group="ONE/Environment/Climate finance/Provider perspective/Commitments",
-    description="Funding for climate adaptation and mitigation projects",
-    searchDescriptions=[
-        "Climate finance commitments provided",
-        "Adaptation and mitigation finance provided",
-    ],
-    properties={"measurementMethod": "Commitment"},
-    )
-```
+You can pass pandas DataFrames to the manager and the manager will handle exporting the data as
+CSVs in the correct format.
 
-You can pass pandas DataFrames to the manager, specifying what schema is being used, and the manager will handle 
-exporting the data as CSVs in the correct format.
-
-```python title="Add implicit schema data
+```python title="Add explicit schema data"
 import pandas as pd
+from bblocks.datacommons_tools.custom_data.models.data_files import ColumnMappings
 
 df = pd.DataFrame(...)
 
-manager.add_implicit_schema_file(
+manager.add_explicit_schema_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
     provenance="ONE Climate Finance",
-    entityType="Country",
     data=df,
-    ignoreColumns=["oecd_provider_code"],
-    observationProperties={"unit": "USDollar"},
+    columnMappings=ColumnMappings(
+        entity="country",
+        date="year",
+        variable="variable",
+        value="value",
+    ),
 )
 ```
-
-[//]: # (<--- TODO: Add explicit schema data example --->)
-```python title="Add explicit schema data"```
 
 
 Once you are finished adding and editing data and configuration, you can 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -58,39 +58,10 @@ Additional methods exist to manage sources and provenances:
 
 ## Managing variables
 
-The `CustomDataManager` lets you easily add variables to the `config.json` or MCF files based on whether you are
-using the implicit or explicit schema. Read more about implicit and explicit schemas
-[here](dc-schemas.md).
+The `CustomDataManager` lets you add variables to MCF files for the explicit schema. Read more
+about the explicit schema [here](dc-schemas.md).
 
-
-If you are using the implicit schema, you can specify details about the variables in the `config.json` file in the
-`variables` section. Adding a `variable` section to the `config.json` is optional, but recommended to specify 
-variable names and associate properties with the variables. For each variable you can specify:
-- `statVar`: The statistical variable ID
-- `name`: A human-friendly readable name 
-- `description`: A more detailed name or description
-- `searchDescriptions`: A comma-separated list of natural-language text descriptions
-of the variable used to generate embeddings for the NL query interface
-- `group`: The group the variable belongs to
-- `properties`: Any properties associated with the variable for example `Gender` - `Male`, `Female`, `Other` etc.
-
-```python
-manager.add_variable_to_config(statVar="ghed_che",
-                               name="Current health expenditure",
-                               description="The total expenditure on health from domestic and foreign sources",
-                               group="Health",
-                               searchDescriptions=["Total health spending", "Health financing"],
-                               properties={"measurementMethod": "WHOEstimate"}
-                               )
-```
-
-If the variable already exists, you can overwrite it by setting the `override` parameter to `True`.
-
-[//]: # (<--- TODO: Explicit schema adding variables --->)
-
-
-You can rename variables using the `rename_variable` method, optionally specifying the MCF file
-if you are using the explicit schema.
+You can rename variables using the `rename_variable` method, optionally specifying the MCF file.
 
 
 ```python
@@ -114,23 +85,30 @@ The `CustomDataManager` provides support for working with pandas DataFrames, all
 data stored in a DataFrame to the manager which will export the data to a CSV file in the correct format
 for Data Commons.
 
-To register a data file using the implicit schema, use the `add_implicit_schema_file` method:
+To register a data file, use the `add_explicit_schema_file` method:
 
 ```python
 import pandas as pd
+from bblocks.datacommons_tools.custom_data.models.data_files import ColumnMappings
 
 df = pd.DataFrame({
-    "Country": ["USA", "Canada", "Mexico"],
-    "Year": [2020, 2020, 2020],
-    "gdp": [21000000, 1700000, 1200000]
+    "country": ["USA", "Canada", "Mexico"],
+    "year": [2020, 2020, 2020],
+    "variable": ["Amount_EconomicActivity_GrossDomesticProduction_Nominal"] * 3,
+    "value": [21000000, 1700000, 1200000],
 })
 
-manager.add_implicit_schema_file(file_name="gdp.csv", 
-                                 provenance="IMF", 
-                                 data=df,
-                                 entityType="Country",
-                                 observationProperties={"unit": "USDollar"}
-                                 )
+manager.add_explicit_schema_file(
+    file_name="gdp.csv",
+    provenance="IMF",
+    data=df,
+    columnMappings=ColumnMappings(
+        entity="country",
+        date="year",
+        variable="variable",
+        value="value",
+    ),
+)
 ```
 
 Adding data when registering a data file is optional. You can also add the data later using the `add_data` method:
@@ -138,8 +116,6 @@ Adding data when registering a data file is optional. You can also add the data 
 ```python
 manager.add_data(data=df, file_name="gdp.csv")
 ```
-
-[//]: # (<--- TODO: add explicit schema data file registration here --->)
 
 ## Removing variables and data files
 
@@ -179,9 +155,16 @@ and keeping them structured. By default, this is not set and the Data Commons im
 to be in the main output directory. If this is set to `True`, You can specify the subdirectory when adding a data file:
 
 ```python
-manager.add_implicit_schema_file(file_name="economics/gdp.csv", 
-                                 ...  # other parameters as before
-                                 )
+manager.add_explicit_schema_file(
+    file_name="economics/gdp.csv",
+    provenance="IMF",
+    columnMappings=ColumnMappings(
+        entity="country",
+        date="year",
+        variable="variable",
+        value="value",
+    ),
+)
 ```
 
 You can also set the `groupStatVarsByProperty` field in the `config.json` file, 

--- a/src/bblocks/datacommons_tools/custom_data/config_utils.py
+++ b/src/bblocks/datacommons_tools/custom_data/config_utils.py
@@ -179,17 +179,6 @@ def merge_configs(
         context="Input file",
     )
 
-    # Merge the variables
-    if new.variables:
-        if not existing.variables:
-            existing.variables = {}
-        _merge_dict(
-            target_dict=existing.variables,
-            source_dict=new.variables,
-            policy=policy,
-            context="Variable",
-        )
-
     # Merge the sources
     for name, src in new.sources.items():
         _merge_source(

--- a/src/bblocks/datacommons_tools/custom_data/data_management.py
+++ b/src/bblocks/datacommons_tools/custom_data/data_management.py
@@ -16,8 +16,6 @@ from bblocks.datacommons_tools.custom_data.config_utils import (
 )
 from bblocks.datacommons_tools.custom_data.models.config_file import Config
 from bblocks.datacommons_tools.custom_data.models.data_files import (
-    ObservationProperties,
-    ImplicitSchemaFile,
     ColumnMappings,
     ExplicitSchemaFile,
     MCFFileName,
@@ -25,7 +23,6 @@ from bblocks.datacommons_tools.custom_data.models.data_files import (
 from bblocks.datacommons_tools.custom_data.models.mcf import MCFNodes
 from bblocks.datacommons_tools.custom_data.models.sources import Source
 from bblocks.datacommons_tools.custom_data.models.stat_vars import (
-    Variable,
     StatType,
     StatVarMCFNode,
     StatVarGroupMCFNode,
@@ -90,14 +87,6 @@ class CustomDataManager:
     >>>    source_name="Source Name"
     >>> )
 
-    To add a variable to the config (using the implicit schema), use the add_variable_to_implicit_schema method
-    >>> dc_manager.add_variable_to_config(
-    >>>    "StatVar",
-    >>>     name="Variable Name",
-    >>>     description="Variable Description",
-    >>>     group="Group Name"
-    >>>    )
-
     To add a variable for export to an MCF file (using the explicit schema), use the
     add_variable_to_mcf method
     >>> dc_manager.add_variable_to_mcf(
@@ -111,16 +100,6 @@ class CustomDataManager:
     contain the variables you want to add.
     >>> dc_manager.add_variables_to_mcf_from_csv(file_path="path/to/file.csv")
 
-    To add an input file and data to the config, using the implicit (per column) schema,
-    use the add_variablePerColumn_input_file method
-    >>> dc_manager.add_implicit_schema_file(
-    >>>    file_name="input_file.csv",
-    >>>    provenance="Provenance Name",
-    >>>    data=df,
-    >>>    entityType="Country",
-    >>>    observationProperties={"unit": "USDollar"}
-    >>>    )
-
     To add an input file and data to the config, using the explicit (per row) schema,
     use the add_variablePerRow_input_file method
     >>> dc_manager.add_explicit_schema_file(
@@ -132,8 +111,7 @@ class CustomDataManager:
 
     It isn't a requirement to add the data at the same time as the input file. You can add the data
     later using the add_data method. This is useful when you want to edit the config file
-    without needing the data. For example, for the variablePerColumn input file:
-    >>> dc_manager.add_implicit_schema_file(file_name="input_file.csv",provenance="Provenance Name")
+    without needing the data.
 
     To add data to the config, you can use the add_input_file and override the information already
     registered, or you can use the add_data method.
@@ -209,7 +187,7 @@ class CustomDataManager:
             [len(var) for var in [n.nodes for n in self._mcf_nodes.values()] if var]
         )
 
-        variables_count = len(self._config.variables or {}) + nodes_count
+        variables_count = nodes_count
         dataframes_count = len(self._data)
 
         include_input_subdirs = self._config.includeInputSubdirs
@@ -509,52 +487,6 @@ class CustomDataManager:
 
         return self
 
-    def add_variable_to_config(
-        self,
-        statVar: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        searchDescriptions: Optional[List[str]] = None,
-        group: Optional[str] = None,
-        properties: Optional[Dict[str, str]] = None,
-        override: bool = False,
-    ) -> CustomDataManager:
-        """Add a variable to the config. This only applies to the implicit schema.
-
-        This method registers a variable in the config. If there is no variables section
-        defined in the config, it will create one.
-
-        Args:
-            statVar: The identifier of the statistical variable. Used as the key in the config.
-            name: Name of the variable (Optional)
-            description: Description of the variable (Optional)
-            searchDescriptions: List of search descriptions (Optional)
-            group: Name of the group (Optional)
-            properties: Properties of the variable (Optional)
-            override: If True, overwrite the existing variable if it exists.
-                Defaults to False.
-        """
-
-        # check if the config has a variables section
-        if self._config.variables is None:
-            self._config.variables = {}
-
-        # check if the variable already exists
-        if statVar in self._config.variables:
-            if not override:
-                raise ValueError(
-                    f"Variable '{statVar}' already exists. Use override=True to overwrite it."
-                )
-
-        self._config.variables[statVar] = Variable(
-            name=name,
-            description=description,
-            searchDescriptions=searchDescriptions,
-            group=group,
-            properties=properties,
-        )
-        return self
-
     def _data_override_check(self, file_name: str, override: bool) -> None:
         """Check if the data already exists and override is not set"""
         if file_name in self._data:
@@ -563,59 +495,6 @@ class CustomDataManager:
                     f"Data for file '{file_name}' already exists. "
                     "Use a different name or set override as `True`."
                 )
-
-    def add_implicit_schema_file(
-        self,
-        file_name: str,
-        provenance: str,
-        entityType: str,
-        data: Optional[pd.DataFrame] = None,
-        observationProperties: Dict[str, str] = None,
-        ignoreColumns: Optional[List[str]] = None,
-        override: bool = False,
-    ) -> CustomDataManager:
-        f"""Add an inputFile to the config and optionally register the data as pandas DataFrame.
-
-        This method registers an input file in the config. Optionally it also registers the
-        data that accompanies the input file registered. The registration of the data is made
-        optional in cases where a user wants to edit the config file without the
-        accompanying data. The data can be registered later using the add data method.
-
-        This method is for the implicit schema approach (variable per column). Read more about
-        implicit and explicit schemas here:
-        {DC_DOCS_URL}#step-2-choose-between-implicit-and-explicit-schema-definition
-
-        Args:
-            file_name: Name of the file (should be a .csv file)
-            provenance: Provenance of the data. This should be the name of the provenance
-                in the sources section of the config file. Use add_provenance to add a provenance
-                to the config file.
-            data: Data to register (optional)
-            entityType: Type of the entity (optional)
-            observationProperties: Observation properties. Allowed keys
-                are [unit, observationPeriod, scalingFactor, measurementMethod]
-            ignoreColumns: List of columns to ignore (optional)
-            override: If True, overwrite the existing file if it exists. Defaults to False.
-        """
-        if observationProperties is None:
-            observationProperties = {}
-
-        # check if the file already exists
-        self._data_override_check(file_name=file_name, override=override)
-
-        # add the file to the config
-        self._config.inputFiles[file_name] = ImplicitSchemaFile(
-            entityType=entityType,
-            ignoreColumns=ignoreColumns,
-            provenance=provenance,
-            observationProperties=ObservationProperties(**observationProperties),
-        )
-
-        # if data is provided, register it
-        if data is not None:
-            self._data[file_name] = data
-
-        return self
 
     def add_explicit_schema_file(
         self,
@@ -634,8 +513,8 @@ class CustomDataManager:
         accompanying data. The data can be registered later using the add data method.
 
         This method is for the explicit schema approach (variable per row). Read more about
-        implicit and explicit schemas here:
-        {DC_DOCS_URL}#step-2-choose-between-implicit-and-explicit-schema-definition
+        the explicit (variable-per-row) schema format here:
+        {DC_DOCS_URL}
 
 
         Args:
@@ -701,7 +580,7 @@ class CustomDataManager:
     def rename_variable(
         self, old_name: str, new_name: str, *, mcf_file_name: str | None = None
     ) -> CustomDataManager:
-        """Rename a variable across config and any loaded MCF files.
+        """Rename a variable across any loaded MCF files.
 
         Args:
             old_name: The name of the variable to rename.
@@ -709,28 +588,33 @@ class CustomDataManager:
             mcf_file_name: Optional name of the MCF file from which to rename the variable.
                 If omitted, all managed MCF files are searched.
         Raises:
-            ValueError: If the variable is not found in the config or MCF files,
+            ValueError: If the variable is not found in any searched MCF file, or if the
+                new name already exists in any searched MCF file.
 
         """
 
-        if not self._config.variables or old_name not in self._config.variables:
+        file_names = (
+            [validate_mcf_file_name(mcf_file_name)]
+            if mcf_file_name
+            else list(self._mcf_nodes.keys())
+        )
+
+        found_old = any(
+            node.Node == old_name
+            for name in file_names
+            for node in (self._mcf_nodes.get(name) or MCFNodes()).nodes
+        )
+        found_new = any(
+            node.Node == new_name
+            for name in file_names
+            for node in (self._mcf_nodes.get(name) or MCFNodes()).nodes
+        )
+
+        if not found_old:
             raise ValueError(f"Variable '{old_name}' not found")
-        if new_name in (self._config.variables or {}):
+        if found_new:
             raise ValueError(f"Variable '{new_name}' already exists")
 
-        self._config.variables[new_name] = self._config.variables.pop(old_name)
-
-        file_names = (
-            [
-                (
-                    validate_mcf_file_name(mcf_file_name)
-                    if mcf_file_name is not None
-                    else None
-                )
-            ]
-            if mcf_file_name
-            else self._mcf_nodes.keys()
-        )
         for name in file_names:
             nodes = self._mcf_nodes.get(name)
             if not nodes:
@@ -773,11 +657,6 @@ class CustomDataManager:
             if info.provenance == old_name:
                 info.provenance = new_name
 
-        if self._config.variables:
-            for var in self._config.variables.values():
-                if var.properties and var.properties.get("provenance") == old_name:
-                    var.properties["provenance"] = new_name
-
         for nodes in self._mcf_nodes.values():
             for node in nodes.nodes:
                 prov = getattr(node, "provenance", None)
@@ -812,9 +691,9 @@ class CustomDataManager:
     ) -> CustomDataManager:
         """Remove a single indicator from the manager.
 
-        This deletes the indicator from the ``variables`` section of the config
-        and from any loaded MCF files. If ``mcf_file_name`` is provided, only
-        that MCF file is searched; otherwise all MCF files will be inspected.
+        This removes the indicator from any loaded MCF files. If
+        ``mcf_file_name`` is provided, only that MCF file is searched;
+        otherwise all MCF files will be inspected.
 
         Args:
             indicator_id: Identifier of the indicator/StatVar to remove.
@@ -822,16 +701,10 @@ class CustomDataManager:
                 node. If omitted, all managed MCF files are searched.
 
         Raises:
-            ValueError: If the indicator is not found in either the config or any
-                MCF file.
+            ValueError: If the indicator is not found in any MCF file.
         """
 
         found = False
-
-        # remove from config variables
-        if self._config.variables and indicator_id in self._config.variables:
-            del self._config.variables[indicator_id]
-            found = True
 
         # remove from mcf files
         file_names = (
@@ -875,13 +748,6 @@ class CustomDataManager:
             self._config.inputFiles.pop(file_name)
             self._data.pop(file_name, None)
             removed = True
-
-        # Remove variables that explicitly store the provenance in their properties
-        if self._config.variables:
-            for var_name, var in list(self._config.variables.items()):
-                if var.properties and var.properties.get("provenance") == provenance:
-                    del self._config.variables[var_name]
-                    removed = True
 
         # Remove MCF nodes with a matching provenance property
         for nodes in self._mcf_nodes.values():
@@ -1126,13 +992,12 @@ class CustomDataManager:
         """Merge all config files in a directory and its subdirectories
 
         This method will recursively search for config files in a directory and its
-        subdirectories (to a depth of?) and merge them with the config already in the manager.
+        subdirectories and merge them with the config already in the manager.
         If no config exists in the manager, it will be created from the merged config files.
 
         Args:
             directory: The directory to search for config files.
             policy: How to resolve collisions. Can be "error", "override", or "ignore".
-            How to resolve collisions. Can be "error", "override", or "ignore".
                 Defaults to "error". If "error", an error is raised if there are any
                 collisions. If "override", the new config will override the existing
                 config. If "ignore", the new config's value will be ignored if there are any

--- a/src/bblocks/datacommons_tools/custom_data/models/config_file.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/config_file.py
@@ -1,13 +1,9 @@
-from typing import Optional, Dict, Annotated
+from typing import Optional, Dict
 
-from pydantic import BaseModel, ConfigDict, model_validator, Field
+from pydantic import BaseModel, ConfigDict, model_validator
 
-from bblocks.datacommons_tools.custom_data.models.data_files import (
-    ImplicitSchemaFile,
-    ExplicitSchemaFile,
-)
+from bblocks.datacommons_tools.custom_data.models.data_files import ExplicitSchemaFile
 from bblocks.datacommons_tools.custom_data.models.sources import Source
-from bblocks.datacommons_tools.custom_data.models.stat_vars import Variable
 
 
 class Config(BaseModel):
@@ -25,7 +21,6 @@ class Config(BaseModel):
         inputFiles: Dictionary of input files.
         svHierarchyPropsBlocklist: Array of additional property dcids to exclude from hierarchy generation.
             These are added to the internal blocklist used by Data Commons.
-        variables: Dictionary of variables.
         sources: Dictionary of sources.
     """
 
@@ -35,23 +30,36 @@ class Config(BaseModel):
     customIdNamespace: Optional[str] = None
     customSvgPrefix: Optional[str] = None
     svHierarchyPropsBlocklist: Optional[list[str]] = None
-    inputFiles: Dict[
-        str,
-        Annotated[
-            ImplicitSchemaFile | ExplicitSchemaFile, Field(discriminator="data_format")
-        ],
-    ]
-    variables: Optional[Dict[str, Variable]] = None  # optional section
+    inputFiles: Dict[str, ExplicitSchemaFile]
     sources: Dict[str, Source]
 
-    # model configuration - to allow for extra fields and to populate by name
-    # (for the "format" field) and forbid extra fields
+    # model configuration - populate by name (for the "format" field alias)
+    # and forbid extra fields
     model_config = ConfigDict(
         populate_by_name=True,
         extra="forbid",
         str_strip_whitespace=True,
         validate_assignment=True,
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_implicit_schema_files(cls, data):
+        """Reject legacy implicit-schema (variablePerColumn) inputFiles with a clear error."""
+        if isinstance(data, dict):
+            for key, entry in (data.get("inputFiles") or {}).items():
+                if isinstance(entry, dict) and "variablePerColumn" in {
+                    entry.get("format"),
+                    entry.get("data_format"),
+                }:
+                    raise ValueError(
+                        f"Config contains implicit-schema file '{key}': "
+                        "format 'variablePerColumn' is no longer supported. "
+                        "Migrate to explicit schema before loading. See "
+                        "https://docs.datacommons.org/custom_dc/custom_data.html "
+                        "for the explicit-schema format."
+                    )
+        return data
 
     @model_validator(mode="after")
     def validate_input_file_keys_are_csv(self) -> "Config":

--- a/src/bblocks/datacommons_tools/custom_data/models/data_files.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/data_files.py
@@ -1,47 +1,14 @@
-from enum import StrEnum
 from typing import Optional, List, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, constr
-
-
-class FileType(StrEnum):
-    """Enumeration of the file types for the input files.
-
-    Attributes:
-        STAT_VAR_PER_COLUMN: Variable per column file type.
-        STAT_VAR_PER_ROW: Variable per row file type.
-    """
-
-    STAT_VAR_PER_COLUMN = "variablePerColumn"
-    STAT_VAR_PER_ROW = "variablePerRow"
 
 
 class MCFFileName(BaseModel):
     file_name: constr(strip_whitespace=True, pattern=r".*\.mcf$")
 
 
-class ObservationProperties(BaseModel):
-    """Representation of the ObservationProperties section of the InputFiles section of the config file
-    This is for the implicit schema only.
-
-    Attributes:
-        unit: Unit of the observation.
-        observationPeriod: Observation period of the data.
-        scalingFactor: Scaling factor for the data.
-        measurementMethod: Measurement method used for the data.
-    """
-
-    unit: Optional[str] = None
-    observationPeriod: Optional[str] = None
-    scalingFactor: Optional[str] = None
-    measurementMethod: Optional[str] = None
-
-    model_config = ConfigDict(extra="forbid")
-
-
 class ColumnMappings(BaseModel):
     """Representation of the ColumnMappings section of the InputFiles section of the config file
-    This is for explicit schema only
 
     Attributes:
         variable: Variable name.
@@ -66,62 +33,23 @@ class ColumnMappings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class InputFile(BaseModel):
-    """Representation of the InputFiles section of the config file
+class ExplicitSchemaFile(BaseModel):
+    """Representation of an input file using the explicit (variable-per-row) schema.
 
     Attributes:
         provenance: Provenance of the data.
         ignoreColumns: List of columns to ignore.
-    """
-
-    provenance: str
-    ignoreColumns: Optional[List[str]] = None
-    # Allow since inherited classes will have extra fields
-    model_config = ConfigDict(extra="allow")
-    data_format: FileType = Field(..., alias="format")
-
-
-class ImplicitSchemaFile(InputFile):
-    """Representation of the ColumnFile section of the config file
-    This is what is known as the implicit schema.
-
-    Attributes:
-        entityType: Type of the entity (e.g., Country, State).
-        observationProperties: Properties of the observation.
-        # Inherited from InputFile
-        provenance: Provenance of the data.
-        ignoreColumns: List of columns to ignore.
-        # Automatically set
-        data_format: Format of the data (variable per column).
-            This attribute is represented as "format" in the JSON.
-
-    """
-
-    entityType: str
-    observationProperties: ObservationProperties
-    data_format: Literal["variablePerColumn"] = Field(
-        default="variablePerColumn", alias="format"
-    )
-
-
-class ExplicitSchemaFile(InputFile):
-    """Representation of the RowFile section of the config file
-    This is what is known as the explicit schema.
-
-    Attributes:
-
-        columnMappings:  If headings in the CSV file does not use the default names,
-             the equivalent names for each column. (explicit schema only).
-
-        # Inherited from InputFile
-        provenance: Provenance of the data.
-        ignoreColumns: List of columns to ignore.
-        # Automatically set
+        columnMappings: If headings in the CSV file do not use the default names,
+            the equivalent names for each column.
         data_format: Format of the data (variable per row).
             This attribute is represented as "format" in the JSON.
     """
 
+    provenance: str
+    ignoreColumns: Optional[List[str]] = None
     columnMappings: ColumnMappings
     data_format: Literal["variablePerRow"] = Field(
         default="variablePerRow", alias="format"
     )
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)

--- a/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
+++ b/src/bblocks/datacommons_tools/custom_data/models/stat_vars.py
@@ -1,12 +1,9 @@
 from enum import StrEnum
-from typing import Optional, List, Dict, Literal
-
-from pydantic import BaseModel, ConfigDict
+from typing import Optional, Literal
 
 
 from bblocks.datacommons_tools.custom_data.models.common import (
     QuotedStrListOrStr,
-    StrOrListStr,
     Dcid,
     GroupDcid,
     PeerGroupDcid,
@@ -29,27 +26,6 @@ class StatType(StrEnum):
     VARIANCE_VALUE = "dcid:varianceValue"
     MARGIN_OF_ERROR = "dcid:marginOfError"
     STANDARD_ERROR = "dcid:stdErr"
-
-
-class Variable(BaseModel):
-    """Representation of the Variables section of the config file
-    This section is optional in the config file
-
-    Attributes:
-        name: Name of the variable.
-        description: Description of the variable.
-        searchDescriptions: List of search descriptions for the variable.
-        group: Group to which the variable belongs.
-        properties: Properties of the variable.
-    """
-
-    name: Optional[str] = None
-    description: Optional[str] = None
-    searchDescriptions: Optional[List[str]] = None
-    group: Optional[StrOrListStr] = None
-    properties: Optional[Dict[str, str]] = None
-
-    model_config = ConfigDict(extra="forbid")
 
 
 class StatVarMCFNode(MCFNode):

--- a/tests/goldens/config.json
+++ b/tests/goldens/config.json
@@ -4,23 +4,30 @@
     "inputFiles": {
         "a.csv": {
             "provenance": "provA",
-            "entityType": "Country",
-            "observationProperties": { "unit": "USDollar" },
-            "format": "variablePerColumn"
+            "columnMappings": {
+                "entity": "Country",
+                "date": "Year",
+                "value": "Val"
+            },
+            "format": "variablePerRow"
         },
         "b.csv": {
             "provenance": "provB",
-            "columnMappings": { "entity": "Country", "date": "Year", "value": "Val" },
+            "columnMappings": {
+                "entity": "Country",
+                "date": "Year",
+                "value": "Val"
+            },
             "format": "variablePerRow"
         }
-    },
-    "variables": {
-        "v1": { "name": "Var One" }
     },
     "sources": {
         "S1": {
             "url": "http://source1/",
-            "provenances": { "provA": "http://prova/", "provB": "http://provb/" }
+            "provenances": {
+                "provA": "http://prova/",
+                "provB": "http://provb/"
+            }
         }
     }
 }

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -1,3 +1,7 @@
+import json
+import tempfile
+import os
+
 import pandas as pd
 import pytest
 
@@ -5,8 +9,8 @@ from bblocks.datacommons_tools import CustomDataManager
 from bblocks.datacommons_tools.custom_data.data_management import DEFAULT_GROUP_NAME
 from bblocks.datacommons_tools.custom_data.models.config_file import Config
 from bblocks.datacommons_tools.custom_data.models.data_files import (
-    ImplicitSchemaFile,
-    ObservationProperties,
+    ColumnMappings,
+    ExplicitSchemaFile,
 )
 from bblocks.datacommons_tools.custom_data.models.sources import Source
 
@@ -16,12 +20,10 @@ def test_custom_data_manager_add_provenance_and_override():
     Verifies provenance addition logic in CustomDataManager.
     """
     manager = CustomDataManager()
-    # Missing source_url should fail
     with pytest.raises(ValueError):
         manager.add_provenance(
             provenance_name="pA", provenance_url="http://prov", source_name="new_source"
         )
-    # Provide source_url to succeed
     manager.add_provenance(
         provenance_name="pA",
         provenance_url="http://prov",
@@ -29,7 +31,6 @@ def test_custom_data_manager_add_provenance_and_override():
         source_url="http://src",
     )
 
-    # Adding same provenance without override should error
     with pytest.raises(ValueError):
         manager.add_provenance(
             provenance_name="pA",
@@ -37,30 +38,14 @@ def test_custom_data_manager_add_provenance_and_override():
             source_name="new_source",
         )
 
-    # Override existing provenance URL
     manager.add_provenance(
         provenance_name="pA",
         provenance_url="http://prov2",
         source_name="new_source",
         override=True,
     )
-    # Confirm update
     src = manager._config.sources["new_source"]
     assert src.provenances["pA"].unicode_string() == "http://prov2/"
-
-
-def test_custom_data_manager_add_variable_to_config_and_override():
-    """
-    Ensures variables are registered and override works in config.
-    """
-    manager = CustomDataManager()
-    manager.add_variable_to_config(statVar="v1", name="Var1")
-    # Duplicate without override errors
-    with pytest.raises(ValueError):
-        manager.add_variable_to_config(statVar="v1", name="Var1New")
-    # Override succeeds
-    manager.add_variable_to_config(statVar="v1", name="Var1New", override=True)
-    assert manager._config.variables["v1"].name == "Var1New"
 
 
 def test_set_additional_config_fields():
@@ -89,39 +74,13 @@ def test_set_additional_config_fields():
     ]
 
 
-def test_add_implicit_and_explicit_schema_file_registration_and_override(tmp_path):
+def test_add_explicit_schema_file_registration_and_override(tmp_path):
     """
-    Verifies implicit/explicit schema file registration in config and data,
+    Verifies explicit schema file registration in config and data,
     and override/error behaviors.
     """
     manager = CustomDataManager()
     manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
-
-    df1 = pd.DataFrame({"A": [1, 2]})
-    manager.add_implicit_schema_file(
-        file_name="imp.csv",
-        provenance="p1",
-        data=df1,
-        entityType="Country",
-        observationProperties={"unit": "U"},
-    )
-    assert "imp.csv" in manager._config.inputFiles
-    assert "imp.csv" in manager._data
-
-    df2 = pd.DataFrame({"A": [3, 4]})
-    with pytest.raises(ValueError):
-        manager.add_implicit_schema_file(
-            "imp.csv", provenance="p1", entityType="Country"
-        )
-
-    manager.add_implicit_schema_file(
-        file_name="imp.csv",
-        provenance="p1",
-        data=df2,
-        override=True,
-        entityType="State",
-    )
-    pd.testing.assert_frame_equal(manager._data["imp.csv"], df2)
 
     df3 = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
     manager.add_explicit_schema_file(
@@ -132,6 +91,21 @@ def test_add_implicit_and_explicit_schema_file_registration_and_override(tmp_pat
     )
     assert "exp.csv" in manager._config.inputFiles
     assert "exp.csv" in manager._data
+
+    with pytest.raises(ValueError):
+        manager.add_explicit_schema_file(
+            file_name="exp.csv",
+            provenance="p1",
+        )
+
+    df_new = pd.DataFrame({"entity": ["e2"], "Year": [2021], "Value": [200]})
+    manager.add_explicit_schema_file(
+        file_name="exp.csv",
+        provenance="p1",
+        data=df_new,
+        override=True,
+    )
+    pd.testing.assert_frame_equal(manager._data["exp.csv"], df_new)
 
     df4 = pd.DataFrame({"X": [1]})
     with pytest.raises(ValueError):
@@ -158,12 +132,11 @@ def test_export_methods(tmp_path):
     manager = CustomDataManager()
     manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
     df = pd.DataFrame({"A": [1]})
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="data.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
-        observationProperties={"unit": "U"},
+        columnMappings={"entity": "A"},
     )
     manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
 
@@ -224,21 +197,19 @@ def test_custom_data_manager_repr():
     """
     manager = CustomDataManager()
     manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
-    manager.add_variable_to_config(statVar="dcid:v1", name="Var1")
     df = pd.DataFrame({"A": [1]})
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="f.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
-        observationProperties={"unit": "u"},
+        columnMappings={"entity": "A"},
     )
     manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
     r = repr(manager)
     assert "1 inputFiles" in r
     assert "1 containing data" in r
     assert "1 sources" in r
-    assert "2 variables" in r
+    assert "1 variables" in r
 
 
 def test_remove_indicator_and_provenance():
@@ -246,18 +217,15 @@ def test_remove_indicator_and_provenance():
     manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
 
     df = pd.DataFrame({"A": [1]})
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="a.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
-        observationProperties={"unit": "u"},
+        columnMappings={"entity": "A"},
     )
-    manager.add_variable_to_config(statVar="dcid:sv1", name="Var")
     manager.add_variable_to_mcf(Node="dcid:sv1", name="Var", provenance="p1")
 
     manager.remove_indicator("dcid:sv1")
-    assert "dcid:sv1" not in (manager._config.variables or {})
     for nodes in manager._mcf_nodes.values():
         assert all(n.Node != "dcid:sv1" for n in nodes.nodes)
 
@@ -265,7 +233,6 @@ def test_remove_indicator_and_provenance():
         manager.remove_indicator("missing")
 
     manager.add_variable_to_mcf(Node="dcid:sv2", name="Var2", provenance="p1")
-    manager.add_variable_to_config(statVar="dcid:sv2", name="Var2")
     manager.add_explicit_schema_file(file_name="b.csv", provenance="p1", data=df)
 
     manager.remove_by_provenance("p1")
@@ -287,12 +254,11 @@ def test_remove_provenance_and_source_methods():
     manager.add_provenance("p2", "http://prov2", "s1")
 
     df = pd.DataFrame({"A": [1]})
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="a.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
-        observationProperties={"unit": "u"},
+        columnMappings={"entity": "A"},
     )
     manager.add_explicit_schema_file(file_name="b.csv", provenance="p2", data=df)
 
@@ -313,12 +279,11 @@ def test_remove_provenance_and_source_methods():
     # remove_source works on a fresh manager
     manager2 = CustomDataManager()
     manager2.add_provenance("p1", "http://prov", "s1", source_url="http://src")
-    manager2.add_implicit_schema_file(
+    manager2.add_explicit_schema_file(
         file_name="c.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
-        observationProperties={"unit": "u"},
+        columnMappings={"entity": "A"},
     )
 
     manager2.remove_source("s1")
@@ -340,10 +305,9 @@ def _make_cfg(
     sv_blocklist: list[str] | None = None,
 ):
     input_files = {
-        key: ImplicitSchemaFile(
+        key: ExplicitSchemaFile(
             provenance=prov,
-            entityType="Country",
-            observationProperties=ObservationProperties(),
+            columnMappings=ColumnMappings(),
         )
     }
     sources = {source: Source(url="http://src", provenances={prov: "http://p"})}
@@ -446,15 +410,11 @@ def test_rename_provenance_updates_all_references():
     manager.add_provenance("p1", "http://prov1", "s1", source_url="http://src")
 
     df = pd.DataFrame({"A": [1]})
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="a.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
-        observationProperties={"unit": "u"},
-    )
-    manager.add_variable_to_config(
-        "dcid:sv1", name="Var", properties={"provenance": "p1"}
+        columnMappings={"entity": "A"},
     )
     manager.add_variable_to_mcf(Node="dcid:sv1", name="Var", provenance="p1")
 
@@ -462,7 +422,6 @@ def test_rename_provenance_updates_all_references():
 
     assert "pX" in manager._config.sources["s1"].provenances
     assert manager._config.inputFiles["a.csv"].provenance == "pX"
-    assert manager._config.variables["dcid:sv1"].properties["provenance"] == "pX"
     for nodes in manager._mcf_nodes.values():
         assert any(getattr(n, "provenance", None) == '"pX"' for n in nodes.nodes)
 
@@ -470,22 +429,31 @@ def test_rename_provenance_updates_all_references():
         manager.rename_provenance("pX", "pX")
 
 
-def test_rename_variable_and_source_methods():
+def test_rename_variable_mcf_only():
+    """rename_variable operates on MCF nodes exclusively (no config.variables)."""
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov1", "s1", source_url="http://src")
-    manager.add_variable_to_config("dcid:v1", name="Var1")
     manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
 
     manager.rename_variable("dcid:v1", "dcid:v2")
-    assert "dcid:v2" in manager._config.variables
     for nodes in manager._mcf_nodes.values():
         assert any(n.Node == "dcid:v2" for n in nodes.nodes)
+    for nodes in manager._mcf_nodes.values():
+        assert all(n.Node != "dcid:v1" for n in nodes.nodes)
 
-    manager.add_variable_to_config("dcid:v3", name="Var3")
+    # Renaming a missing variable raises ValueError
+    with pytest.raises(ValueError):
+        manager.rename_variable("missing", "dcid:v3")
+
+    # Renaming to an existing MCF node name raises ValueError
+    manager.add_variable_to_mcf(Node="dcid:v3", name="Var3")
     with pytest.raises(ValueError):
         manager.rename_variable("dcid:v2", "dcid:v3")
-    with pytest.raises(ValueError):
-        manager.rename_variable("missing", "dcid:v4")
+
+
+def test_rename_source():
+    """rename_source correctly updates the config sources dict."""
+    manager = CustomDataManager()
+    manager.add_provenance("p1", "http://prov1", "s1", source_url="http://src")
 
     manager.rename_source("s1", "s2")
     assert "s2" in manager._config.sources and "s1" not in manager._config.sources
@@ -504,16 +472,14 @@ def test_validate_all_input_files_have_data(tmp_path):
     df = pd.DataFrame({"A": [1, 2]})
 
     # Register one file WITH data and one WITHOUT data
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="with_data.csv",
         provenance="p1",
         data=df,
-        entityType="Country",
     )
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         file_name="no_data.csv",
         provenance="p1",
-        entityType="Country",
     )
 
     # Standalone validation method raises because no_data.csv has no data
@@ -542,3 +508,25 @@ def test_validate_all_input_files_have_data(tmp_path):
     assert (tmp_path / "config.json").exists()
     assert (tmp_path / "with_data.csv").exists()
     assert (tmp_path / "no_data.csv").exists()
+
+
+def test_loading_legacy_implicit_config_raises_with_message():
+    """Loading a JSON config with variablePerColumn format raises ValueError with a clear message."""
+    cfg = {
+        "inputFiles": {
+            "legacy.csv": {
+                "provenance": "p",
+                "entityType": "Country",
+                "observationProperties": {},
+                "format": "variablePerColumn",
+            }
+        },
+        "sources": {"S": {"url": "http://s/", "provenances": {"p": "http://p/"}}},
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "config.json")
+        with open(path, "w") as f:
+            json.dump(cfg, f)
+        with pytest.raises(ValueError, match="is no longer supported") as exc_info:
+            Config.from_json(path)
+        assert "legacy.csv" in str(exc_info.value)

--- a/tests/test_explicit_path_characterization.py
+++ b/tests/test_explicit_path_characterization.py
@@ -1,0 +1,330 @@
+"""Characterization tests for the explicit-schema path.
+
+These tests pin the CURRENT observable behavior of the explicit-schema path
+using explicit-schema fixtures only (ExplicitSchemaFile / add_explicit_schema_file
+/ ColumnMappings). They must pass against current HEAD and remain green after the
+implicit-schema path is removed (since they never reference ImplicitSchemaFile,
+ObservationProperties, Variable, or add_variable_to_config).
+"""
+
+import pandas as pd
+import pytest
+from unittest.mock import Mock
+
+from bblocks.datacommons_tools import CustomDataManager
+from bblocks.datacommons_tools.custom_data.models.config_file import Config
+from bblocks.datacommons_tools.custom_data.models.data_files import (
+    ExplicitSchemaFile,
+    ColumnMappings,
+)
+from bblocks.datacommons_tools.custom_data.models.sources import Source
+from bblocks.datacommons_tools.gcp_utilities.storage import (
+    get_unregistered_csv_files,
+    get_missing_csv_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _explicit_manager(file_name="exp.csv", *, with_data=True):
+    """Manager with one source + one explicit-schema file (optionally with data)."""
+    mgr = CustomDataManager()
+    mgr.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    df = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
+    mgr.add_explicit_schema_file(
+        file_name=file_name,
+        provenance="p1",
+        data=df if with_data else None,
+        columnMappings={"entity": "entity", "date": "Year", "value": "Value"},
+    )
+    return mgr, df
+
+
+def _make_explicit_cfg(
+    key: str,
+    prov: str,
+    source: str,
+    *,
+    include_subdirs=None,
+    custom_namespace=None,
+    custom_svg_prefix=None,
+    sv_blocklist=None,
+):
+    """Build a minimal Config with one ExplicitSchemaFile."""
+    input_files = {
+        key: ExplicitSchemaFile(
+            provenance=prov,
+            columnMappings=ColumnMappings(entity="Country", date="Year", value="Val"),
+        )
+    }
+    sources = {source: Source(url="http://src", provenances={prov: "http://p"})}
+    return Config(
+        inputFiles=input_files,
+        sources=sources,
+        includeInputSubdirs=include_subdirs,
+        customIdNamespace=custom_namespace,
+        customSvgPrefix=custom_svg_prefix,
+        svHierarchyPropsBlocklist=sv_blocklist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slice 1: Manager-path characterization (B1, B5, B6, B8)
+# ---------------------------------------------------------------------------
+
+
+def test_add_explicit_schema_file_registers_in_config_and_data():
+    """B1 — add_explicit_schema_file registers file in config and data store."""
+    manager, df = _explicit_manager()
+
+    assert "exp.csv" in manager._config.inputFiles
+    entry = manager._config.inputFiles["exp.csv"]
+    assert isinstance(entry, ExplicitSchemaFile)
+    assert entry.provenance == "p1"
+    assert entry.columnMappings.entity == "entity"
+    assert entry.columnMappings.date == "Year"
+    assert entry.columnMappings.value == "Value"
+    assert entry.data_format == "variablePerRow"
+
+    assert "exp.csv" in manager._data
+    pd.testing.assert_frame_equal(manager._data["exp.csv"], df)
+
+
+def test_add_explicit_schema_file_override_and_duplicate_error():
+    """B1 — re-adding the same file_name without override raises ValueError;
+    with override=True the data is replaced."""
+    manager, _ = _explicit_manager()
+
+    df_new = pd.DataFrame({"entity": ["e2"], "Year": [2021], "Value": [200]})
+
+    # Duplicate without override must raise
+    with pytest.raises(ValueError):
+        manager.add_explicit_schema_file("exp.csv", provenance="p1")
+
+    # Override succeeds and replaces stored data
+    manager.add_explicit_schema_file(
+        file_name="exp.csv",
+        provenance="p1",
+        data=df_new,
+        columnMappings={"entity": "entity", "date": "Year", "value": "Value"},
+        override=True,
+    )
+    pd.testing.assert_frame_equal(manager._data["exp.csv"], df_new)
+
+
+def test_add_data_standalone_success_and_error():
+    """B6 — standalone add_data: success path, duplicate error, override, unregistered error."""
+    manager, _ = _explicit_manager(with_data=False)
+
+    # Data was not supplied at registration time
+    assert "exp.csv" not in manager._data
+
+    df = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
+
+    # First add_data call succeeds
+    manager.add_data(df, "exp.csv")
+    pd.testing.assert_frame_equal(manager._data["exp.csv"], df)
+
+    # Second call without override raises
+    with pytest.raises(ValueError):
+        manager.add_data(df, "exp.csv")
+
+    # Override succeeds
+    df2 = pd.DataFrame({"entity": ["e2"], "Year": [2021], "Value": [200]})
+    manager.add_data(df2, "exp.csv", override=True)
+    pd.testing.assert_frame_equal(manager._data["exp.csv"], df2)
+
+    # Unregistered file raises
+    with pytest.raises(ValueError):
+        manager.add_data(df, "unregistered.csv")
+
+
+def test_export_config_round_trip_explicit(tmp_path):
+    """B5 — export_config writes config.json; Config.from_json reloads it correctly."""
+    manager, _ = _explicit_manager()
+
+    manager.export_config(tmp_path)
+
+    config_file = tmp_path / "config.json"
+    assert config_file.exists()
+
+    loaded = Config.from_json(str(config_file))
+    assert isinstance(loaded, Config)
+
+    mappings = loaded.inputFiles["exp.csv"].columnMappings
+    assert mappings.model_dump(exclude_none=True) == {
+        "entity": "entity",
+        "date": "Year",
+        "value": "Value",
+    }
+    assert loaded.inputFiles["exp.csv"].data_format == "variablePerRow"
+
+
+def test_config_to_dict_explicit_shape():
+    """B5 — config_to_dict returns the expected serialized shape for the explicit path.
+
+    Pins the key names and values as observed on current HEAD. The key for the
+    format is 'data_format' (not the alias 'format') in config_to_dict output.
+    """
+    manager, _ = _explicit_manager()
+
+    d = manager.config_to_dict()
+    entry = d["inputFiles"]["exp.csv"]
+
+    expected = {
+        "provenance": "p1",
+        "data_format": "variablePerRow",
+        "columnMappings": {
+            "entity": "entity",
+            "date": "Year",
+            "value": "Value",
+        },
+    }
+    assert entry == expected
+
+
+def test_export_mcf_file_explicit_path(tmp_path):
+    """B8 (light pin) — variable added via add_variable_to_mcf appears in exported MCF."""
+    manager, _ = _explicit_manager()
+    manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
+
+    manager.export_mfc_file(tmp_path, mcf_file_name="custom_nodes.mcf")
+
+    mcf_file = tmp_path / "custom_nodes.mcf"
+    assert mcf_file.exists()
+    assert "Node: dcid:vX" in mcf_file.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Slice 2: Model- and util-path characterization (B2, B7, B9)
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_schema_file_default_format():
+    """B2 — ExplicitSchemaFile defaults data_format to 'variablePerRow';
+    by_alias serialization uses key 'format'."""
+    ef = ExplicitSchemaFile(provenance="p", columnMappings=ColumnMappings())
+
+    assert ef.data_format == "variablePerRow"
+    assert ef.model_dump(by_alias=True)["format"] == "variablePerRow"
+
+
+def test_config_build_and_from_json_round_trip_explicit(tmp_path):
+    """B2 — an explicit-only Config survives a serialize → deserialize cycle."""
+    cfg = Config(
+        inputFiles={
+            "a.csv": ExplicitSchemaFile(
+                provenance="p",
+                columnMappings=ColumnMappings(
+                    entity="Country", date="Year", value="Val"
+                ),
+            )
+        },
+        sources={"s": Source(url="http://s", provenances={"p": "http://p"})},
+    )
+
+    path = tmp_path / "cfg.json"
+    path.write_text(cfg.model_dump_json())
+
+    loaded = Config.from_json(str(path))
+    assert loaded.model_dump() == cfg.model_dump()
+
+
+def test_merge_configs_from_directory_explicit(tmp_path):
+    """B7 — from_config_files_in_directory merges two explicit-only configs correctly."""
+    d1 = tmp_path / "one"
+    d1.mkdir()
+    cfg1 = _make_explicit_cfg(
+        "a.csv",
+        "p1",
+        "s",
+        custom_namespace="ns",
+        sv_blocklist=["measurementDenominator"],
+    )
+    (d1 / "config.json").write_text(
+        cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    d2 = tmp_path / "two"
+    d2.mkdir()
+    cfg2 = _make_explicit_cfg(
+        "b.csv",
+        "p2",
+        "s",
+        custom_svg_prefix="ns/custom/",
+    )
+    (d2 / "config.json").write_text(
+        cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    manager = CustomDataManager.from_config_files_in_directory(tmp_path)
+
+    assert set(manager._config.inputFiles.keys()) == {"a.csv", "b.csv"}
+    provs = manager._config.sources["s"].provenances
+    assert set(provs.keys()) == {"p1", "p2"}
+
+
+def test_merge_configs_from_directory_explicit_duplicate_error(tmp_path):
+    """B7 — from_config_files_in_directory raises ValueError on duplicate keys."""
+    d1 = tmp_path / "one"
+    d1.mkdir()
+    cfg1 = _make_explicit_cfg("a.csv", "p1", "s")
+    (d1 / "config.json").write_text(
+        cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    d2 = tmp_path / "two"
+    d2.mkdir()
+    cfg2 = _make_explicit_cfg("a.csv", "p2", "s")
+    (d2 / "config.json").write_text(
+        cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    with pytest.raises(ValueError):
+        CustomDataManager.from_config_files_in_directory(tmp_path)
+
+
+def test_get_unregistered_and_missing_csv_files_explicit():
+    """B9 — get_unregistered_csv_files and get_missing_csv_files work with
+    an explicit-only Config (depend only on inputFiles.keys(), schema-agnostic)."""
+    cfg = Config(
+        inputFiles={
+            "a.csv": ExplicitSchemaFile(
+                provenance="p",
+                columnMappings=ColumnMappings(
+                    entity="Country", date="Year", value="Val"
+                ),
+            )
+        },
+        sources={"s": Source(url="http://src", provenances={"p": "http://p"})},
+    )
+
+    # --- get_unregistered_csv_files ---
+    bucket = Mock()
+    blob_a = Mock()
+    blob_a.name = "folder/a.csv"
+    blob_extra = Mock()
+    blob_extra.name = "folder/extra.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_extra]
+    bucket.name = "my-bucket"
+
+    unregistered = get_unregistered_csv_files(bucket, cfg, "folder")
+    assert unregistered == ["extra.csv"]
+
+    # --- get_missing_csv_files ---
+    cfg.inputFiles["extra.csv"] = ExplicitSchemaFile(
+        provenance="p",
+        columnMappings=ColumnMappings(entity="Country", date="Year", value="Val"),
+    )
+
+    bucket2 = Mock()
+    blob_a2 = Mock()
+    blob_a2.name = "folder/a.csv"
+    bucket2.list_blobs.return_value = [blob_a2]
+    bucket2.name = "my-bucket"
+
+    missing = get_missing_csv_files(bucket2, cfg, "folder")
+    assert missing == ["extra.csv"]

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -29,21 +29,19 @@ def test_config_json_snapshot(tmp_path):
     manager = CustomDataManager()
     manager.set_includeInputSubdirs(True).set_groupStatVarsByProperty(False)
 
-    manager.add_implicit_schema_file(
+    manager.add_explicit_schema_file(
         "a.csv",
         provenance="provA",
-        observationProperties={"unit": "USDollar"},
-        entityType="Country",
+        columnMappings={"entity": "Country", "date": "Year", "value": "Val"},
     )
     manager.add_explicit_schema_file(
         "b.csv",
         provenance="provB",
         columnMappings={"entity": "Country", "date": "Year", "value": "Val"},
     )
-    # add variable and source
+    # add sources
     manager.add_provenance("provA", "http://prova/", "S1", source_url="http://source1/")
     manager.add_provenance("provB", "http://provb/", "S1", source_url="http://source1/")
-    manager.add_variable_to_config("v1", name="Var One")
 
     # export
     manager.export_config(str(tmp_path))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -15,18 +15,17 @@ from bblocks.datacommons_tools.gcp_utilities.storage import (
 )
 from bblocks.datacommons_tools.custom_data.models.config_file import Config
 from bblocks.datacommons_tools.custom_data.models.data_files import (
-    ImplicitSchemaFile,
-    ObservationProperties,
+    ColumnMappings,
+    ExplicitSchemaFile,
 )
 from bblocks.datacommons_tools.custom_data.models.sources import Source
 
 
 def _minimal_config(key: str = "a.csv") -> Config:
     input_files = {
-        key: ImplicitSchemaFile(
+        key: ExplicitSchemaFile(
             provenance="prov",
-            entityType="Country",
-            observationProperties=ObservationProperties(),
+            columnMappings=ColumnMappings(),
         )
     }
     sources = {"src": Source(url="http://s", provenances={"prov": "http://p"})}
@@ -263,10 +262,9 @@ def test_get_missing_csv_files():
     bucket.list_blobs.return_value = [blob_a]
 
     cfg = _minimal_config()
-    cfg.inputFiles["extra.csv"] = ImplicitSchemaFile(
+    cfg.inputFiles["extra.csv"] = ExplicitSchemaFile(
         provenance="prov",
-        entityType="Country",
-        observationProperties=ObservationProperties(),
+        columnMappings=ColumnMappings(),
     )
 
     missing = get_missing_csv_files(bucket, cfg, "folder")
@@ -281,10 +279,9 @@ def test_get_missing_csv_files_with_prefix_added():
     bucket.list_blobs.return_value = [blob_a]
 
     cfg = _minimal_config("sub/a.csv")
-    cfg.inputFiles["sub/b.csv"] = ImplicitSchemaFile(
+    cfg.inputFiles["sub/b.csv"] = ExplicitSchemaFile(
         provenance="prov",
-        entityType="Country",
-        observationProperties=ObservationProperties(),
+        columnMappings=ColumnMappings(),
     )
 
     missing = get_missing_csv_files(bucket, cfg, "prefix")


### PR DESCRIPTION
## Summary

Data Commons has deprecated the implicit / variable-per-column (schemaless) import path. This PR removes it in full and collapses the scaffolding it required, leaving the explicit-schema path as the single supported route.

## What changed

**Removed**
- `CustomDataManager.add_implicit_schema_file` and `add_variable_to_config`
- `ImplicitSchemaFile`, `ObservationProperties`, the `Variable` config model, the `FileType` enum, and the `InputFile` base class
- the config-level `variables` section and its merge / rename / remove branches

**Changed**
- `ExplicitSchemaFile` is now a standalone model with `extra="forbid"` (previously inherited `extra="allow"`)
- `Config.inputFiles` collapses from a discriminated union to `Dict[str, ExplicitSchemaFile]`
- loading a legacy `variablePerColumn` config now raises a clear `ValueError` with a migration pointer instead of a cryptic `ValidationError`
- `rename_variable` now operates purely on MCF nodes

**Docs**
- `dc-schemas.md`, `preparing-data.md`, `getting-started.md` pruned of implicit references
- `CHANGELOG.md` (`[Unreleased]`) and `docs/docs/changelog.md` document the removal + migration guidance

## Behaviour preservation

Added `tests/test_explicit_path_characterization.py` (11 tests) pinning the current explicit-path behaviour. It was written before the removal and kept green and untouched throughout, as the proof the explicit path is preserved.

- Full suite: **88 passed**
- Characterization gate: **11/11**, untouched
- `ruff check`: clean

## ⚠️ Breaking change

The implicit-schema public API is removed. Configs using `format: variablePerColumn` must migrate to the explicit schema (`add_explicit_schema_file` with `columnMappings`); loading such a config now fails fast with a clear error.

## Follow-ups (out of scope here)
- The now-vestigial "explicit" qualifier on `ExplicitSchemaFile` / `add_explicit_schema_file` could be dropped in a later cleanup.
- A custom `ImplicitSchemaRemovedError(ValueError)` could let migration tooling catch the load-time failure precisely.
- Pre-existing class-docstring staleness (`add_variablePerRow_input_file` / `add_input_file` names) noticed during review; not introduced here.