### PR TITLE
Fix columnMappings keys to dcid: predicate form (#102)

### DIFF
--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -856,7 +856,7 @@ class CustomDataManager:
 
         self._config.validate_config()
 
-        return self._config.model_dump(mode="json", exclude_none=True)
+        return self._config.model_dump(mode="json", exclude_none=True, by_alias=True)
 
     def export_data(self, dir_path: str | PathLike[str]) -> None:
         """Export the data to CSV files

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints
 
 
 class MCFFileName(BaseModel):
@@ -11,6 +11,11 @@ class MCFFileName(BaseModel):
 
 class ColumnMappings(BaseModel):
     """Representation of the ColumnMappings section of the InputFiles section of the config file
+
+    The DCP importer keys observations by ``dcid:``-prefixed predicate names, so each
+    field serialises to its ``dcid:`` alias (via ``model_dump(by_alias=True)``) while the
+    friendly short name remains the Python attribute. Both forms are accepted on input.
+    ``scalingFactor`` has no recognised ``dcid:`` key and stays a plain short field.
 
     Attributes:
         variable: Variable name.
@@ -23,14 +28,42 @@ class ColumnMappings(BaseModel):
         observationPeriod: Observation period of the data.
     """
 
-    variable: str | None = None
-    entity: str | None = None
-    date: str | None = None
-    value: str | None = None
-    unit: str | None = None
+    variable: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("variable", "dcid:variableMeasured"),
+        serialization_alias="dcid:variableMeasured",
+    )
+    entity: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("entity", "dcid:observationAbout"),
+        serialization_alias="dcid:observationAbout",
+    )
+    date: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("date", "dcid:observationDate"),
+        serialization_alias="dcid:observationDate",
+    )
+    value: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("value", "dcid:value"),
+        serialization_alias="dcid:value",
+    )
+    unit: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("unit", "dcid:unit"),
+        serialization_alias="dcid:unit",
+    )
     scalingFactor: str | None = None
-    measurementMethod: str | None = None
-    observationPeriod: str | None = None
+    measurementMethod: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("measurementMethod", "dcid:measurementMethod"),
+        serialization_alias="dcid:measurementMethod",
+    )
+    observationPeriod: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("observationPeriod", "dcid:observationPeriod"),
+        serialization_alias="dcid:observationPeriod",
+    )
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/goldens/config.json
+++ b/tests/goldens/config.json
@@ -6,18 +6,18 @@
         "a.csv": {
             "provenance": "provA",
             "columnMappings": {
-                "entity": "Country",
-                "date": "Year",
-                "value": "Val"
+                "dcid:observationAbout": "Country",
+                "dcid:observationDate": "Year",
+                "dcid:value": "Val"
             },
             "format": "variablePerRow"
         },
         "b.csv": {
             "provenance": "provB",
             "columnMappings": {
-                "entity": "Country",
-                "date": "Year",
-                "value": "Val"
+                "dcid:observationAbout": "Country",
+                "dcid:observationDate": "Year",
+                "dcid:value": "Val"
             },
             "format": "variablePerRow"
         }

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -556,3 +556,63 @@ def test_loading_legacy_implicit_config_raises_with_message():
         with pytest.raises(ValueError, match="is no longer supported") as exc_info:
             Config.from_json(path)
         assert "legacy.csv" in str(exc_info.value)
+
+
+def test_column_mappings_emit_dcid_keys():
+    """Verify ColumnMappings emits dcid: prefixed keys on serialization."""
+    cm = ColumnMappings(
+        variable="Var",
+        entity="Country",
+        date="Year",
+        value="Val",
+        unit="USD",
+        scalingFactor="1000",
+        measurementMethod="Census",
+        observationPeriod="P1Y",
+    )
+    result = cm.model_dump(by_alias=True)
+    print()
+    print(result)
+
+    # All 7 aliased fields must emit dcid: keys
+    assert result["dcid:variableMeasured"] == "Var"
+    assert result["dcid:observationAbout"] == "Country"
+    assert result["dcid:observationDate"] == "Year"
+    assert result["dcid:value"] == "Val"
+    assert result["dcid:unit"] == "USD"
+    assert result["dcid:measurementMethod"] == "Census"
+    assert result["dcid:observationPeriod"] == "P1Y"
+
+    # scalingFactor stays short on both sides
+    assert "scalingFactor" in result
+    assert "dcid:scalingFactor" not in result
+
+    # Short keys must NOT appear for aliased fields
+    for short_key in [
+        "variable",
+        "entity",
+        "date",
+        "value",
+        "unit",
+        "measurementMethod",
+        "observationPeriod",
+    ]:
+        assert short_key not in result
+
+
+def test_column_mappings_accepts_dcid_keys_on_input():
+    """Verify ColumnMappings accepts dcid: keys on input (read-back guard)."""
+    cm = ColumnMappings.model_validate(
+        {
+            "dcid:observationAbout": "Country",
+            "dcid:observationDate": "Year",
+            "dcid:value": "Val",
+        }
+    )
+    assert cm.entity == "Country"
+    assert cm.date == "Year"
+    assert cm.value == "Val"
+
+    # Short-key input must also still work
+    cm2 = ColumnMappings.model_validate({"entity": "Country"})
+    assert cm2.entity == "Country"

--- a/tests/test_explicit_path_characterization.py
+++ b/tests/test_explicit_path_characterization.py
@@ -166,8 +166,9 @@ def test_export_config_round_trip_explicit(tmp_path):
 def test_config_to_dict_explicit_shape():
     """B5 — config_to_dict returns the expected serialized shape for the explicit path.
 
-    Pins the key names and values as observed on current HEAD. The key for the
-    format is 'data_format' (not the alias 'format') in config_to_dict output.
+    Pins the key names and values for the explicit path. The keys use the
+    DC-import aliases: 'format' for the data format and the 'dcid:' predicate
+    forms for columnMappings.
     """
     manager, _ = _explicit_manager()
 
@@ -176,11 +177,11 @@ def test_config_to_dict_explicit_shape():
 
     expected = {
         "provenance": "p1",
-        "data_format": "variablePerRow",
+        "format": "variablePerRow",
         "columnMappings": {
-            "entity": "entity",
-            "date": "Year",
-            "value": "Value",
+            "dcid:observationAbout": "entity",
+            "dcid:observationDate": "Year",
+            "dcid:value": "Value",
         },
     }
     assert entry == expected


### PR DESCRIPTION
Closes #102.

## What

`ColumnMappings` serialized its fields under short Python names (`entity`, `variable`, `date`, …), but the DCP importer keys observations by `dcid:`-prefixed predicate names. Any other key is treated as a custom dimension, so every exported `config.json` failed the import:

> `ValueError: Missing required column mapping for: 'dcid:variableMeasured'`

## How

Update `ColumnMappings` to accept either form on input and always emit the `dcid:` key on output.

  | field | emitted key |
  |---|---|
  | `variable` | `dcid:variableMeasured` |
  | `entity` | `dcid:observationAbout` |
  | `date` | `dcid:observationDate` |
  | `value` | `dcid:value` |
  | `unit` | `dcid:unit` |
  | `measurementMethod` | `dcid:measurementMethod` |
  | `observationPeriod` | `dcid:observationPeriod` |
  | `scalingFactor` | `scalingFactor` *(unchanged — see below)* |

## scalingFactor

Left as the short `scalingFactor` key because the importer has no `dcid:scalingFactor` route yet.

## Tests
- `test_column_mappings_emit_dcid_keys` — asserts the exact emitted key strings and that `scalingFactor` stays short (guards against alias typos).
- `test_column_mappings_accepts_dcid_keys_on_input` — read-back guard.
- Existing golden/round-trip tests pass against the updated fixture.

Co-authored with [Claude Code](https://claude.com/claude-code)