### PR TITLE
fix(storage): make GCS storage layer importName-subdirectory aware

### DIFF
--- a/src/dcp_tools/gcp_utilities/settings.py
+++ b/src/dcp_tools/gcp_utilities/settings.py
@@ -7,7 +7,7 @@ from os import PathLike
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, Json
+from pydantic import Field, Json, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _DEFAULT_IMAGE = "gcr.io/datcom-ci/datacommons-services:latest"
@@ -54,6 +54,11 @@ class KGSettings(BaseSettings):
     datacommons_service_image: str = Field(
         default=_DEFAULT_IMAGE, alias="DATACOMMONS_SERVICE_IMAGE"
     )
+
+    @field_validator("gcs_input_folder_path", "gcs_output_folder_path")
+    @classmethod
+    def _strip_slashes(cls, v: str) -> str:
+        return v.strip("/")
 
     @property
     def full_gcs_input_path(self) -> str:

--- a/src/dcp_tools/gcp_utilities/storage.py
+++ b/src/dcp_tools/gcp_utilities/storage.py
@@ -14,12 +14,11 @@ from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.mcf import MCFNodes
 from dcp_tools.logger import logger
 
-_SKIP_IN_SUBDIR = {".json"}
 _VALID_EXTENSIONS = {".csv", ".json", ".mcf"}
 
 
 def _iter_local_files(directory: Path) -> Iterable[Path]:
-    """Yield all the files to be uploaded (excluding the skipped ones in subdirectories)
+    """Yield all the files to be uploaded under ``directory``.
 
     Args:
         directory (Path): The directory to iterate through.
@@ -27,8 +26,6 @@ def _iter_local_files(directory: Path) -> Iterable[Path]:
     """
     for path in directory.rglob("*"):
         if not path.is_file():
-            continue
-        if path.parent != directory and path.suffix in _SKIP_IN_SUBDIR:
             continue
         yield path
 
@@ -66,11 +63,51 @@ def _normalize_gcs_prefix(bucket: Bucket, prefix: str | None) -> str | None:
     return f"{prefix}/"
 
 
+def _remote_path(local_path: Path, directory: Path, gcs_folder_name: str | None) -> str:
+    """Map a local file path to its remote blob name under ``gcs_folder_name``.
+
+    The relative directory structure under ``directory`` is preserved.
+    """
+    relative = local_path.relative_to(directory).as_posix()
+    return f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
+
+
+def _scoped_prefix(gcs_folder_name: str | None, import_name: str | None) -> str | None:
+    """Append ``import_name`` to ``gcs_folder_name`` when scoping to one import.
+
+    Args:
+        gcs_folder_name (str | None): Base folder path in the GCS bucket.
+        import_name (str | None): Single-segment import name (e.g. ``"myImport"``).
+            Must not contain ``/``.
+
+    Returns:
+        str | None: Effective prefix scoped to the import, or the base prefix
+            when ``import_name`` is ``None``.
+
+    Raises:
+        ValueError: If ``import_name`` contains a ``/`` (must be a single path segment).
+    """
+    base = gcs_folder_name.strip("/") if gcs_folder_name else None
+    if import_name:
+        seg = import_name.strip("/")
+        if "/" in seg:
+            raise ValueError(
+                f"import_name must be a single path segment, got {import_name!r}"
+            )
+        return f"{base}/{seg}" if base else seg
+    return base
+
+
 def upload_directory_to_gcs(
-    bucket: Bucket, directory: Path, gcs_folder_name: str | None = None
+    bucket: Bucket, directory: Path, *, gcs_folder_name: str | None = None
 ) -> None:
-    """Upload a local directory to Google Cloud Storage. Folder structures
-    is maintained in the GCS bucket in a specified base folder
+    """Upload a local directory to Google Cloud Storage. Folder structure
+    is maintained in the GCS bucket in a specified base folder.
+
+    Every file matching the supported extensions anywhere under ``directory``
+    is uploaded. Import subdirs must therefore contain only files meant for
+    upload (no scratch or intermediate ``.json``); callers are responsible for
+    keeping the source tree clean.
 
     Args:
         bucket (Bucket): GCS bucket instance.
@@ -85,14 +122,16 @@ def upload_directory_to_gcs(
     if not directory.exists():
         raise FileNotFoundError(f"The directory {directory} does not exist.")
 
+    if gcs_folder_name is not None:
+        gcs_folder_name = gcs_folder_name.strip("/") or None
+
     files_uploaded = 0
 
     for local_path in _iter_local_files(directory):
         if local_path.suffix not in _VALID_EXTENSIONS:
             logger.warning(f"Skipping unsupported file type: {local_path}")
             continue
-        relative = local_path.relative_to(directory).as_posix()
-        remote_path = f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
+        remote_path = _remote_path(local_path, directory, gcs_folder_name)
         bucket.blob(remote_path).upload_from_filename(str(local_path))
         logger.info(f"Uploaded {local_path} to {remote_path}")
         files_uploaded += 1
@@ -104,37 +143,70 @@ def upload_directory_to_gcs(
 
 
 def sync_directory_to_gcs(
-    bucket: Bucket, directory: Path, gcs_folder_name: str | None = None
+    bucket: Bucket, directory: Path, *, gcs_folder_name: str | None = None
 ) -> None:
     """Upload a local directory then delete stale remote blobs.
 
     This function first uploads all local files (via
-    :func:`upload_directory_to_gcs`) and then removes any blobs under
-    ``gcs_folder_name`` that no longer have a local counterpart.
+    :func:`upload_directory_to_gcs`) and then removes any blobs that are
+    stale (no longer have a local counterpart) within the scopes of the
+    import subdirectories present locally.
+
+    Deletion is subset-safe by directory-tree discovery: blobs under import
+    subdirectories not present locally are never deleted. Pass the parent
+    directory containing all ``<importName>/`` subdirs; the function discovers
+    which imports are present and scopes deletion automatically — no
+    ``import_name`` argument is required.
 
     Args:
         bucket (Bucket): GCS bucket instance.
