### PR TITLE
feat(custom_data): emit and round-trip importName in config.json

### DIFF
--- a/src/dcp_tools/custom_data/config_utils.py
+++ b/src/dcp_tools/custom_data/config_utils.py
@@ -26,6 +26,7 @@ def iter_config_files(directory: Path, pattern: str = "config.json") -> Iterator
 def _merge_simple_attrs(existing: Config, new: Config, policy: DuplicatePolicy) -> None:
     """Merge simple attributes that are booleans, strings, or None."""
     for attr in (
+        "importName",
         "includeInputSubdirs",
         "groupStatVarsByProperty",
         "defaultCustomRootStatVarGroupName",

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -189,6 +189,7 @@ class CustomDataManager:
         variables_count = nodes_count
         dataframes_count = len(self._data)
 
+        import_name = self._config.importName
         include_input_subdirs = self._config.includeInputSubdirs
         group_statvars = self._config.groupStatVarsByProperty
         root_group_name = self._config.defaultCustomRootStatVarGroupName
@@ -201,12 +202,23 @@ class CustomDataManager:
             f"\n{input_files_count} inputFiles, with {dataframes_count} containing data"
             f"\n{sources_count} sources"
             f"\n{variables_count} variables"
-            f"\nflags: includeInputSubdirs={include_input_subdirs}, "
+            f"\nflags: importName={import_name}, "
+            f"includeInputSubdirs={include_input_subdirs}, "
             f"groupStatVarsByProperty={group_statvars}, "
             f"defaultCustomRootStatVarGroupName={root_group_name}, "
             f"customIdNamespace={namespace}, customSvgPrefix={svg_prefix}, "
             f"svHierarchyPropsBlocklist={blocklist}>"
         )
+
+    def set_importName(self, name: str | None) -> CustomDataManager:
+        """Set the import name in the config.
+
+        The import name is used by the platform prep job to name the JSON-LD output
+        directory. Pass ``None`` to unset it; ``export_config`` then defaults it to the
+        export directory name.
+        """
+        self._config.importName = name
+        return self
 
     def set_includeInputSubdirs(self, set_value: bool) -> CustomDataManager:
         """Set the includeInputSubdirs attribute of the config"""
@@ -793,11 +805,16 @@ class CustomDataManager:
 
         self._config.validate_config()
 
+        # Default importName to the export directory name (matching the prep job's
+        # fallback) for this export only, without mutating manager state, so
+        # re-exporting to another directory picks up that directory's name.
+        config = self._config
+        if config.importName is None:
+            config = config.model_copy(update={"importName": Path(dir_path).name})
+
         output_path = Path(dir_path) / "config.json"
         with output_path.open("w") as f:
-            f.write(
-                self._config.model_dump_json(indent=4, exclude_none=True, by_alias=True)
-            )
+            f.write(config.model_dump_json(indent=4, exclude_none=True, by_alias=True))
 
     def export_mfc_file(
         self,
@@ -826,7 +843,9 @@ class CustomDataManager:
         """Export the config to a dictionary
 
         Before exporting, the config is validated to ensure that all required fields are
-        present and that the config is valid.
+        present and that the config is valid. Unlike ``export_config``, this is a raw
+        state dump: it does not default ``importName`` (there is no directory to derive
+        it from), so an unset ``importName`` is absent from the returned dict.
 
         Returns:
             Dict: The config as a dictionary

--- a/src/dcp_tools/custom_data/models/config_file.py
+++ b/src/dcp_tools/custom_data/models/config_file.py
@@ -11,6 +11,9 @@ class Config(BaseModel):
     """Representation of the config file
 
     Attributes:
+        importName: Name of the import. Used by the platform prep job to name the
+            JSON-LD output directory. Optional; defaults to the export directory name
+            on export when unset.
         includeInputSubdirs: Include input subdirectories.
         groupStatVarsByProperty: Group stat vars by property.
         defaultCustomRootStatVarGroupName: Display name for the custom root StatVarGroup.
@@ -25,6 +28,7 @@ class Config(BaseModel):
         sources: Dictionary of sources.
     """
 
+    importName: str | None = None
     includeInputSubdirs: bool | None = None
     groupStatVarsByProperty: bool | None = None
     defaultCustomRootStatVarGroupName: str | None = None

--- a/tests/goldens/config.json
+++ b/tests/goldens/config.json
@@ -1,4 +1,5 @@
 {
+    "importName": "test_import",
     "includeInputSubdirs": true,
     "groupStatVarsByProperty": false,
     "inputFiles": {

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -74,6 +74,32 @@ def test_set_additional_config_fields():
     ]
 
 
+def test_import_name_set_and_export_default(tmp_path):
+    """set_importName stores the value; export_config defaults it to the dir name."""
+    # explicit importName survives export unchanged
+    manager = CustomDataManager()
+    manager.set_importName("MyImport")
+    assert manager._config.importName == "MyImport"
+    out = tmp_path / "OECD_wage_data"
+    out.mkdir()
+    manager.export_config(out)
+    assert Config.from_json(str(out / "config.json")).importName == "MyImport"
+
+    # unset importName defaults to each export directory name without mutating state,
+    # so re-exporting the same manager elsewhere picks up the new directory's name.
+    manager2 = CustomDataManager()
+    out2 = tmp_path / "frog_data"
+    out2.mkdir()
+    manager2.export_config(out2)
+    assert Config.from_json(str(out2 / "config.json")).importName == "frog_data"
+    assert manager2._config.importName is None
+
+    out3 = tmp_path / "toad_data"
+    out3.mkdir()
+    manager2.export_config(out3)
+    assert Config.from_json(str(out3 / "config.json")).importName == "toad_data"
+
+
 def test_add_explicit_schema_file_registration_and_override(tmp_path):
     """
     Verifies explicit schema file registration in config and data,

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -27,6 +27,7 @@ def test_mcfnode_snapshot():
 
 def test_config_json_snapshot(tmp_path):
     manager = CustomDataManager()
+    manager.set_importName("test_import")
     manager.set_includeInputSubdirs(True).set_groupStatVarsByProperty(False)
 
     manager.add_explicit_schema_file(

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -26,3 +26,17 @@ def test_config_validators_raise_on_invalid_input_files(tmp_path):
     )
     with pytest.raises(ValueError):
         Config.from_json(str(config2))
+
+
+def test_config_round_trips_import_name(tmp_path):
+    """A platform config.json with a top-level importName loads and round-trips."""
+    config = tmp_path / "config.json"
+    config.write_text(
+        '{"importName": "OECD_wage_data",'
+        ' "inputFiles": {"data.csv": {"provenance": "p1", "columnMappings": {}}},'
+        ' "sources": {"s1": {"url": "http://example.com",'
+        ' "provenances": {"p1": "http://ex.com"}}}}'
+    )
+    loaded = Config.from_json(str(config))
+    assert loaded.importName == "OECD_wage_data"
+    assert loaded.model_dump(exclude_none=True)["importName"] == "OECD_wage_data"


### PR DESCRIPTION
Closes #103.

## What changed
Adds a top-level `importName` to `config.json` — the package can now both **emit** it and **round-trip** a platform config that already contains it.

- `Config.importName: Optional[str]` — adding the field also lifts the `extra="forbid"` block that previously rejected any config carrying `importName`.
- `CustomDataManager.set_importName()` (chainable, matches the `set_*` pattern); surfaced in `__repr__`.
- `export_config` defaults `importName` to the export directory name when unset, applied to a `model_copy` for serialization only — no manager-state mutation, so re-exporting to another directory picks up that directory's name.
- `importName` added to the directory-merge simple-attrs so merges round-trip it.
- `config_to_dict()` documented as a raw state dump (does not default `importName`).

## Acceptance
- Exported `config.json` carries a top-level `importName` matching the upload subdirectory. ✓
- The package loads a platform `config.json` that already contains `importName`. ✓

## Testing
90 tests pass. New coverage: round-trip load, set + export-default, re-export to a different dir with no-mutation assertion, and an updated golden snapshot.

Co-authored-by: Claude <noreply@anthropic.com>