-        directory (Path): Local directory to upload.
+        directory (Path): Local directory to upload (typically the parent of
+            all ``<importName>/`` subdirectories).
         gcs_folder_name (str | None): Name of the base folder in the GCS
             bucket. If ``None``, the bucket root is used.
     """
-    upload_directory_to_gcs(bucket, directory, gcs_folder_name)
+    if gcs_folder_name is not None:
+        gcs_folder_name = gcs_folder_name.strip("/") or None
 
+    upload_directory_to_gcs(bucket, directory, gcs_folder_name=gcs_folder_name)
+
+    # Remote prefix with trailing slash (empty string when no prefix)
+    base = f"{gcs_folder_name}/" if gcs_folder_name else ""
+
+    # Build the expected set and discover which import subdirs are present
     expected: set[str] = set()
+    subtree_scopes: set[str] = set()  # full subtrees safe to prune (import subdirs)
+    has_root_level_file = False  # whether any file sits directly under directory
+
     for local_path in _iter_local_files(directory):
         if local_path.suffix not in _VALID_EXTENSIONS:
             continue
-        relative = local_path.relative_to(directory).as_posix()
-        remote_path = f"{gcs_folder_name}/{relative}" if gcs_folder_name else relative
+        remote_path = _remote_path(local_path, directory, gcs_folder_name)
         expected.add(remote_path)
+        rel = local_path.relative_to(directory)
+        if len(rel.parts) > 1:
+            # Nested under an import subdir — whole subtree is in scope for pruning
+            subtree_scopes.add(f"{base}{rel.parts[0]}/")
+        else:
+            has_root_level_file = True
 
-    prefix = gcs_folder_name or None
     try:
-        remote = set(list_bucket_files(bucket, prefix))
+        remote = set(list_bucket_files(bucket, gcs_folder_name=gcs_folder_name))
     except FileNotFoundError:
         remote = set()
 
-    stale = remote - expected
+    def _deletable(r: str) -> bool:
+        # Subtree rule: any depth under a present import subdir
+        if any(r.startswith(s) for s in subtree_scopes):
+            return True
+        # Root rule: ONLY direct children of `base` (no further "/"), and only
+        # when this run actually had root-level local files. Deletes legacy
+        # prefix/old.csv but never prefix/otherImport/b.csv (deeper "/").
+        if has_root_level_file and r.startswith(base) and "/" not in r[len(base) :]:
+            return True
+        return False
+
+    stale = {r for r in (remote - expected) if _deletable(r)}
     if stale:
         logger.info(
             f"Found {len(stale)} stale blob(s) under "
@@ -145,7 +217,9 @@ def sync_directory_to_gcs(
         logger.info(f"No stale blobs found under '{gcs_folder_name or 'root'}'")
 
 
-def list_bucket_files(bucket: Bucket, gcs_folder_name: str | None = None) -> list[str]:
+def list_bucket_files(
+    bucket: Bucket, *, gcs_folder_name: str | None = None
+) -> list[str]:
     """Return the list of blob names in ``gcs_folder_name``.
 
     Args:
@@ -168,30 +242,47 @@ def list_bucket_files(bucket: Bucket, gcs_folder_name: str | None = None) -> lis
 
 
 def get_unregistered_csv_files(
-    bucket: Bucket, config: Config | dict, gcs_folder_name: str | None = None
+    bucket: Bucket,
+    config: Config | dict,
+    *,
+    gcs_folder_name: str | None = None,
+    import_name: str | None = None,
 ) -> list[str]:
     """Identify CSV files in the bucket not referenced in ``config``.
+
+    When ``import_name`` is provided, the check is scoped to that import's
+    subdirectory (e.g. ``import_name="myImport"`` checks under
+    ``gcs_folder_name/myImport/``). Blobs from sibling imports are not
+    returned. When omitted, behaves as today — compares against ``gcs_folder_name``
+    directly.
 
     Args:
         bucket (Bucket): GCS bucket instance.
         config (Config): Parsed configuration object.
         gcs_folder_name (str | None): Folder path prefix in the bucket. If
             ``None``, search the entire bucket.
+        import_name (str | None): Single-segment import name used to scope
+            the listing to ``gcs_folder_name/<import_name>/``. Must not
+            contain ``/``.
 
     Returns:
         list[str]: CSV file names present in the bucket but missing from
             ``config.inputFiles``.
     """
+    effective = _scoped_prefix(gcs_folder_name, import_name)
+    try:
+        blob_names = list_bucket_files(bucket=bucket, gcs_folder_name=effective)
+    except FileNotFoundError:
+        blob_names = []
 
-    blob_names = list_bucket_files(bucket=bucket, gcs_folder_name=gcs_folder_name)
     csv_files: list[str] = []
     for name in blob_names:
         path = Path(name)
         if path.suffix != ".csv":
             continue
-        if gcs_folder_name:
+        if effective:
             try:
-                prefix = gcs_folder_name.rstrip("/")
+                prefix = effective.rstrip("/")
                 path = path.relative_to(prefix)
             except ValueError:
                 pass
@@ -205,22 +296,37 @@ def get_unregistered_csv_files(
 
 
 def get_missing_csv_files(
-    bucket: Bucket, config: Config | dict, gcs_folder_name: str | None = None
+    bucket: Bucket,
+    config: Config | dict,
+    *,
+    gcs_folder_name: str | None = None,
+    import_name: str | None = None,
 ) -> list[str]:
     """Identify CSV files referenced in ``config`` but absent from ``bucket``.
+
+    When ``import_name`` is provided, the check is scoped to that import's
+    subdirectory (e.g. ``import_name="myImport"`` checks under
+    ``gcs_folder_name/myImport/``). When omitted, behaves as today — compares
+    against ``gcs_folder_name`` directly.
 
     Args:
         bucket (Bucket): GCS bucket instance.
         config (Config | dict): Parsed configuration object.
         gcs_folder_name (str | None): Folder path prefix in the bucket. If
             ``None``, search the entire bucket.
+        import_name (str | None): Single-segment import name used to scope
+            the check to ``gcs_folder_name/<import_name>/``. Must not
+            contain ``/``.
 
     Returns:
         list[str]: CSV file names present in ``config.inputFiles`` but missing
             from the bucket.
     """
-
-    blob_names = set(list_bucket_files(bucket=bucket, gcs_folder_name=gcs_folder_name))
+    effective = _scoped_prefix(gcs_folder_name, import_name)
+    try:
+        blob_names = set(list_bucket_files(bucket=bucket, gcs_folder_name=effective))
+    except FileNotFoundError:
+        blob_names = set()
 
     if isinstance(config, dict):
         config = Config.model_validate(config)
@@ -230,7 +336,7 @@ def get_missing_csv_files(
         path = Path(name)
         if path.suffix != ".csv":
             continue
-        blob_name = f"{gcs_folder_name}/{name}" if gcs_folder_name else name
+        blob_name = f"{effective}/{name}" if effective else name
         if blob_name not in blob_names:
             missing.append(name)
 

--- a/src/dcp_tools/gcp_utilities/storage.py
+++ b/src/dcp_tools/gcp_utilities/storage.py
@@ -150,13 +150,14 @@ def sync_directory_to_gcs(
     This function first uploads all local files (via
     :func:`upload_directory_to_gcs`) and then removes any blobs that are
     stale (no longer have a local counterpart) within the scopes of the
-    import subdirectories present locally.
+    import subdirectories that contain files locally.
 
-    Deletion is subset-safe by directory-tree discovery: blobs under import
-    subdirectories not present locally are never deleted. Pass the parent
-    directory containing all ``<importName>/`` subdirs; the function discovers
-    which imports are present and scopes deletion automatically — no
-    ``import_name`` argument is required.
+    Deletion is subset-safe by directory-tree discovery. Blobs under import
+    subdirectories with no files locally are never deleted. This includes both
+    imports not brought locally at all and import subdirs that are present but
+    empty. Pass the parent directory containing all ``<importName>/`` subdirs;
+    the function discovers which imports have files and scopes deletion to
+    them, so no ``import_name`` argument is required.
 
     Args:
         bucket (Bucket): GCS bucket instance.
@@ -202,9 +203,7 @@ def sync_directory_to_gcs(
         # Root rule: ONLY direct children of `base` (no further "/"), and only
         # when this run actually had root-level local files. Deletes legacy
         # prefix/old.csv but never prefix/otherImport/b.csv (deeper "/").
-        if has_root_level_file and r.startswith(base) and "/" not in r[len(base) :]:
-            return True
-        return False
+        return has_root_level_file and r.startswith(base) and "/" not in r[len(base) :]
 
     stale = {r for r in (remote - expected) if _deletable(r)}
     if stale:

--- a/tests/test_explicit_path_characterization.py
+++ b/tests/test_explicit_path_characterization.py
@@ -311,7 +311,7 @@ def test_get_unregistered_and_missing_csv_files_explicit():
     bucket.list_blobs.return_value = [blob_a, blob_extra]
     bucket.name = "my-bucket"
 
-    unregistered = get_unregistered_csv_files(bucket, cfg, "folder")
+    unregistered = get_unregistered_csv_files(bucket, cfg, gcs_folder_name="folder")
     assert unregistered == ["extra.csv"]
 
     # --- get_missing_csv_files ---
@@ -326,5 +326,5 @@ def test_get_unregistered_and_missing_csv_files_explicit():
     bucket2.list_blobs.return_value = [blob_a2]
     bucket2.name = "my-bucket"
 
-    missing = get_missing_csv_files(bucket2, cfg, "folder")
+    missing = get_missing_csv_files(bucket2, cfg, gcs_folder_name="folder")
     assert missing == ["extra.csv"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -9,6 +9,7 @@ from dcp_tools.custom_data.models.data_files import (
     ExplicitSchemaFile,
 )
 from dcp_tools.custom_data.models.sources import Source
+from dcp_tools.gcp_utilities.settings import KGSettings
 from dcp_tools.gcp_utilities.storage import (
     delete_bucket_files,
     get_bucket_files,
@@ -363,13 +364,11 @@ def test_get_missing_csv_files_with_prefix_added():
     assert missing == ["sub/b.csv"]
 
 
-def test_get_unregistered_csv_files_per_import(tmp_path):
+def test_get_unregistered_csv_files_per_import():
     """Per-import scoping prevents sibling-import blobs from appearing as unregistered."""
     bucket = Mock()
     blob_a = Mock()
     blob_a.name = "prefix/myImport/a.csv"
-    blob_other = Mock()
-    blob_other.name = "prefix/otherImport/b.csv"
     bucket.list_blobs.return_value = [blob_a]
     bucket.name = "my-bucket"
 
@@ -378,6 +377,8 @@ def test_get_unregistered_csv_files_per_import(tmp_path):
         bucket, cfg, gcs_folder_name="prefix", import_name="myImport"
     )
 
+    # The listing is scoped to the import's own subdir, so a sibling import's
+    # blobs never reach the comparison and cannot show up as unregistered.
     assert result == []
     bucket.list_blobs.assert_called_once_with(prefix="prefix/myImport/")
 
@@ -429,8 +430,6 @@ def test_registration_checks_fresh_import_empty_prefix():
 
 def test_gcs_input_folder_path_strips_slashes(monkeypatch):
     """KGSettings strips leading/trailing slashes from folder paths at model init."""
-    from bblocks.datacommons_tools.gcp_utilities.settings import KGSettings
-
     env_vals = {
         "LOCAL_PATH": "/tmp/data",
         "GCP_PROJECT_ID": "proj",

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -38,7 +38,6 @@ def test_upload_directory_to_gcs(tmp_path):
     sub = tmp_path / "sub"
     sub.mkdir()
     (sub / "c.mcf").write_text("Node: dcid:x\n")
-    # json in subdir should be skipped
     (sub / "d.json").write_text("{}")
 
     bucket = Mock()
@@ -52,9 +51,14 @@ def test_upload_directory_to_gcs(tmp_path):
     bucket.blob.side_effect = blob_side
     bucket.name = "my-bucket"
 
-    upload_directory_to_gcs(bucket, tmp_path, "prefix")
+    upload_directory_to_gcs(bucket, tmp_path, gcs_folder_name="prefix")
 
-    expected_keys = {"prefix/a.csv", "prefix/b.json", "prefix/sub/c.mcf"}
+    expected_keys = {
+        "prefix/a.csv",
+        "prefix/b.json",
+        "prefix/sub/c.mcf",
+        "prefix/sub/d.json",
+    }
     assert set(blobs.keys()) == expected_keys
     for b in blobs.values():
         b.upload_from_filename.assert_called_once()
@@ -108,7 +112,7 @@ def test_sync_directory_to_gcs_with_stale_blobs(tmp_path):
     blob_old.name = "prefix/old.csv"
     bucket.list_blobs.return_value = [blob_a, blob_b, blob_old]
 
-    sync_directory_to_gcs(bucket, tmp_path, "prefix")
+    sync_directory_to_gcs(bucket, tmp_path, gcs_folder_name="prefix")
 
     # Upload should have been called for a.csv and b.json
     assert "prefix/a.csv" in upload_blobs
@@ -140,7 +144,7 @@ def test_sync_directory_to_gcs_no_stale_blobs(tmp_path):
     blob_a.name = "prefix/a.csv"
     bucket.list_blobs.return_value = [blob_a]
 
-    sync_directory_to_gcs(bucket, tmp_path, "prefix")
+    sync_directory_to_gcs(bucket, tmp_path, gcs_folder_name="prefix")
 
     # Only the upload blob should have been created, no delete calls
     assert "prefix/a.csv" in blobs
@@ -178,6 +182,71 @@ def test_sync_directory_to_gcs_no_prefix(tmp_path):
     assert "old.csv" in all_blob_calls
 
 
+def test_sync_directory_to_gcs_preserves_sibling_import(tmp_path):
+    """Sync of a present import must never delete a sibling import's blobs."""
+    my_import = tmp_path / "myImport"
+    my_import.mkdir()
+    (my_import / "a.csv").write_text("col\n1\n")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    # Remote has blobs for myImport (one current, one stale) and otherImport
+    blob_a = Mock()
+    blob_a.name = "prefix/myImport/a.csv"
+    blob_stale = Mock()
+    blob_stale.name = "prefix/myImport/stale.csv"
+    blob_other = Mock()
+    blob_other.name = "prefix/otherImport/b.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_stale, blob_other]
+
+    sync_directory_to_gcs(bucket, tmp_path, gcs_folder_name="prefix")
+
+    all_blob_calls = [c.args[0] for c in bucket.blob.call_args_list]
+
+    # POSITIVE: the stale blob within myImport is deleted
+    assert "prefix/myImport/stale.csv" in all_blob_calls
+
+    # NEGATIVE: the sibling import's blob is never touched
+    assert "prefix/otherImport/b.csv" not in all_blob_calls
+
+
+def test_sync_directory_to_gcs_legacy_root_level_still_prunes(tmp_path):
+    """Root-level stale blobs are still pruned when local files sit directly
+    under tmp_path (no import subdirs), maintaining backward compatibility."""
+    (tmp_path / "a.csv").write_text("col\n1\n")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    blob_a = Mock()
+    blob_a.name = "prefix/a.csv"
+    blob_old = Mock()
+    blob_old.name = "prefix/old.csv"
+    bucket.list_blobs.return_value = [blob_a, blob_old]
+
+    sync_directory_to_gcs(bucket, tmp_path, gcs_folder_name="prefix")
+
+    all_blob_calls = [c.args[0] for c in bucket.blob.call_args_list]
+    assert "prefix/old.csv" in all_blob_calls
+
+
 def test_list_bucket_files_with_prefix():
     bucket = Mock()
     blob_a = Mock()
@@ -186,7 +255,10 @@ def test_list_bucket_files_with_prefix():
     blob_b.name = "folder/b.csv"
     bucket.list_blobs.return_value = [blob_a, blob_b]
     bucket.name = "my-bucket"
-    files = [f.replace("\\", "/") for f in list_bucket_files(bucket, "folder")]
+    files = [
+        f.replace("\\", "/")
+        for f in list_bucket_files(bucket, gcs_folder_name="folder")
+    ]
     assert files == ["folder/a.csv", "folder/b.csv"]
     bucket.list_blobs.assert_called_once_with(prefix="folder/")
 
@@ -198,7 +270,9 @@ def test_list_bucket_files_with_gs_path():
     bucket.list_blobs.return_value = [blob]
     bucket.name = "one-datacommons-staging"
 
-    result = list_bucket_files(bucket, "gs://one-datacommons-staging/one-data")
+    result = list_bucket_files(
+        bucket, gcs_folder_name="gs://one-datacommons-staging/one-data"
+    )
 
     assert [f.replace("\\", "/") for f in result] == ["one-data/a.csv"]
     bucket.list_blobs.assert_called_once_with(prefix="one-data/")
@@ -220,7 +294,7 @@ def test_list_bucket_files_missing_folder():
     bucket.name = "my-bucket"
 
     with pytest.raises(FileNotFoundError):
-        list_bucket_files(bucket, "missing")
+        list_bucket_files(bucket, gcs_folder_name="missing")
 
     bucket.list_blobs.assert_called_once_with(prefix="missing/")
 
@@ -234,7 +308,7 @@ def test_get_unregistered_csv_files():
     bucket.list_blobs.return_value = [blob_a, blob_extra]
     bucket.name = "my-bucket"
     cfg = _minimal_config()
-    missing = get_unregistered_csv_files(bucket, cfg, "folder")
+    missing = get_unregistered_csv_files(bucket, cfg, gcs_folder_name="folder")
     assert missing == ["extra.csv"]
 
 
@@ -248,7 +322,7 @@ def test_get_unregistered_csv_files_with_prefix_removed():
     bucket.name = "my-bucket"
 
     cfg = _minimal_config("sub/a.csv")
-    missing = get_unregistered_csv_files(bucket, cfg, "prefix")
+    missing = get_unregistered_csv_files(bucket, cfg, gcs_folder_name="prefix")
     missing = [f.replace("\\", "/") for f in missing]
 
     assert missing == ["sub/b.csv"]
@@ -266,7 +340,7 @@ def test_get_missing_csv_files():
         columnMappings=ColumnMappings(),
     )
 
-    missing = get_missing_csv_files(bucket, cfg, "folder")
+    missing = get_missing_csv_files(bucket, cfg, gcs_folder_name="folder")
 
     assert missing == ["extra.csv"]
 
@@ -283,10 +357,128 @@ def test_get_missing_csv_files_with_prefix_added():
         columnMappings=ColumnMappings(),
     )
 
-    missing = get_missing_csv_files(bucket, cfg, "prefix")
+    missing = get_missing_csv_files(bucket, cfg, gcs_folder_name="prefix")
     missing = [f.replace("\\", "/") for f in missing]
 
     assert missing == ["sub/b.csv"]
+
+
+def test_get_unregistered_csv_files_per_import(tmp_path):
+    """Per-import scoping prevents sibling-import blobs from appearing as unregistered."""
+    bucket = Mock()
+    blob_a = Mock()
+    blob_a.name = "prefix/myImport/a.csv"
+    blob_other = Mock()
+    blob_other.name = "prefix/otherImport/b.csv"
+    bucket.list_blobs.return_value = [blob_a]
+    bucket.name = "my-bucket"
+
+    cfg = _minimal_config("a.csv")
+    result = get_unregistered_csv_files(
+        bucket, cfg, gcs_folder_name="prefix", import_name="myImport"
+    )
+
+    assert result == []
+    bucket.list_blobs.assert_called_once_with(prefix="prefix/myImport/")
+
+
+def test_get_missing_csv_files_per_import():
+    """Per-import scoping checks the correct blob path (with importName segment)."""
+    bucket = Mock()
+    blob_a = Mock()
+    blob_a.name = "prefix/myImport/a.csv"
+    bucket.list_blobs.return_value = [blob_a]
+    bucket.name = "my-bucket"
+
+    cfg = _minimal_config("a.csv")
+    cfg.inputFiles["b.csv"] = ExplicitSchemaFile(
+        provenance="prov",
+        columnMappings=ColumnMappings(),
+    )
+
+    result = get_missing_csv_files(
+        bucket, cfg, gcs_folder_name="prefix", import_name="myImport"
+    )
+
+    assert result == ["b.csv"]
+    bucket.list_blobs.assert_called_once_with(prefix="prefix/myImport/")
+
+
+def test_registration_checks_fresh_import_empty_prefix():
+    """When the import prefix yields no blobs, treat remote as empty."""
+    bucket = Mock()
+    bucket.list_blobs.return_value = []
+    bucket.name = "my-bucket"
+
+    cfg = _minimal_config("a.csv")
+    cfg.inputFiles["b.csv"] = ExplicitSchemaFile(
+        provenance="prov",
+        columnMappings=ColumnMappings(),
+    )
+
+    unregistered = get_unregistered_csv_files(
+        bucket, cfg, gcs_folder_name="prefix", import_name="myImport"
+    )
+    assert unregistered == []
+
+    missing = get_missing_csv_files(
+        bucket, cfg, gcs_folder_name="prefix", import_name="myImport"
+    )
+    assert sorted(missing) == ["a.csv", "b.csv"]
+
+
+def test_gcs_input_folder_path_strips_slashes(monkeypatch):
+    """KGSettings strips leading/trailing slashes from folder paths at model init."""
+    from bblocks.datacommons_tools.gcp_utilities.settings import KGSettings
+
+    env_vals = {
+        "LOCAL_PATH": "/tmp/data",
+        "GCP_PROJECT_ID": "proj",
+        "GCS_BUCKET_NAME": "bucket",
+        "GCS_INPUT_FOLDER_PATH": "ingestion/input/",
+        "GCS_OUTPUT_FOLDER_PATH": "/output/path/",
+        "CLOUD_SQL_DB_NAME": "db",
+        "CLOUD_SQL_REGION": "us-central1",
+        "CLOUD_JOB_REGION": "us-central1",
+        "CLOUD_SERVICE_REGION": "us-central1",
+        "CLOUD_RUN_JOB_NAME": "job",
+        "CLOUD_RUN_SERVICE_NAME": "svc",
+    }
+    for k, v in env_vals.items():
+        monkeypatch.setenv(k, v)
+
+    settings = KGSettings()
+    assert settings.gcs_input_folder_path == "ingestion/input"
+    assert settings.gcs_output_folder_path == "output/path"
+
+
+def test_upload_trailing_slash_single_slash_keys(tmp_path):
+    """Trailing slash in gcs_folder_name produces single-slash blob paths."""
+    (tmp_path / "a.csv").write_text("col\n1\n")
+
+    bucket = Mock()
+    blobs: dict[str, Mock] = {}
+
+    def blob_side(name: str):
+        b = Mock()
+        blobs[name] = b
+        return b
+
+    bucket.blob.side_effect = blob_side
+    bucket.name = "my-bucket"
+
+    upload_directory_to_gcs(bucket, tmp_path, gcs_folder_name="prefix/")
+
+    assert "prefix/a.csv" in blobs
+    assert "prefix//a.csv" not in blobs
+
+
+def test_upload_directory_to_gcs_kwargs_only(tmp_path):
+    """gcs_folder_name must be passed as a keyword argument."""
+    bucket = Mock()
+    bucket.name = "my-bucket"
+    with pytest.raises(TypeError):
+        upload_directory_to_gcs(bucket, tmp_path, "prefix")  # type: ignore[call-arg]
 
 
 def test_delete_bucket_files():


### PR DESCRIPTION
## What

The DCP platform stores each import under a shared input prefix, `ingestion/input/<importName>/`. The storage layer assumed a flat, single-import layout. Three defects followed.

1. **Nested `config.json` was skipped on upload.** `_SKIP_IN_SUBDIR` dropped any `.json` that was not in the upload root, so per-import configs never reached GCS and the load job had nothing to read.
2. **`--sync` deleted sibling imports.** `sync_directory_to_gcs` listed every blob under the shared prefix and deleted anything without a local counterpart, wiping every other import's data. Permanent data loss.
3. **Registration checks misreported.** `get_unregistered_csv_files` and `get_missing_csv_files` compared `<importName>/data.csv` blob paths against flat config keys, so every CSV read as both unregistered and missing.

## How

Sync deletion now scopes to the import subdirectories present locally. Two rules decide what is stale. A subtree rule prunes any depth under a present import subdir. A direct-child rule prunes legacy root-level blobs. A blob under an import you did not bring locally is never a deletion candidate, which is the data-loss fix.

`_SKIP_IN_SUBDIR` is gone, so nested `config.json` uploads. The two registration functions take an optional `import_name` that scopes the check to one import's subdirectory; omit it and they behave as before. A fresh import with nothing uploaded yet now returns the right answer instead of raising.

Supporting changes are a shared `_remote_path` helper so upload and sync compute paths in one place, a `KGSettings` validator that strips stray slashes from the folder paths, and kwargs-only signatures on the public storage functions.

`pipeline.py` is unchanged. Sync became subset-safe by discovering import names from the directory tree, so the caller needs no new argument.

## Testing

`uv run pytest` passes 96 tests. `ruff check` and `ruff format --check` are clean. Eight new or updated tests cover sibling-import preservation, legacy pruning, per-import registration, the fresh-import case, slash handling, and kwargs-only enforcement.

Closes #108

Co-authored-by: Claude <noreply@anthropic.com>
