### PR TITLE
feat(custom_data): emit MCF Source/Provenance nodes for DCP strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ You can add or manage provenance information using `add_source` and `add_provena
 In this example, we will add a source and provenance for ONE Data's Climate Finance Files.
 
 ```python title="Add source and provenance"
-manager.add_source(name="ONE Data", url="https://data.one.org")
+manager.add_source(name="ONEData", url="https://data.one.org")
 manager.add_provenance(
-    name="ONE Climate Finance",
+    name="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
-    source="ONE Data",
+    source="ONEData",
 )
 ```
 
@@ -97,7 +97,7 @@ To add to the `CustomDataManager`, using the Implicit Schema:
 ```python title="Register data"
 manager.add_implicit_schema_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
-    provenance="ONE Climate Finance",
+    provenance="ONEClimateFinance",
     entityType="Country",
     data=data,
     ignoreColumns=["oecd_provider_code"],

--- a/README.md
+++ b/README.md
@@ -71,16 +71,16 @@ manager.set_includeInputSubdirs(True)
 ```
 
 ### 2. Add the provenance information for our data
-You can add or manage provenance information on the `config.py` file.
+You can add or manage provenance information using `add_source` and `add_provenance`.
 
-In this example, we will add a provenance for ONE Data's Climate Finance Files.
+In this example, we will add a source and provenance for ONE Data's Climate Finance Files.
 
-```python title="Add provenance and source"
+```python title="Add source and provenance"
+manager.add_source(name="ONE Data", url="https://data.one.org")
 manager.add_provenance(
-    provenance_name="ONE Climate Finance",
-    provenance_url="https://datacommons.one.org/data/climate-finance-files",
-    source_name="ONE Data",
-    source_url="https://data.one.org",
+    name="ONE Climate Finance",
+    url="https://datacommons.one.org/data/climate-finance-files",
+    source="ONE Data",
 )
 ```
 
@@ -140,8 +140,12 @@ manager.add_variable_to_config(
 Next, once all the data is added and the config is set up, you can export the `config.json` and data. When you export, the `config.json` is validated automatically
 
 ```python title="Export config and data"
-manager.export_all("path/to/output/folder")
+manager.export_all("path/to/output/folder", mcf_file_names=["provenance.mcf"])
 ```
+
+`export_all` writes a complete bundle: if an input file references a provenance,
+the MCF file defining it (`provenance.mcf` by default) must be listed in
+`mcf_file_names`, or it raises before writing anything.
 
 ### 6. (Optionally) load to the Knowledge Graph
 You can also programmatically push the data and config to a Google Cloud

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -43,11 +43,14 @@ manager = CustomDataManager()
 Add the source and provenance:
 
 ```python
+manager.add_source(
+    name="International Monetary Fund (IMF)",
+    url="https://www.imf.org/en/Home",
+)
 manager.add_provenance(
-    provenance_name="World Economic Outlook (WEO)",
-    provenance_url="https://www.imf.org/en/Publications/WEO",
-    source_name="International Monetary Fund (IMF)",
-    source_url="https://www.imf.org/en/Home",
+    name="World Economic Outlook (WEO)",
+    url="https://www.imf.org/en/Publications/WEO",
+    source="International Monetary Fund (IMF)",
 )
 ```
 

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -44,13 +44,13 @@ Add the source and provenance:
 
 ```python
 manager.add_source(
-    name="International Monetary Fund (IMF)",
+    name="IMF",
     url="https://www.imf.org/en/Home",
 )
 manager.add_provenance(
-    name="World Economic Outlook (WEO)",
+    name="WEO",
     url="https://www.imf.org/en/Publications/WEO",
-    source="International Monetary Fund (IMF)",
+    source="IMF",
 )
 ```
 
@@ -61,7 +61,7 @@ from dcp_tools.custom_data.models.data_files import ColumnMappings
 
 manager.add_explicit_schema_file(
     file_name="economy/gdp.csv",
-    provenance="World Economic Outlook (WEO)",
+    provenance="WEO",
     data=df,
     columnMappings=ColumnMappings(
         entityColumn="country",

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -64,11 +64,11 @@ The `CustomDataManager` lets you create or edit the `config.json` file without e
 You can register variables, sources or provenances, and data files. 
 
 ```python title="Add source and provenance"
-manager.add_source(name="ONE Data", url="https://data.one.org")
+manager.add_source(name="ONEData", url="https://data.one.org")
 manager.add_provenance(
-    name="ONE Climate Finance",
+    name="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
-    source="ONE Data",
+    source="ONEData",
 )
 ```
 
@@ -83,7 +83,7 @@ df = pd.DataFrame(...)
 
 manager.add_explicit_schema_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
-    provenance="ONE Climate Finance",
+    provenance="ONEClimateFinance",
     data=df,
     columnMappings=ColumnMappings(
         entity="country",

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -63,12 +63,12 @@ The `CustomDataManager` lets you create or edit the `config.json` file without e
 
 You can register variables, sources or provenances, and data files. 
 
-```python title="Add provenance and source"
+```python title="Add source and provenance"
+manager.add_source(name="ONE Data", url="https://data.one.org")
 manager.add_provenance(
-    provenance_name="ONE Climate Finance",
-    provenance_url="https://datacommons.one.org/data/climate-finance-files",
-    source_name="ONE Data",
-    source_url="https://data.one.org",
+    name="ONE Climate Finance",
+    url="https://datacommons.one.org/data/climate-finance-files",
+    source="ONE Data",
 )
 ```
 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -41,13 +41,17 @@ as `dcid:provenance/<name>`.
 Add a source first, then add one or more provenances that point to it:
 
 ```python
-manager.add_source(name="Source Name", url="https://example.com/source")
+manager.add_source(name="SourceName", url="https://example.com/source")
 manager.add_provenance(
-    name="Provenance Name",
+    name="ProvenanceName",
     url="https://example.com/provenance",
-    source="Source Name",
+    source="SourceName",
 )
 ```
+
+Each `name` becomes part of a dcid (`dcid:source/<name>`, `dcid:provenance/<name>`), so it must be a
+valid dcid token — no whitespace (use `"ONEData"`, not `"ONE Data"`). A name containing whitespace
+raises a `ValueError`.
 
 `add_provenance` requires the named source to already exist (added via `add_source`). If a source or
 provenance with the same name already exists, a `ValueError` is raised unless you pass `override=True`.

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -33,27 +33,38 @@ manager = CustomDataManager.from_config_files_in_directory("path/to/directory")
 
 ## Managing provenances and sources
 
-The `CustomDataManager` allows you to manage the sources and provenances in the `config.json` file.
-You can add a provenance and source using the `add_provenance` methods.
+The `CustomDataManager` allows you to define the sources and provenances for your data. Sources and
+provenances are written as MCF `Source` and `Provenance` nodes — by default into a file called
+`provenance.mcf`. Each input file references a provenance by name; internally that reference is stored
+as `dcid:provenance/<name>`.
+
+Add a source first, then add one or more provenances that point to it:
 
 ```python
-manager.add_provenance(provenance_name="Provenance Name",
-                       provenance_url="https://example.com/provenance",
-                       source_name="Source Name",
-                       source_url="https://example.com/source"
-                       )
+manager.add_source(name="Source Name", url="https://example.com/source")
+manager.add_provenance(
+    name="Provenance Name",
+    url="https://example.com/provenance",
+    source="Source Name",
+)
 ```
 
-If the source already exists in the `config.json`, it will not be added again. But if the source does not exist
-yet, you should specify the source URL. If the provenance already exists, you can override it by setting the 
-`overwrite` parameter to `True`.
+`add_provenance` requires the named source to already exist (added via `add_source`). If a source or
+provenance with the same name already exists, a `ValueError` is raised unless you pass `override=True`.
 
-Additional methods exist to manage sources and provenances:
+Both methods accept optional metadata kwargs (`description`, `license`, `isPartOf` on both; additionally
+`licenseType`, `lastDataRefreshDate`, `nextDataRefreshDate`, `nextSourceReleaseDate`,
+`sourceReleaseFrequency`, `earliestObservationDate`, `latestObservationDate`, and `curator` on
+`add_provenance`). Use the `additional_properties` dict for any property not covered by those kwargs.
 
-- `remove_source` - removes a source and all its provenances from the `config.json`.
-- `remove_provenance` - removes a provenance from the `config.json`.
-- `rename_source` - renames a source in the `config.json`.
-- `rename_provenance` - renames a provenance in the `config.json`.
+Source and Provenance nodes live in `provenance.mcf` by default. To write that file to disk you must list
+it explicitly when exporting:
+
+```python
+manager.export_all("path/to/output/folder", mcf_file_names=["provenance.mcf"])
+```
+
+This is the same mechanism used for any other MCF file — `provenance.mcf` is not exported automatically.
 
 
 ## Managing variables
@@ -119,18 +130,7 @@ manager.add_data(data=df, file_name="gdp.csv")
 
 ## Removing variables and data files
 
-You have already seen above how to remove variables and data files using the `remove_variable` 
-and `remove_data_file` methods.
-You can also remove variables and files based on their associated provenance or source.
-
-```python title="Remove variables by provenance"
-manager.remove_by_provenance("World Economic Outlook")
-```
-
-```python title="Remove data files by source"
-manager.remove_by_source("IMF")
-```
-
+You can remove variables and data files using the `remove_indicator` and `rename_variable` methods.
 
 
 ## Adding and merging config files
@@ -235,3 +235,7 @@ To export MCF files as well, you should specify the `mcf_file_names` parameter:
 ```python
 manager.export_all("path/to/output/folder", mcf_file_names=["mcf_file1.mcf", "mcf_file2.mcf"])
 ```
+
+If an input file references a provenance, the MCF file defining it (`provenance.mcf` by default)
+must be among `mcf_file_names`; otherwise `export_all` raises before writing anything, so the
+exported bundle can never reference a provenance node that is missing from disk.

--- a/src/dcp_tools/custom_data/config_utils.py
+++ b/src/dcp_tools/custom_data/config_utils.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Literal
 
 from dcp_tools.custom_data.models.config_file import Config
-from dcp_tools.custom_data.models.sources import Source
 from dcp_tools.logger import logger
 
 DuplicatePolicy = Literal["error", "override", "ignore"]
@@ -43,37 +42,6 @@ def _merge_simple_attrs(existing: Config, new: Config, policy: DuplicatePolicy) 
     )
 
 
-def _merge_source(
-    target_sources: dict[str, Source],
-    name: str,
-    source: Source,
-    policy: DuplicatePolicy,
-) -> None:
-    """Merge a *Source* entry and its nested structures."""
-    if name not in target_sources:
-        logger.info(f"Added source '{name}'")
-        target_sources[name] = source
-        return
-
-    target = target_sources[name]
-    if target.url != source.url:
-        _handle_conflict(
-            field=f"URL for source '{name}'",
-            target_value=target,
-            source_value=source,
-            policy=policy,
-        )
-        if policy == "override":
-            target.url = source.url
-
-    _merge_dict(
-        target_dict=target.provenances,
-        source_dict=source.provenances,
-        policy=policy,
-        context=f"provenance of source '{name}'",
-    )
-
-
 def _handle_conflict(
     field: str, target_value: Any, source_value: Any, policy: DuplicatePolicy
 ) -> None:
@@ -86,30 +54,43 @@ def _handle_conflict(
         raise ValueError(f"Conflicting {field}: {target_value!r} vs {source_value!r}")
 
 
-def _merge_dict(
-    target_dict: dict[Any, Any],
-    source_dict: dict[Any, Any],
-    policy: DuplicatePolicy,
-    context: str,
-) -> None:
-    """Merge two mapping-like structures, according to *policy*."""
-    for key, src_val in source_dict.items():
-        if key not in target_dict:
-            target_dict[key] = src_val
+def _merge_input_files(existing: Config, new: Config, policy: DuplicatePolicy) -> None:
+    """Merge input file entries from *new* into *existing* in-place.
+
+    Entries are keyed by ``filename`` or ``pattern`` (whichever is set).
+    Conflict semantics follow *policy*: ``"error"`` raises, ``"override"``
+    replaces, ``"ignore"`` and equal entries are skipped.
+    """
+    existing_by_key: dict[str, int] = {}
+    for i, e in enumerate(existing.inputFiles):
+        k = e.filename or e.pattern
+        if k is not None:
+            existing_by_key[k] = i
+
+    for entry in new.inputFiles:
+        key = entry.filename or entry.pattern
+        if key is None:
+            # Should not happen: ExplicitSchemaFile enforces filename XOR pattern.
+            continue
+        if key not in existing_by_key:
+            logger.info(f"Added input file '{key}'")
+            existing.inputFiles.append(entry)
+            existing_by_key[key] = len(existing.inputFiles) - 1
             continue
 
-        tgt_val = target_dict[key]
-        if tgt_val == src_val:
+        idx = existing_by_key[key]
+        tgt = existing.inputFiles[idx]
+        if tgt == entry:
             continue
 
         _handle_conflict(
-            field=f"{context} '{key}'",
-            target_value=tgt_val,
-            source_value=src_val,
+            field=f"Input file '{key}'",
+            target_value=tgt,
+            source_value=entry,
             policy=policy,
         )
         if policy == "override":
-            target_dict[key] = src_val
+            existing.inputFiles[idx] = entry
 
 
 def _merge_attribute(
@@ -175,18 +156,7 @@ def merge_configs(
     _merge_simple_attrs(existing=existing, new=new, policy=policy)
 
     # Merge the input file list
-    _merge_dict(
-        target_dict=existing.inputFiles,
-        source_dict=new.inputFiles,
-        policy=policy,
-        context="Input file",
-    )
-
-    # Merge the sources
-    for name, src in new.sources.items():
-        _merge_source(
-            target_sources=existing.sources, name=name, source=src, policy=policy
-        )
+    _merge_input_files(existing=existing, new=new, policy=policy)
 
 
 def merge_configs_from_directory(
@@ -202,7 +172,7 @@ def merge_configs_from_directory(
             values are encountered.
 
     """
-    base = Config(inputFiles={}, sources={})
+    base = Config(inputFiles=[])
     for path in iter_config_files(Path(directory)):
         logger.info(f"Merging config file {path}")
         config = Config.from_json(str(path))

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -8,13 +8,13 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from pydantic import HttpUrl
 
 from dcp_tools.custom_data.config_utils import (
     DuplicatePolicy,
     merge_configs,
     merge_configs_from_directory,
 )
+from dcp_tools.custom_data.models.common import mint_dcid
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
@@ -22,7 +22,7 @@ from dcp_tools.custom_data.models.data_files import (
     MCFFileName,
 )
 from dcp_tools.custom_data.models.mcf import MCFNodes
-from dcp_tools.custom_data.models.sources import Source
+from dcp_tools.custom_data.models.sources import ProvenanceMCFNode, SourceMCFNode
 from dcp_tools.custom_data.models.stat_vars import (
     StatType,
     StatVarGroupMCFNode,
@@ -36,17 +36,19 @@ from dcp_tools.custom_data.schema_tools import (
 
 DEFAULT_STATVAR_MCF_NAME: str = "custom_nodes.mcf"
 DEFAULT_GROUP_NAME: str = "custom_groups.mcf"
+DEFAULT_PROVENANCE_MCF_NAME: str = "provenance.mcf"
 
 
-def _parse_kwargs_into_properties(locals_dict: dict[str, Any]) -> dict[str, Any]:
+def _parse_kwargs_into_properties(
+    locals_dict: dict[str, Any], *, extra_exclude: set[str] | None = None
+) -> dict[str, Any]:
     """Parse a dictionary of keyword arguments into a dictionary of properties"""
 
-    props = {
-        k: v
-        for k, v in locals_dict.items()
-        if k not in {"self", "additional_properties", "override", "mcf_file_name"}
-        and v is not None
-    }
+    exclude = {"self", "additional_properties", "override", "mcf_file_name"}
+    if extra_exclude:
+        exclude |= extra_exclude
+
+    props = {k: v for k, v in locals_dict.items() if k not in exclude and v is not None}
 
     if "additional_properties" in locals_dict:
         additional = locals_dict.get("additional_properties", {})
@@ -60,7 +62,7 @@ class CustomDataManager:
     """Class to handle the config json, data, and MCF files for Custom Data Commons
 
     Args:
-        config_file: Path to the config json file. If not provided, a new config objet will be created.
+        config_file: Path to the config json file. If not provided, a new config object will be created.
         mcf_files: Path to one or more MCF files. If not provided, a new MCFNodes object will be created.
 
     Usage:
@@ -70,20 +72,15 @@ class CustomDataManager:
     or
     >>> dc_manager = CustomDataManager(config_file="path/to/config.json", mcf_file="path/to/mcf_file.mcf")
 
-    To add a provenance to the config, use the add_provenance method
-    >>> dc_manager.add_provenance(
-    >>>     provenance_name="Provenance Name",
-    >>>     provenance_url="https://example.com/provenance",
-    >>>     source_name="Source Name",
-    >>>     source_url="https://example.com/source"
-    >>> )
+    Source/Provenance (MCF):
 
-    This will add a provenance and a source in the config. If the source already exists,
-    you can add another provenance to the existing source
+    To add a Source and Provenance (emitted as MCF nodes to ``provenance.mcf`` by default),
+    use the ``add_source`` and ``add_provenance`` methods:
+    >>> dc_manager.add_source(name="ONE Data", url="https://data.one.org")
     >>> dc_manager.add_provenance(
-    >>>    provenance_name="Provenance Name",
-    >>>    provenance_url="https://example.com/provenance",
-    >>>    source_name="Source Name"
+    >>>     name="ONE Climate Finance",
+    >>>     url="https://datacommons.one.org/data/climate-finance-files",
+    >>>     source="ONE Data",
     >>> )
 
     To add a variable for export to an MCF file (using the explicit schema), use the
@@ -100,7 +97,7 @@ class CustomDataManager:
     >>> dc_manager.add_variables_to_mcf_from_csv(file_path="path/to/file.csv")
 
     To add an input file and data to the config, using the explicit (per row) schema,
-    use the add_variablePerRow_input_file method
+    use the add_explicit_schema_file method
     >>> dc_manager.add_explicit_schema_file(
     >>>    file_name="input_file.csv",
     >>>    provenance="Provenance Name",
@@ -156,9 +153,7 @@ class CustomDataManager:
         """
 
         self._config = (
-            Config.from_json(config_file)
-            if config_file
-            else Config(inputFiles={}, sources={})
+            Config.from_json(config_file) if config_file else Config(inputFiles=[])
         )
 
         if mcf_files:
@@ -181,12 +176,16 @@ class CustomDataManager:
 
     def __repr__(self) -> str:
         input_files_count = len(self._config.inputFiles)
-        sources_count = len(self._config.sources)
-        nodes_count = sum(
-            [len(var) for var in [n.nodes for n in self._mcf_nodes.values()] if var]
-        )
 
-        variables_count = nodes_count
+        all_nodes = [n for nodes in self._mcf_nodes.values() for n in nodes.nodes]
+        sources_count = sum(
+            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcs:Source"
+        )
+        provenances_count = sum(
+            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcs:Provenance"
+        )
+        variables_count = len(all_nodes) - sources_count - provenances_count
+
         dataframes_count = len(self._data)
 
         import_name = self._config.importName
@@ -201,6 +200,7 @@ class CustomDataManager:
             f"<CustomDataManager config: "
             f"\n{input_files_count} inputFiles, with {dataframes_count} containing data"
             f"\n{sources_count} sources"
+            f"\n{provenances_count} provenances"
             f"\n{variables_count} variables"
             f"\nflags: importName={import_name}, "
             f"includeInputSubdirs={include_input_subdirs}, "
@@ -284,56 +284,126 @@ class CustomDataManager:
             self._config.svHierarchyPropsBlocklist = deduped
         return self
 
-    def add_provenance(
+    def add_source(
         self,
-        provenance_name: str,
-        provenance_url: HttpUrl | str,
-        source_name: str,
-        source_url: HttpUrl | str | None = None,
+        *,
+        name: str,
+        url: str,
+        description: str | None = None,
+        license: str | None = None,
+        isPartOf: str | None = None,
+        additional_properties: dict[str, str] | None = None,
         override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_PROVENANCE_MCF_NAME,
     ) -> CustomDataManager:
-        """Add a provenance to the config
+        """Add a Source MCF node.
 
-        Add a provenance (optionally with a new source) to the sources section of the config
-        file. If the source does not exist, it will be added but a source URL must be provided.
-        If the source exists, the provenance will be added to the existing source.
-        If the provenance already exists, it will be overwritten if override is set to True.
+        Emits a ``dcs:Source`` node to the MCF collection (default: ``provenance.mcf``).
+        The node is referenced by ``add_provenance`` via the same bare ``name``.
 
         Args:
-            provenance_name: Name of the provenance
-            provenance_url: URL of the provenance
-            source_name: Name of the source
-            source_url: URL of the source (optional)
-            override: If True, overwrite the existing provenance if it exists. Defaults to False.
+            name: Bare name for the source. Minting rule: bare name →
+                ``dcid:source/<name>``; pass an already ``dcid:``-prefixed value to use
+                it verbatim. Names must be valid dcid tokens (no whitespace).
+            url: URL of the data source.
+            description: Optional human-readable description. (Optional)
+            license: Optional license information. (Optional)
+            isPartOf: Optional DCID of a parent source. (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"provenance.mcf"``.
+
+        Returns:
+            CustomDataManager object
 
         Raises:
-            ValueError: If the source does not exist and no source URL is provided,
-                or if the provenance already exists and override is not set to True.
+            ValueError: If the name contains whitespace, if a node with the same id
+                already exists and ``override`` is False, or if the file name is invalid.
         """
 
-        if source_name not in self._config.sources:
-            if source_url is None:
-                raise ValueError(
-                    f"Source '{source_name}' not found. "
-                    "Please provide a source URL so the source can be added."
-                )
-            self._config.sources[source_name] = Source(
-                url=HttpUrl(source_url),
-                provenances={provenance_name: HttpUrl(provenance_url)},
-            )
+        Node = mint_dcid(prefix="source", name=name)
+        url = str(url)
+        props = _parse_kwargs_into_properties(locals(), extra_exclude={"name"})
+        node = SourceMCFNode(**props)
 
-        else:
-            if (
-                provenance_name in self._config.sources[source_name].provenances
-                and not override
-            ):
-                raise ValueError(
-                    f"Provenance '{provenance_name}' already exists for source '{source_name}'. "
-                    "Use override=True to overwrite it."
-                )
-            self._config.sources[source_name].provenances[provenance_name] = HttpUrl(
-                provenance_url
-            )
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+
+        return self
+
+    def add_provenance(
+        self,
+        *,
+        name: str,
+        url: str,
+        source: str,
+        description: str | None = None,
+        license: str | None = None,
+        licenseType: str | None = None,
+        lastDataRefreshDate: str | None = None,
+        nextDataRefreshDate: str | None = None,
+        nextSourceReleaseDate: str | None = None,
+        sourceReleaseFrequency: str | None = None,
+        earliestObservationDate: str | None = None,
+        latestObservationDate: str | None = None,
+        curator: str | None = None,
+        isPartOf: str | None = None,
+        additional_properties: dict[str, str] | None = None,
+        override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_PROVENANCE_MCF_NAME,
+    ) -> CustomDataManager:
+        """Add a Provenance MCF node linked to an existing Source.
+
+        Emits a ``dcs:Provenance`` node to the MCF collection (default: ``provenance.mcf``).
+        The corresponding Source must already be registered via ``add_source``.
+
+        Args:
+            name: Bare name for the provenance. Minting rule: bare name →
+                ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
+                use it verbatim. Names must be valid dcid tokens (no whitespace).
+            url: URL of the provenance dataset.
+            source: Bare name of the parent Source (must already have been added via
+                ``add_source``). The same minting rule applies: bare name →
+                ``dcid:source/<source>``; ``dcid:``-prefixed → verbatim.
+            description: Optional human-readable description. (Optional)
+            license: Optional license information. (Optional)
+            licenseType: Optional license type. (Optional)
+            lastDataRefreshDate: Optional date of last data refresh. (Optional)
+            nextDataRefreshDate: Optional date of next expected data refresh. (Optional)
+            nextSourceReleaseDate: Optional date of next source release. (Optional)
+            sourceReleaseFrequency: Optional frequency of source releases. (Optional)
+            earliestObservationDate: Optional earliest observation date. (Optional)
+            latestObservationDate: Optional latest observation date. (Optional)
+            curator: Optional curator of the dataset. (Optional)
+            isPartOf: Optional DCID of a parent provenance. (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"provenance.mcf"``.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If the ``source`` has not been added yet, if either name
+                contains whitespace, if a node with the same id already exists and
+                ``override`` is False, or if the file name is invalid.
+        """
+
+        Node = mint_dcid(prefix="provenance", name=name)
+        url = str(url)
+        sourceLink = mint_dcid(prefix="source", name=source)
+        self._require_source_exists(source, sourceLink)
+        props = _parse_kwargs_into_properties(
+            locals(), extra_exclude={"name", "source"}
+        )
+        node = ProvenanceMCFNode(**props)
+
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
 
         return self
 
@@ -498,11 +568,13 @@ class CustomDataManager:
 
     def add_explicit_schema_file(
         self,
-        file_name: str,
+        file_name: str | None = None,
+        *,
         provenance: str,
         data: pd.DataFrame | None = None,
         columnMappings: dict[str, str] | None = None,
         ignoreColumns: list[str] | None = None,
+        pattern: str | None = None,
         override: bool = False,
     ) -> CustomDataManager:
         """Add an inputFile to the config and optionally register the data as pandas DataFrame.
@@ -510,41 +582,77 @@ class CustomDataManager:
         This method registers an input file in the config. Optionally it also registers the
         data that accompanies the input file registered. The registration of the data is made
         optional in cases where a user wants to edit the config file without the
-        accompanying data. The data can be registered later using the add data method.
+        accompanying data. The data can be registered later using the add_data method.
 
         This method is for the explicit schema approach (variable per row). Read more about
         the explicit (variable-per-row) schema format here:
         https://docs.datacommons.org/custom_dc/custom_data.html
 
+        Exactly one of ``file_name`` or ``pattern`` must be provided. Pattern entries are
+        config-only: ``data=`` is not accepted with ``pattern=``.
 
         Args:
-            file_name: Name of the file (should be a .csv file)
-            provenance: Provenance of the data. This should be the name of the provenance
-                in the sources section of the config file. Use add_provenance to add a provenance
-                to the config file.
-            data: Data to register (optional)
-            columnMappings: Column mappings. Match the headings in the CSV file to the allowed
-                properties. Allowed keys are [entity, date, value, unit,
+            file_name: Exact name of the file (must have a .csv extension). Mutually
+                exclusive with ``pattern``.
+            provenance: Provenance name for the data. Bare name → minted as
+                ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
+                use it verbatim. Names must be valid dcid tokens (no whitespace).
+            data: Data to register (optional; only valid with ``file_name``).
+            columnMappings: Column mappings. Match the headings in the CSV file to the
+                allowed properties. Allowed keys are [entity, date, value, unit,
                 scalingFactor, measurementMethod, observationPeriod].
-            ignoreColumns: List of columns to ignore (optional)
-            override: If True, overwrite the existing file if it exists. Defaults to False.
+            ignoreColumns: List of columns to ignore (optional).
+            pattern: Glob pattern matching one or more input files. Mutually exclusive
+                with ``file_name``. Pattern entries carry no local data.
+            override: If True, overwrite the existing entry if it exists. Defaults to False.
 
+        Raises:
+            ValueError: If neither or both of ``file_name``/``pattern`` are provided,
+                if ``data`` is passed together with ``pattern``, or if a duplicate entry
+                exists and ``override`` is False.
         """
 
-        # check if the file already exists
-        self._data_override_check(file_name=file_name, override=override)
+        if (file_name is None) == (pattern is None):
+            raise ValueError(
+                "Exactly one of 'file_name' or 'pattern' must be provided."
+            )
+        if pattern is not None and data is not None:
+            raise ValueError("'data' cannot be provided together with 'pattern'.")
 
-        if columnMappings is None:
-            columnMappings = {}
-
-        self._config.inputFiles[file_name] = ExplicitSchemaFile(
-            ignoreColumns=ignoreColumns,
+        entry = ExplicitSchemaFile(
+            filename=file_name,
+            pattern=pattern,
             provenance=provenance,
-            columnMappings=ColumnMappings(**columnMappings),
+            columnMappings=ColumnMappings(**(columnMappings or {})),
+            ignoreColumns=ignoreColumns,
         )
 
-        # if data is provided, register it
+        # Upsert into the list keyed by filename or pattern
+        existing_idx: int | None = None
+        for i, e in enumerate(self._config.inputFiles):
+            if file_name is not None and e.filename == file_name:
+                existing_idx = i
+                break
+            if pattern is not None and e.pattern == pattern:
+                existing_idx = i
+                break
+
+        if existing_idx is not None:
+            if not override:
+                key = file_name if file_name is not None else pattern
+                raise ValueError(
+                    f"Input file '{key}' already registered. "
+                    "Use override=True to replace it."
+                )
+            self._config.inputFiles[existing_idx] = entry
+        else:
+            self._config.inputFiles.append(entry)
+
+        # Register data if provided (filename path only).
+        # file_name is non-None here: the pattern+data guard and XOR check above ensure it.
         if data is not None:
+            assert file_name is not None
+            self._data_override_check(file_name=file_name, override=override)
             self._data[file_name] = data
 
         return self
@@ -561,7 +669,7 @@ class CustomDataManager:
             override: If True, overwrite the existing data if it exists.
         """
 
-        if file_name not in self._config.inputFiles:
+        if not any(e.filename == file_name for e in self._config.inputFiles):
             raise ValueError(
                 f"File '{file_name}' not found in the config file. Please register the "
                 "file in the config file before adding data, using the "
@@ -621,67 +729,6 @@ class CustomDataManager:
 
         return self
 
-    def rename_provenance(self, old_name: str, new_name: str) -> CustomDataManager:
-        """Rename a provenance and update all references.
-
-        Args:
-            old_name: The name of the provenance to rename.
-            new_name: The new name for the provenance.
-        Raises:
-            ValueError: If the provenance is not found in the config or MCF files,
-                or if the new name already exists.
-        Raises:
-            ValueError: If the provenance is not found in the config or MCF files,
-                or if the new name already exists.
-
-        """
-
-        source = None
-        for src in self._config.sources.values():
-            if old_name in src.provenances:
-                source = src
-                break
-
-        if source is None:
-            raise ValueError(f"Provenance '{old_name}' not found")
-        if new_name in source.provenances:
-            raise ValueError(f"Provenance '{new_name}' already exists for source")
-
-        source.provenances[new_name] = source.provenances.pop(old_name)
-
-        for info in self._config.inputFiles.values():
-            if info.provenance == old_name:
-                info.provenance = new_name
-
-        for nodes in self._mcf_nodes.values():
-            for node in nodes.nodes:
-                prov = getattr(node, "provenance", None)
-                if prov in {old_name, f'"{old_name}"'}:
-                    node.provenance = f'"{new_name}"'
-
-        return self
-
-    def rename_source(self, old_name: str, new_name: str) -> CustomDataManager:
-        """Rename a source key in the config.
-
-        Args:
-            old_name: The name of the source to rename.
-            new_name: The new name for the source.
-        Raises:
-            ValueError: If the source is not found in the config or MCF files,
-                or if the new name already exists.
-
-        """
-
-        if old_name not in self._config.sources:
-            raise ValueError(f"Source '{old_name}' not found")
-        if new_name in self._config.sources:
-            raise ValueError(f"Source '{new_name}' already exists")
-
-        self._config.sources[new_name] = self._config.sources.pop(old_name)
-
-        return self
-
     def remove_indicator(
         self, indicator_id: str, *, mcf_file_name: str | None = None
     ) -> CustomDataManager:
@@ -728,67 +775,72 @@ class CustomDataManager:
 
         return self
 
-    def remove_by_provenance(self, provenance: str) -> CustomDataManager:
-        """Remove all files and indicators associated with a provenance."""
+    def _require_source_exists(self, source: str, source_link: str) -> None:
+        """Raise ValueError if no Source MCF node with id ``source_link`` exists.
 
-        removed = False
+        Args:
+            source: The bare user-facing source name (used in the error message).
+            source_link: The minted dcid for the source (used for the lookup).
+        """
+        if not any(
+            getattr(n, "typeOf", None) == "dcs:Source" and n.Node == source_link
+            for nodes in self._mcf_nodes.values()
+            for n in nodes.nodes
+        ):
+            raise ValueError(
+                f"Source '{source}' not found. "
+                f"Call add_source(name={source!r}, url=...) before add_provenance()."
+            )
 
-        files_to_remove = [
-            f
-            for f, info in self._config.inputFiles.items()
-            if info.provenance == provenance
-        ]
-        for file_name in files_to_remove:
-            self._config.inputFiles.pop(file_name)
-            self._data.pop(file_name, None)
-            removed = True
+    def _validate_provenances(self) -> None:
+        """Raise ValueError if any inputFile references a provenance with no matching node.
 
-        for nodes in self._mcf_nodes.values():
-            for node in list(nodes.nodes):
-                if getattr(node, "provenance", None) == f'"{provenance}"':
-                    nodes.remove(node.Node)
-                    removed = True
+        Scans all MCF files for ``dcs:Provenance`` nodes and checks that every
+        ``inputFiles`` entry with a ``provenance`` ref has a corresponding node.
+        """
+        known = {
+            n.Node
+            for nodes in self._mcf_nodes.values()
+            for n in nodes.nodes
+            if getattr(n, "typeOf", None) == "dcs:Provenance"
+        }
+        for entry in self._config.inputFiles:
+            if entry.provenance and entry.provenance not in known:
+                bare = entry.provenance.removeprefix("dcid:provenance/")
+                raise ValueError(
+                    f"Input file references unknown provenance '{bare}' "
+                    f"('{entry.provenance}'). "
+                    f"Call add_provenance(name={bare!r}, url=..., source=...) first."
+                )
 
-        if not removed:
-            raise ValueError(f"No data found for provenance '{provenance}'")
+    def _validate_provenance_files_exported(self, exported_mcf: set[str]) -> None:
+        """Raise if an inputFile references a provenance whose MCF file is not exported.
 
-        return self
-
-    def remove_provenance(self, provenance: str) -> CustomDataManager:
-        """Remove a provenance and any associated data and references."""
-
-        self.remove_by_provenance(provenance)
-
-        found = False
-        for source in self._config.sources.values():
-            if provenance in source.provenances:
-                del source.provenances[provenance]
-                found = True
-
-        if not found:
-            raise ValueError(f"Provenance '{provenance}' not found in sources")
-
-        return self
-
-    def remove_by_source(self, source: str) -> CustomDataManager:
-        """Remove all data associated with every provenance of a source."""
-
-        if source not in self._config.sources:
-            raise ValueError(f"Source '{source}' not found")
-
-        for prov in list(self._config.sources[source].provenances.keys()):
-            self.remove_by_provenance(prov)
-
-        return self
-
-    def remove_source(self, source: str) -> CustomDataManager:
-        """Remove a source and all its provenances from the config and data."""
-
-        self.remove_by_source(source)
-
-        del self._config.sources[source]
-
-        return self
+        ``export_all`` writes a complete bundle, so every provenance an input file
+        references must be defined in an MCF file included in ``mcf_file_names``.
+        Without this check a forgotten ``mcf_file_names=["provenance.mcf"]`` would
+        write a config.json that points at provenance nodes absent from the bundle —
+        a reference the DCP importer rejects. Unknown provenances (no node at all)
+        are left to ``_validate_provenances``.
+        """
+        defined_in = {
+            n.Node: fname
+            for fname, nodes in self._mcf_nodes.items()
+            for n in nodes.nodes
+            if getattr(n, "typeOf", None) == "dcs:Provenance"
+        }
+        missing: dict[str, str] = {}
+        for entry in self._config.inputFiles:
+            owning = defined_in.get(entry.provenance)
+            if owning is not None and owning not in exported_mcf:
+                missing.setdefault(owning, entry.provenance)
+        if missing:
+            files = sorted(missing)
+            raise ValueError(
+                f"export_all() would write a config.json that references provenance(s) "
+                f"defined in MCF file(s) not being exported: {files}. Add them to "
+                f"mcf_file_names (e.g. mcf_file_names={files!r}) so the bundle is complete."
+            )
 
     def export_config(self, dir_path: str | PathLike[str]) -> None:
         """Export the config to a JSON file
@@ -803,6 +855,7 @@ class CustomDataManager:
             ValueError: If the config is not valid
         """
 
+        self._validate_provenances()
         self._config.validate_config()
 
         # Default importName to the export directory name (matching the prep job's
@@ -854,6 +907,7 @@ class CustomDataManager:
             ValueError: If the config is not valid
         """
 
+        self._validate_provenances()
         self._config.validate_config()
 
         return self._config.model_dump(mode="json", exclude_none=True, by_alias=True)
@@ -874,15 +928,18 @@ class CustomDataManager:
     def validate_all_input_files_have_data(self) -> CustomDataManager:
         """Validate that every declared input file has a corresponding data entry.
 
+        Pattern entries (glob-matched files) are skipped; only ``filename`` entries
+        require a registered dataframe.
+
         Raises:
             ValueError: If one or more input files declared in the config do not have
                 associated data registered in this manager.
         """
 
         missing = [
-            file_name
-            for file_name in self._config.inputFiles
-            if file_name not in self._data
+            entry.filename
+            for entry in self._config.inputFiles
+            if entry.filename is not None and entry.filename not in self._data
         ]
         if missing:
             raise ValueError(
@@ -901,30 +958,45 @@ class CustomDataManager:
     ) -> None:
         """Export the config, MCF file, and data to a directory
 
+        ``export_all`` writes a complete bundle and enforces it: if an input file
+        references a provenance whose MCF file is not listed in ``mcf_file_names``,
+        it raises before writing anything (so no partial bundle lands on disk). To
+        export only the config (deferring MCF export), use ``export_config`` directly.
+
         Args:
             dir_path: Path to the directory where the config and data will be exported.
             override: If True, overwrite the files if they exist. Defaults to False.
             mcf_file_names: Name of the MCF file(s) to export (must end in .mcf).
                 Defaults to None, which means no MCF file will be exported.
+                Source and Provenance nodes live in ``provenance.mcf`` by default and
+                must be listed here to be written (e.g.
+                ``mcf_file_names=["provenance.mcf"]``).
             validate_data: If True, raise a ValueError before exporting if any input
                 file declared in the config does not have a corresponding data entry.
                 Defaults to False.
+
+        Raises:
+            ValueError: If an input file references a provenance defined in an MCF
+                file not included in ``mcf_file_names`` (the bundle would be incomplete).
         """
+
+        if isinstance(mcf_file_names, str):
+            mcf_file_names = [mcf_file_names]
 
         if validate_data:
             self.validate_all_input_files_have_data()
 
+        self._validate_provenance_files_exported(set(mcf_file_names or ()))
+
         self.export_config(dir_path)
 
-        self.export_data(dir_path)
+        if self._data:
+            self.export_data(dir_path)
 
-        if mcf_file_names:
-            if isinstance(mcf_file_names, str):
-                mcf_file_names = [mcf_file_names]
-            for mcf_file_name in mcf_file_names:
-                self.export_mfc_file(
-                    dir_path=dir_path, mcf_file_name=mcf_file_name, override=override
-                )
+        for mcf_file_name in mcf_file_names or ():
+            self.export_mfc_file(
+                dir_path=dir_path, mcf_file_name=mcf_file_name, override=override
+            )
 
     def validate_config(self) -> CustomDataManager:
         """Validate the config
@@ -936,6 +1008,7 @@ class CustomDataManager:
             pydantic.ValidationError if the config is not valid
         """
 
+        self._validate_provenances()
         self._config.validate_config()
         return self
 

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -179,10 +179,10 @@ class CustomDataManager:
 
         all_nodes = [n for nodes in self._mcf_nodes.values() for n in nodes.nodes]
         sources_count = sum(
-            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcs:Source"
+            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcid:Source"
         )
         provenances_count = sum(
-            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcs:Provenance"
+            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
         )
         variables_count = len(all_nodes) - sources_count - provenances_count
 
@@ -298,7 +298,7 @@ class CustomDataManager:
     ) -> CustomDataManager:
         """Add a Source MCF node.
 
-        Emits a ``dcs:Source`` node to the MCF collection (default: ``provenance.mcf``).
+        Emits a ``dcid:Source`` node to the MCF collection (default: ``provenance.mcf``).
         The node is referenced by ``add_provenance`` via the same bare ``name``.
 
         Args:
@@ -356,7 +356,7 @@ class CustomDataManager:
     ) -> CustomDataManager:
         """Add a Provenance MCF node linked to an existing Source.
 
-        Emits a ``dcs:Provenance`` node to the MCF collection (default: ``provenance.mcf``).
+        Emits a ``dcid:Provenance`` node to the MCF collection (default: ``provenance.mcf``).
         The corresponding Source must already be registered via ``add_source``.
 
         Args:
@@ -783,7 +783,7 @@ class CustomDataManager:
             source_link: The minted dcid for the source (used for the lookup).
         """
         if not any(
-            getattr(n, "typeOf", None) == "dcs:Source" and n.Node == source_link
+            getattr(n, "typeOf", None) == "dcid:Source" and n.Node == source_link
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
         ):
@@ -795,14 +795,14 @@ class CustomDataManager:
     def _validate_provenances(self) -> None:
         """Raise ValueError if any inputFile references a provenance with no matching node.
 
-        Scans all MCF files for ``dcs:Provenance`` nodes and checks that every
+        Scans all MCF files for ``dcid:Provenance`` nodes and checks that every
         ``inputFiles`` entry with a ``provenance`` ref has a corresponding node.
         """
         known = {
             n.Node
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
-            if getattr(n, "typeOf", None) == "dcs:Provenance"
+            if getattr(n, "typeOf", None) == "dcid:Provenance"
         }
         for entry in self._config.inputFiles:
             if entry.provenance and entry.provenance not in known:
@@ -831,10 +831,10 @@ class CustomDataManager:
         for fname, nodes in self._mcf_nodes.items():
             for n in nodes.nodes:
                 node_type = getattr(n, "typeOf", None)
-                if node_type == "dcs:Provenance":
+                if node_type == "dcid:Provenance":
                     prov_file[n.Node] = fname
                     prov_source[n.Node] = getattr(n, "sourceLink", None)
-                elif node_type == "dcs:Source":
+                elif node_type == "dcid:Source":
                     source_file[n.Node] = fname
 
         missing: dict[str, str] = {}

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -814,31 +814,50 @@ class CustomDataManager:
                 )
 
     def _validate_provenance_files_exported(self, exported_mcf: set[str]) -> None:
-        """Raise if an inputFile references a provenance whose MCF file is not exported.
+        """Raise if an inputFile references a provenance — or its linked Source —
+        defined in an MCF file that is not being exported.
 
         ``export_all`` writes a complete bundle, so every provenance an input file
-        references must be defined in an MCF file included in ``mcf_file_names``.
-        Without this check a forgotten ``mcf_file_names=["provenance.mcf"]`` would
-        write a config.json that points at provenance nodes absent from the bundle —
-        a reference the DCP importer rejects. Unknown provenances (no node at all)
-        are left to ``_validate_provenances``.
+        references must be defined in an exported MCF file, and so must the Source it
+        links to via ``sourceLink``. Without this check a forgotten
+        ``mcf_file_names=["provenance.mcf"]`` (or a Source kept in a separate, unexported
+        MCF file) would write a config.json pointing at nodes absent from the bundle —
+        references the DCP importer rejects. Unknown provenances (no node at all) are
+        left to ``_validate_provenances``.
         """
-        defined_in = {
-            n.Node: fname
-            for fname, nodes in self._mcf_nodes.items()
-            for n in nodes.nodes
-            if getattr(n, "typeOf", None) == "dcs:Provenance"
-        }
+        prov_file: dict[str, str] = {}
+        prov_source: dict[str, str | None] = {}
+        source_file: dict[str, str] = {}
+        for fname, nodes in self._mcf_nodes.items():
+            for n in nodes.nodes:
+                node_type = getattr(n, "typeOf", None)
+                if node_type == "dcs:Provenance":
+                    prov_file[n.Node] = fname
+                    prov_source[n.Node] = getattr(n, "sourceLink", None)
+                elif node_type == "dcs:Source":
+                    source_file[n.Node] = fname
+
         missing: dict[str, str] = {}
         for entry in self._config.inputFiles:
-            owning = defined_in.get(entry.provenance)
-            if owning is not None and owning not in exported_mcf:
-                missing.setdefault(owning, entry.provenance)
+            ref = entry.provenance
+            owning = prov_file.get(ref)
+            if owning is None:
+                continue  # unknown provenance -> _validate_provenances reports it
+            if owning not in exported_mcf:
+                missing.setdefault(owning, ref)
+                continue
+            # The provenance is exported; the Source it links to must be too.
+            link = prov_source.get(ref)
+            if link is not None:
+                src_owner = source_file.get(link)
+                if src_owner is not None and src_owner not in exported_mcf:
+                    missing.setdefault(src_owner, link)
+
         if missing:
             files = sorted(missing)
             raise ValueError(
-                f"export_all() would write a config.json that references provenance(s) "
-                f"defined in MCF file(s) not being exported: {files}. Add them to "
+                f"export_all() would write a config.json referencing source/provenance "
+                f"node(s) defined in MCF file(s) not being exported: {files}. Add them to "
                 f"mcf_file_names (e.g. mcf_file_names={files!r}) so the bundle is complete."
             )
 

--- a/src/dcp_tools/custom_data/models/common.py
+++ b/src/dcp_tools/custom_data/models/common.py
@@ -144,3 +144,37 @@ TopicDcidOrListTopicDcid = Annotated[
     PlainSerializer(mcf_str, return_type=TopicDcid | None, when_used="always"),
 ]
 """Accepts a string or list and serialises to a comma-separated string."""
+
+
+def mint_dcid(*, prefix: str, name: str) -> str:
+    """Mint a dcid for a source/provenance node id or reference.
+
+    Three-way minting rule (canonical):
+        Bare name                     -> ``dcid:<prefix>/<name>``
+                                         e.g. ``'CustomSource'`` -> ``'dcid:source/CustomSource'``
+        Already ``dcid:``-prefixed    -> returned verbatim (power-user escape hatch)
+                                         e.g. ``'dcid:bio/y'`` -> ``'dcid:bio/y'``
+        Contains ``/`` (no ``dcid:``) -> prepended with ``dcid:``
+                                         e.g. ``'source/Foo'`` -> ``'dcid:source/Foo'``
+        Whitespace or empty name      -> ``ValueError`` (strict contract; no slugify)
+
+    Args:
+        prefix: Namespace prefix used when minting a bare name (e.g. ``'source'``,
+            ``'provenance'``).
+        name: The bare name, partially-qualified path, or already-minted dcid.
+
+    Returns:
+        A fully-qualified dcid string.
+
+    Raises:
+        ValueError: If *name* is empty or contains any whitespace character.
+    """
+    if not name or any(c.isspace() for c in name):
+        raise ValueError(
+            f"mint_dcid: name must be a non-empty token with no whitespace; got {name!r}"
+        )
+    if name.startswith("dcid:"):
+        return name
+    if "/" in name:
+        return f"dcid:{name}"
+    return f"dcid:{prefix}/{name}"

--- a/src/dcp_tools/custom_data/models/config_file.py
+++ b/src/dcp_tools/custom_data/models/config_file.py
@@ -4,7 +4,6 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, model_validator
 
 from dcp_tools.custom_data.models.data_files import ExplicitSchemaFile
-from dcp_tools.custom_data.models.sources import Source
 
 
 class Config(BaseModel):
@@ -22,10 +21,11 @@ class Config(BaseModel):
             Default: `"custom"`.
         customSvgPrefix: String prefix for generated custom StatVarGroup ids. If not set,
             and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
-        inputFiles: Dictionary of input files.
+        inputFiles: List of input file entries. Each entry specifies exactly one of
+            ``filename`` (exact CSV name) or ``pattern`` (glob), plus ``provenance``
+            and column mapping information.
         svHierarchyPropsBlocklist: Array of additional property dcids to exclude from hierarchy generation.
             These are added to the internal blocklist used by Data Commons.
-        sources: Dictionary of sources.
     """
 
     importName: str | None = None
@@ -35,8 +35,7 @@ class Config(BaseModel):
     customIdNamespace: str | None = None
     customSvgPrefix: str | None = None
     svHierarchyPropsBlocklist: list[str] | None = None
-    inputFiles: dict[str, ExplicitSchemaFile]
-    sources: dict[str, Source]
+    inputFiles: list[ExplicitSchemaFile]
 
     # model configuration - populate by name (for the "format" field alias)
     # and forbid extra fields
@@ -50,47 +49,46 @@ class Config(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_implicit_schema_files(cls, data: Any) -> Any:
-        """Reject legacy implicit-schema (variablePerColumn) inputFiles with a clear error."""
+        """Reject legacy implicit-schema (variablePerColumn) inputFiles with a clear error.
+
+        Handles both the legacy dict format and the current list format for ``inputFiles``
+        so that the friendly migration message fires before any type-coercion error.
+        """
         if isinstance(data, dict):
-            for key, entry in (data.get("inputFiles") or {}).items():
-                if isinstance(entry, dict) and "variablePerColumn" in {
-                    entry.get("format"),
-                    entry.get("data_format"),
-                }:
-                    raise ValueError(
-                        f"Config contains implicit-schema file '{key}': "
-                        "format 'variablePerColumn' is no longer supported. "
-                        "Migrate to explicit schema before loading. See "
-                        "https://docs.datacommons.org/custom_dc/custom_data.html "
-                        "for the explicit-schema format."
-                    )
+            input_files = data.get("inputFiles") or {}
+            if isinstance(input_files, dict):
+                # Legacy dict format — use the dict key in the error message so callers
+                # can identify the offending file (e.g. test_loading_legacy_implicit_config).
+                for key, entry in input_files.items():
+                    if isinstance(entry, dict) and "variablePerColumn" in {
+                        entry.get("format"),
+                        entry.get("data_format"),
+                    }:
+                        raise ValueError(
+                            f"Config contains implicit-schema file '{key}': "
+                            "format 'variablePerColumn' is no longer supported. "
+                            "Migrate to explicit schema before loading. See "
+                            "https://docs.datacommons.org/custom_dc/custom_data.html "
+                            "for the explicit-schema format."
+                        )
+            elif isinstance(input_files, list):
+                # Current list format — key off filename or pattern for the message.
+                for entry in input_files:
+                    if isinstance(entry, dict) and "variablePerColumn" in {
+                        entry.get("format"),
+                        entry.get("data_format"),
+                    }:
+                        key = (
+                            entry.get("filename") or entry.get("pattern") or "<unknown>"
+                        )
+                        raise ValueError(
+                            f"Config contains implicit-schema file '{key}': "
+                            "format 'variablePerColumn' is no longer supported. "
+                            "Migrate to explicit schema before loading. See "
+                            "https://docs.datacommons.org/custom_dc/custom_data.html "
+                            "for the explicit-schema format."
+                        )
         return data
-
-    @model_validator(mode="after")
-    def validate_input_file_keys_are_csv(self) -> "Config":
-        """Validate that all input file keys are .csv files"""
-
-        for key in self.inputFiles:
-            if not key.lower().endswith(".csv"):
-                raise ValueError(f'Input file key "{key}" must be a .csv file name')
-        return self
-
-    @model_validator(mode="after")
-    def validate_provenance_in_sources(self) -> "Config":
-        """Validate that all input file provenances are in the sources section"""
-
-        known_provenances = set()
-        for source in self.sources.values():
-            known_provenances.update(source.provenances.keys())
-
-        # Validate that each InputFile provenance is among them
-        for file_key, input_file in self.inputFiles.items():
-            if input_file.provenance not in known_provenances:
-                raise ValueError(
-                    f'Input file "{file_key}" references unknown provenance "{input_file.provenance}".'
-                )
-
-        return self
 
     def validate_config(self) -> None:
         """Validate the config"""

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -1,6 +1,16 @@
 from typing import Annotated, Literal
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, StringConstraints
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+
+from dcp_tools.custom_data.models.common import mint_dcid
 
 
 class MCFFileName(BaseModel):
@@ -71,8 +81,17 @@ class ColumnMappings(BaseModel):
 class ExplicitSchemaFile(BaseModel):
     """Representation of an input file using the explicit (variable-per-row) schema.
 
+    Exactly one of ``filename`` or ``pattern`` must be set. The ``.csv``-suffix
+    check applies to ``filename`` only; ``pattern`` entries are exempt.
+
     Attributes:
-        provenance: Provenance of the data.
+        filename: Exact CSV file name (mutually exclusive with ``pattern``).
+        pattern: Glob pattern matching one or more input files (mutually exclusive
+            with ``filename``). Pattern entries are config-only: ``data=`` is not
+            accepted with ``pattern=``.
+        provenance: Provenance name for the data. Bare name is minted as
+            ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
+            use it verbatim. Names must be valid dcid tokens (no whitespace).
         ignoreColumns: List of columns to ignore.
         columnMappings: If headings in the CSV file do not use the default names,
             the equivalent names for each column.
@@ -80,6 +99,8 @@ class ExplicitSchemaFile(BaseModel):
             This attribute is represented as "format" in the JSON.
     """
 
+    filename: str | None = None
+    pattern: str | None = None
     provenance: str
     ignoreColumns: list[str] | None = None
     columnMappings: ColumnMappings
@@ -88,3 +109,16 @@ class ExplicitSchemaFile(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @field_validator("provenance", mode="after")
+    @classmethod
+    def _mint_provenance(cls, value: str) -> str:
+        return mint_dcid(prefix="provenance", name=value)
+
+    @model_validator(mode="after")
+    def _validate_filename_or_pattern(self) -> "ExplicitSchemaFile":
+        if (self.filename is None) == (self.pattern is None):
+            raise ValueError("Exactly one of 'filename' or 'pattern' must be set.")
+        if self.filename is not None and not self.filename.lower().endswith(".csv"):
+            raise ValueError(f'filename "{self.filename}" must have a .csv extension.')
+        return self

--- a/src/dcp_tools/custom_data/models/sources.py
+++ b/src/dcp_tools/custom_data/models/sources.py
@@ -14,13 +14,13 @@ class SourceMCFNode(MCFNode):
         description: Optional human-readable description.
 
         # Source-specific
-        typeOf: Fixed type indicating this is a Source (``dcs:Source``).
+        typeOf: Fixed type indicating this is a Source (``dcid:Source``).
         url: URL of the data source.
         license: Optional license information.
         isPartOf: Optional DCID of a parent source.
     """
 
-    typeOf: Literal["dcs:Source"] = "dcs:Source"
+    typeOf: Literal["dcid:Source"] = "dcid:Source"
     url: QuotedStr | None = None
     license: QuotedStr | None = None
     isPartOf: Dcid | None = None
@@ -36,7 +36,7 @@ class ProvenanceMCFNode(MCFNode):
         description: Optional human-readable description.
 
         # Provenance-specific
-        typeOf: Fixed type indicating this is a Provenance (``dcs:Provenance``).
+        typeOf: Fixed type indicating this is a Provenance (``dcid:Provenance``).
         url: URL of the provenance dataset.
         sourceLink: DCID of the parent Source node.
         license: Optional license information.
@@ -51,7 +51,7 @@ class ProvenanceMCFNode(MCFNode):
         isPartOf: Optional DCID of a parent provenance.
     """
 
-    typeOf: Literal["dcs:Provenance"] = "dcs:Provenance"
+    typeOf: Literal["dcid:Provenance"] = "dcid:Provenance"
     url: QuotedStr | None = None
     sourceLink: Dcid | None = None
     license: QuotedStr | None = None

--- a/src/dcp_tools/custom_data/models/sources.py
+++ b/src/dcp_tools/custom_data/models/sources.py
@@ -1,15 +1,66 @@
-from pydantic import BaseModel, ConfigDict, HttpUrl
+from typing import Literal
+
+from dcp_tools.custom_data.models.common import Dcid, QuotedStr
+from dcp_tools.custom_data.models.mcf import MCFNode
 
 
-class Source(BaseModel):
-    """Representation of the Sources section of the config file
+class SourceMCFNode(MCFNode):
+    """Represents a Source node for MCF.
 
     Attributes:
-        url: URL of the source.
-        provenances: Dictionary of provenances. Each provenance name maps to a URL.
+        # Inherited from MCFNode
+        Node: Identifier for the Node (minted as ``dcid:source/<name>``).
+        name: The human-readable name for the Node.
+        description: Optional human-readable description.
+
+        # Source-specific
+        typeOf: Fixed type indicating this is a Source (``dcs:Source``).
+        url: URL of the data source.
+        license: Optional license information.
+        isPartOf: Optional DCID of a parent source.
     """
 
-    url: HttpUrl
-    provenances: dict[str, HttpUrl]  # Each provenance name maps to a URL
+    typeOf: Literal["dcs:Source"] = "dcs:Source"
+    url: QuotedStr | None = None
+    license: QuotedStr | None = None
+    isPartOf: Dcid | None = None
 
-    model_config = ConfigDict(extra="forbid")
+
+class ProvenanceMCFNode(MCFNode):
+    """Represents a Provenance node for MCF.
+
+    Attributes:
+        # Inherited from MCFNode
+        Node: Identifier for the Node (minted as ``dcid:provenance/<name>``).
+        name: The human-readable name for the Node.
+        description: Optional human-readable description.
+
+        # Provenance-specific
+        typeOf: Fixed type indicating this is a Provenance (``dcs:Provenance``).
+        url: URL of the provenance dataset.
+        sourceLink: DCID of the parent Source node.
+        license: Optional license information.
+        licenseType: Optional license type.
+        lastDataRefreshDate: Optional date of last data refresh.
+        nextDataRefreshDate: Optional date of next expected data refresh.
+        nextSourceReleaseDate: Optional date of next source release.
+        sourceReleaseFrequency: Optional frequency of source releases.
+        earliestObservationDate: Optional earliest observation date in the dataset.
+        latestObservationDate: Optional latest observation date in the dataset.
+        curator: Optional curator of the dataset.
+        isPartOf: Optional DCID of a parent provenance.
+    """
+
+    typeOf: Literal["dcs:Provenance"] = "dcs:Provenance"
+    url: QuotedStr | None = None
+    sourceLink: Dcid | None = None
+    license: QuotedStr | None = None
+    licenseType: QuotedStr | None = None
+    lastDataRefreshDate: QuotedStr | None = None
+    nextDataRefreshDate: QuotedStr | None = None
+    nextSourceReleaseDate: QuotedStr | None = None
+    sourceReleaseFrequency: QuotedStr | None = None
+    earliestObservationDate: QuotedStr | None = None
+    latestObservationDate: QuotedStr | None = None
+    curator: QuotedStr | None = None
+    isPartOf: Dcid | None = None

--- a/src/dcp_tools/gcp_utilities/storage.py
+++ b/src/dcp_tools/gcp_utilities/storage.py
@@ -1,3 +1,4 @@
+import fnmatch
 import io
 import json
 import os
@@ -291,7 +292,13 @@ def get_unregistered_csv_files(
         config = Config.model_validate(config)
 
     registered = {e.filename for e in config.inputFiles if e.filename}
-    return [name for name in csv_files if name not in registered]
+    patterns = [e.pattern for e in config.inputFiles if e.pattern]
+    return [
+        name
+        for name in csv_files
+        if name not in registered
+        and not any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+    ]
 
 
 def get_missing_csv_files(

--- a/src/dcp_tools/gcp_utilities/storage.py
+++ b/src/dcp_tools/gcp_utilities/storage.py
@@ -290,7 +290,7 @@ def get_unregistered_csv_files(
     if isinstance(config, dict):
         config = Config.model_validate(config)
 
-    registered = set(config.inputFiles.keys())
+    registered = {e.filename for e in config.inputFiles if e.filename}
     return [name for name in csv_files if name not in registered]
 
 
@@ -331,7 +331,11 @@ def get_missing_csv_files(
         config = Config.model_validate(config)
 
     missing: list[str] = []
-    for name in config.inputFiles:
+    for entry in config.inputFiles:
+        name = entry.filename
+        if name is None:
+            # Pattern entries are globs, not single files — skip them.
+            continue
         path = Path(name)
         if path.suffix != ".csv":
             continue

--- a/tests/goldens/config.json
+++ b/tests/goldens/config.json
@@ -2,9 +2,10 @@
     "importName": "test_import",
     "includeInputSubdirs": true,
     "groupStatVarsByProperty": false,
-    "inputFiles": {
-        "a.csv": {
-            "provenance": "provA",
+    "inputFiles": [
+        {
+            "filename": "a.csv",
+            "provenance": "dcid:provenance/provA",
             "columnMappings": {
                 "dcid:observationAbout": "Country",
                 "dcid:observationDate": "Year",
@@ -12,8 +13,9 @@
             },
             "format": "variablePerRow"
         },
-        "b.csv": {
-            "provenance": "provB",
+        {
+            "filename": "b.csv",
+            "provenance": "dcid:provenance/provB",
             "columnMappings": {
                 "dcid:observationAbout": "Country",
                 "dcid:observationDate": "Year",
@@ -21,14 +23,5 @@
             },
             "format": "variablePerRow"
         }
-    },
-    "sources": {
-        "S1": {
-            "url": "http://source1/",
-            "provenances": {
-                "provA": "http://prova/",
-                "provB": "http://provb/"
-            }
-        }
-    }
+    ]
 }

--- a/tests/goldens/provenance.mcf
+++ b/tests/goldens/provenance.mcf
@@ -1,0 +1,14 @@
+Node: dcid:source/S1
+typeOf: dcs:Source
+url: "http://source1"
+
+Node: dcid:provenance/provA
+typeOf: dcs:Provenance
+url: "http://prova"
+sourceLink: dcid:source/S1
+
+Node: dcid:provenance/provB
+typeOf: dcs:Provenance
+url: "http://provb"
+sourceLink: dcid:source/S1
+

--- a/tests/goldens/provenance.mcf
+++ b/tests/goldens/provenance.mcf
@@ -1,14 +1,14 @@
 Node: dcid:source/S1
-typeOf: dcs:Source
+typeOf: dcid:Source
 url: "http://source1"
 
 Node: dcid:provenance/provA
-typeOf: dcs:Provenance
+typeOf: dcid:Provenance
 url: "http://prova"
 sourceLink: dcid:source/S1
 
 Node: dcid:provenance/provB
-typeOf: dcs:Provenance
+typeOf: dcid:Provenance
 url: "http://provb"
 sourceLink: dcid:source/S1
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -528,6 +528,26 @@ def test_export_all_requires_provenance_mcf(tmp_path):
     assert (tmp_path / "provenance.mcf").exists()
 
 
+def test_export_all_requires_linked_source_mcf(tmp_path):
+    """The guard follows sourceLink: a Source kept in a separate MCF file must be exported too."""
+    manager = CustomDataManager()
+    manager.add_source(name="s1", url="http://src", mcf_file_name="sources.mcf")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_explicit_schema_file(
+        file_name="data.csv", provenance="p1", data=pd.DataFrame({"A": [1]})
+    )
+
+    # Exporting only provenance.mcf leaves the sourceLink dangling -> raises, names sources.mcf.
+    with pytest.raises(ValueError, match=r"sources\.mcf"):
+        manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
+    assert not (tmp_path / "config.json").exists(), "must not write a partial bundle"
+
+    # Exporting both the provenance and its source file makes the bundle complete.
+    manager.export_all(tmp_path, mcf_file_names=["provenance.mcf", "sources.mcf"])
+    assert (tmp_path / "provenance.mcf").exists()
+    assert (tmp_path / "sources.mcf").exists()
+
+
 def test_loading_legacy_implicit_config_raises_with_message():
     """Loading a JSON config with variablePerColumn format raises ValueError with a clear message."""
     cfg = {

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -12,40 +12,99 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     ExplicitSchemaFile,
 )
-from dcp_tools.custom_data.models.sources import Source
 
 
 def test_custom_data_manager_add_provenance_and_override():
     """
-    Verifies provenance addition logic in CustomDataManager.
+    Verifies source/provenance addition logic in CustomDataManager.
     """
     manager = CustomDataManager()
-    with pytest.raises(ValueError):
-        manager.add_provenance(
-            provenance_name="pA", provenance_url="http://prov", source_name="new_source"
-        )
-    manager.add_provenance(
-        provenance_name="pA",
-        provenance_url="http://prov",
-        source_name="new_source",
-        source_url="http://src",
-    )
 
+    # add_provenance without a prior add_source must raise
     with pytest.raises(ValueError):
-        manager.add_provenance(
-            provenance_name="pA",
-            provenance_url="http://prov2",
-            source_name="new_source",
-        )
+        manager.add_provenance(name="pA", url="http://prov", source="new_source")
 
-    manager.add_provenance(
-        provenance_name="pA",
-        provenance_url="http://prov2",
-        source_name="new_source",
-        override=True,
+    # add_source then add_provenance succeeds
+    manager.add_source(name="new_source", url="http://src")
+    manager.add_provenance(name="pA", url="http://prov", source="new_source")
+
+    prov_nodes = manager._mcf_nodes["provenance.mcf"].nodes
+    source_node = next(
+        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcs:Source"
     )
-    src = manager._config.sources["new_source"]
-    assert src.provenances["pA"].unicode_string() == "http://prov2/"
+    prov_node = next(
+        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcs:Provenance"
+    )
+    assert source_node.Node == "dcid:source/new_source"
+    assert prov_node.Node == "dcid:provenance/pA"
+    assert prov_node.sourceLink == "dcid:source/new_source"
+
+    # duplicate provenance without override raises
+    with pytest.raises(ValueError):
+        manager.add_provenance(name="pA", url="http://prov2", source="new_source")
+
+    # override replaces the node
+    manager.add_provenance(
+        name="pA", url="http://prov2", source="new_source", override=True
+    )
+    updated_prov = next(
+        n
+        for n in manager._mcf_nodes["provenance.mcf"].nodes
+        if getattr(n, "typeOf", None) == "dcs:Provenance"
+    )
+    # url is stored raw; QuotedStr serialization wraps it in quotes at dump time
+    assert updated_prov.url == "http://prov2"
+    assert updated_prov.model_dump()["url"] == '"http://prov2"'
+
+
+def test_add_source_metadata_lands_on_node():
+    """Metadata kwargs on add_source are stored on the Source node."""
+    manager = CustomDataManager()
+    manager.add_source(
+        name="MySource",
+        url="http://mysource.org",
+        description="A test source",
+        license="CC-BY-4.0",
+    )
+    nodes = manager._mcf_nodes["provenance.mcf"].nodes
+    node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcs:Source")
+    assert node.Node == "dcid:source/MySource"
+    # QuotedStr fields are stored raw; quotes applied at serialization
+    assert node.description == "A test source"
+    assert node.license == "CC-BY-4.0"
+
+
+def test_add_provenance_metadata_lands_on_node():
+    """Metadata kwargs on add_provenance are stored on the Provenance node."""
+    manager = CustomDataManager()
+    manager.add_source(name="SrcX", url="http://srcx.org")
+    manager.add_provenance(
+        name="ProvX",
+        url="http://provx.org",
+        source="SrcX",
+        description="Prov desc",
+        lastDataRefreshDate="2024-01-01",
+    )
+    nodes = manager._mcf_nodes["provenance.mcf"].nodes
+    prov_node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcs:Provenance")
+    # QuotedStr fields are stored raw; quotes applied at serialization
+    assert prov_node.description == "Prov desc"
+    assert prov_node.lastDataRefreshDate == "2024-01-01"
+
+
+def test_validate_provenances_raises_for_unknown_provenance(tmp_path):
+    """An inputFile referencing a provenance with no matching node raises at export."""
+    manager = CustomDataManager()
+    # Register a file with a provenance that has no corresponding MCF node
+    manager._config.inputFiles.append(
+        ExplicitSchemaFile(
+            filename="x.csv",
+            provenance="dcid:provenance/ghost",
+            columnMappings=ColumnMappings(),
+        )
+    )
+    with pytest.raises(ValueError, match="ghost"):
+        manager.export_config(tmp_path)
 
 
 def test_set_additional_config_fields():
@@ -106,7 +165,8 @@ def test_add_explicit_schema_file_registration_and_override(tmp_path):
     and override/error behaviors.
     """
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df3 = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
     manager.add_explicit_schema_file(
@@ -115,7 +175,7 @@ def test_add_explicit_schema_file_registration_and_override(tmp_path):
         data=df3,
         columnMappings={"entity": "entity", "date": "Year", "value": "Value"},
     )
-    assert "exp.csv" in manager._config.inputFiles
+    assert any(e.filename == "exp.csv" for e in manager._config.inputFiles)
     assert "exp.csv" in manager._data
 
     with pytest.raises(ValueError):
@@ -141,14 +201,30 @@ def test_add_explicit_schema_file_registration_and_override(tmp_path):
 def test_add_explicit_schema_file_without_column_mappings():
     """Ensure missing columnMappings defaults to empty dict without error."""
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1]})
     manager.add_explicit_schema_file(file_name="exp.csv", provenance="p1", data=df)
 
-    assert "exp.csv" in manager._config.inputFiles
-    mappings = manager._config.inputFiles["exp.csv"].columnMappings
+    entry = next(e for e in manager._config.inputFiles if e.filename == "exp.csv")
+    mappings = entry.columnMappings
     assert mappings.model_dump(exclude_none=True) == {}
+
+
+def test_add_explicit_schema_file_pattern_xor_filename():
+    """add_explicit_schema_file raises when neither or both of file_name/pattern are given."""
+    manager = CustomDataManager()
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        manager.add_explicit_schema_file(provenance="p1")
+
+    with pytest.raises(ValueError, match="Exactly one"):
+        manager.add_explicit_schema_file(
+            file_name="a.csv", pattern="a*", provenance="p1"
+        )
 
 
 def test_export_methods(tmp_path):
@@ -156,7 +232,8 @@ def test_export_methods(tmp_path):
     Exercises export_config, export_data, and export_mcf_file.
     """
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"A": [1]})
     manager.add_explicit_schema_file(
         file_name="data.csv",
@@ -210,7 +287,7 @@ def test_config_round_trip(tmp_path):
     """
     Ensures a Config can be dumped to JSON and loaded back identically.
     """
-    cfg = Config(inputFiles={}, sources={})
+    cfg = Config(inputFiles=[])
     path = tmp_path / "cfg.json"
     path.write_text(cfg.model_dump_json())
     loaded = Config.from_json(str(path))
@@ -222,7 +299,8 @@ def test_custom_data_manager_repr():
     Sanity-check CustomDataManager.__repr__ for correct counts.
     """
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"A": [1]})
     manager.add_explicit_schema_file(
         file_name="f.csv",
@@ -235,12 +313,14 @@ def test_custom_data_manager_repr():
     assert "1 inputFiles" in r
     assert "1 containing data" in r
     assert "1 sources" in r
+    assert "1 provenances" in r
     assert "1 variables" in r
 
 
-def test_remove_indicator_and_provenance():
+def test_remove_indicator():
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1]})
     manager.add_explicit_schema_file(
@@ -258,70 +338,10 @@ def test_remove_indicator_and_provenance():
     with pytest.raises(ValueError):
         manager.remove_indicator("missing")
 
-    manager.add_variable_to_mcf(Node="dcid:sv2", name="Var2", provenance="p1")
-    manager.add_explicit_schema_file(file_name="b.csv", provenance="p1", data=df)
-
-    manager.remove_by_provenance("p1")
-
-    assert not any(
-        info.provenance == "p1" for info in manager._config.inputFiles.values()
-    )
-    assert "a.csv" not in manager._data and "b.csv" not in manager._data
-    for nodes in manager._mcf_nodes.values():
-        assert all(getattr(n, "provenance", None) != '"p1"' for n in nodes.nodes)
-
-    with pytest.raises(ValueError):
-        manager.remove_by_provenance("unknown")
-
-
-def test_remove_provenance_and_source_methods():
-    manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov1", "s1", source_url="http://src")
-    manager.add_provenance("p2", "http://prov2", "s1")
-
-    df = pd.DataFrame({"A": [1]})
-    manager.add_explicit_schema_file(
-        file_name="a.csv",
-        provenance="p1",
-        data=df,
-        columnMappings={"entity": "A"},
-    )
-    manager.add_explicit_schema_file(file_name="b.csv", provenance="p2", data=df)
-
-    manager.remove_provenance("p1")
-
-    # provenance removed from sources and data
-    assert "p1" not in manager._config.sources["s1"].provenances
-    assert "a.csv" not in manager._config.inputFiles
-    assert "a.csv" not in manager._data
-
-    manager.remove_by_source("s1")
-
-    # remaining provenance data removed but source still present
-    assert "b.csv" not in manager._config.inputFiles
-    assert "b.csv" not in manager._data
-    assert "s1" in manager._config.sources
-
-    # remove_source works on a fresh manager
-    manager2 = CustomDataManager()
-    manager2.add_provenance("p1", "http://prov", "s1", source_url="http://src")
-    manager2.add_explicit_schema_file(
-        file_name="c.csv",
-        provenance="p1",
-        data=df,
-        columnMappings={"entity": "A"},
-    )
-
-    manager2.remove_source("s1")
-
-    assert "s1" not in manager2._config.sources
-    assert "c.csv" not in manager2._config.inputFiles
-
 
 def _make_cfg(
     key: str,
     prov: str,
-    source: str,
     *,
     include_subdirs: bool | None = None,
     group_by_property: bool | None = None,
@@ -330,16 +350,15 @@ def _make_cfg(
     custom_svg_prefix: str | None = None,
     sv_blocklist: list[str] | None = None,
 ):
-    input_files = {
-        key: ExplicitSchemaFile(
+    input_files = [
+        ExplicitSchemaFile(
+            filename=key,
             provenance=prov,
             columnMappings=ColumnMappings(),
         )
-    }
-    sources = {source: Source(url="http://src", provenances={prov: "http://p"})}
+    ]
     return Config(
         inputFiles=input_files,
-        sources=sources,
         includeInputSubdirs=include_subdirs,
         groupStatVarsByProperty=group_by_property,
         defaultCustomRootStatVarGroupName=root_group_name,
@@ -355,7 +374,6 @@ def test_merge_configs_from_directory(tmp_path):
     cfg1 = _make_cfg(
         "a.csv",
         "p1",
-        "s",
         custom_namespace="ns",
         sv_blocklist=["measurementDenominator"],
     )
@@ -369,7 +387,6 @@ def test_merge_configs_from_directory(tmp_path):
     cfg2 = _make_cfg(
         "b.csv",
         "p2",
-        "s",
         custom_svg_prefix="ns/custom/",
     )
     (d2 / "config.json").write_text(
@@ -378,9 +395,8 @@ def test_merge_configs_from_directory(tmp_path):
 
     manager = CustomDataManager.from_config_files_in_directory(tmp_path)
 
-    assert set(manager._config.inputFiles.keys()) == {"a.csv", "b.csv"}
-    provs = manager._config.sources["s"].provenances
-    assert set(provs.keys()) == {"p1", "p2"}
+    filenames = {e.filename for e in manager._config.inputFiles}
+    assert filenames == {"a.csv", "b.csv"}
     assert manager._config.includeInputSubdirs is True
     assert manager._config.customIdNamespace == "ns"
     # Blocklist remains the one provided explicitly (none defined in the second config).
@@ -390,14 +406,14 @@ def test_merge_configs_from_directory(tmp_path):
 def test_merge_configs_duplicate_error(tmp_path):
     d1 = tmp_path / "one"
     d1.mkdir()
-    cfg1 = _make_cfg("a.csv", "p1", "s")
+    cfg1 = _make_cfg("a.csv", "p1")
     (d1 / "config.json").write_text(
         cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
 
     d2 = tmp_path / "two"
     d2.mkdir()
-    cfg2 = _make_cfg("a.csv", "p2", "s")
+    cfg2 = _make_cfg("a.csv", "p2")
     (d2 / "config.json").write_text(
         cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
@@ -409,16 +425,14 @@ def test_merge_configs_duplicate_error(tmp_path):
 def test_merge_configs_blocklist_override(tmp_path):
     d1 = tmp_path / "one"
     d1.mkdir()
-    cfg1 = _make_cfg(
-        "a.csv", "p1", "s", sv_blocklist=["measurementDenominator", "statType"]
-    )
+    cfg1 = _make_cfg("a.csv", "p1", sv_blocklist=["measurementDenominator", "statType"])
     (d1 / "config.json").write_text(
         cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
 
     d2 = tmp_path / "two"
     d2.mkdir()
-    cfg2 = _make_cfg("b.csv", "p2", "s", sv_blocklist=["statType", "unit"])
+    cfg2 = _make_cfg("b.csv", "p2", sv_blocklist=["statType", "unit"])
     (d2 / "config.json").write_text(
         cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
@@ -429,30 +443,6 @@ def test_merge_configs_blocklist_override(tmp_path):
 
     # When overriding, we take the latest list but still remove duplicates.
     assert manager._config.svHierarchyPropsBlocklist == ["statType", "unit"]
-
-
-def test_rename_provenance_updates_all_references():
-    manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov1", "s1", source_url="http://src")
-
-    df = pd.DataFrame({"A": [1]})
-    manager.add_explicit_schema_file(
-        file_name="a.csv",
-        provenance="p1",
-        data=df,
-        columnMappings={"entity": "A"},
-    )
-    manager.add_variable_to_mcf(Node="dcid:sv1", name="Var", provenance="p1")
-
-    manager.rename_provenance("p1", "pX")
-
-    assert "pX" in manager._config.sources["s1"].provenances
-    assert manager._config.inputFiles["a.csv"].provenance == "pX"
-    for nodes in manager._mcf_nodes.values():
-        assert any(getattr(n, "provenance", None) == '"pX"' for n in nodes.nodes)
-
-    with pytest.raises(ValueError):
-        manager.rename_provenance("pX", "pX")
 
 
 def test_rename_variable_mcf_only():
@@ -476,24 +466,11 @@ def test_rename_variable_mcf_only():
         manager.rename_variable("dcid:v2", "dcid:v3")
 
 
-def test_rename_source():
-    """rename_source correctly updates the config sources dict."""
-    manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov1", "s1", source_url="http://src")
-
-    manager.rename_source("s1", "s2")
-    assert "s2" in manager._config.sources and "s1" not in manager._config.sources
-
-    with pytest.raises(ValueError):
-        manager.rename_source("unknown", "x")
-    with pytest.raises(ValueError):
-        manager.rename_source("s2", "s2")
-
-
 def test_validate_all_input_files_have_data(tmp_path):
     """Verify the optional data-completeness validation on export_all and the standalone method."""
     manager = CustomDataManager()
-    manager.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1, 2]})
 
@@ -512,15 +489,8 @@ def test_validate_all_input_files_have_data(tmp_path):
     with pytest.raises(ValueError, match=r"no_data\.csv"):
         manager.validate_all_input_files_have_data()
 
-    # export_all without validate_data=True should NOT raise (default off)
-    # It will raise because export_data needs at least one file — so just confirm
-    # validate_data=False doesn't surface the missing-data error
-    try:
-        manager.export_all(tmp_path, validate_data=False)
-    except ValueError as exc:
-        assert "no_data.csv" not in str(exc), (
-            "validate_data=False should not raise about missing data"
-        )
+    # validate_data=False does not surface the missing-data error
+    manager.export_all(tmp_path, validate_data=False, mcf_file_names=["provenance.mcf"])
 
     # export_all with validate_data=True should raise before writing anything
     with pytest.raises(ValueError, match=r"no_data\.csv"):
@@ -530,10 +500,32 @@ def test_validate_all_input_files_have_data(tmp_path):
     manager.add_data(df, "no_data.csv")
     manager.validate_all_input_files_have_data()  # should not raise
 
-    manager.export_all(tmp_path, validate_data=True)  # should not raise
+    manager.export_all(
+        tmp_path, validate_data=True, mcf_file_names=["provenance.mcf"]
+    )  # should not raise
     assert (tmp_path / "config.json").exists()
     assert (tmp_path / "with_data.csv").exists()
     assert (tmp_path / "no_data.csv").exists()
+
+
+def test_export_all_requires_provenance_mcf(tmp_path):
+    """export_all raises (before writing) if a referenced provenance's MCF file is omitted."""
+    manager = CustomDataManager()
+    manager.add_source(name="s1", url="http://src")
+    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_explicit_schema_file(
+        file_name="data.csv", provenance="p1", data=pd.DataFrame({"A": [1]})
+    )
+
+    # Omitting mcf_file_names would ship a config.json referencing a node not on disk.
+    with pytest.raises(ValueError, match=r"provenance\.mcf"):
+        manager.export_all(tmp_path)
+    assert not (tmp_path / "config.json").exists(), "must not write a partial bundle"
+
+    # Listing the provenance MCF file makes the bundle complete.
+    manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
+    assert (tmp_path / "config.json").exists()
+    assert (tmp_path / "provenance.mcf").exists()
 
 
 def test_loading_legacy_implicit_config_raises_with_message():

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -30,10 +30,10 @@ def test_custom_data_manager_add_provenance_and_override():
 
     prov_nodes = manager._mcf_nodes["provenance.mcf"].nodes
     source_node = next(
-        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcs:Source"
+        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcid:Source"
     )
     prov_node = next(
-        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcs:Provenance"
+        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
     )
     assert source_node.Node == "dcid:source/new_source"
     assert prov_node.Node == "dcid:provenance/pA"
@@ -50,7 +50,7 @@ def test_custom_data_manager_add_provenance_and_override():
     updated_prov = next(
         n
         for n in manager._mcf_nodes["provenance.mcf"].nodes
-        if getattr(n, "typeOf", None) == "dcs:Provenance"
+        if getattr(n, "typeOf", None) == "dcid:Provenance"
     )
     # url is stored raw; QuotedStr serialization wraps it in quotes at dump time
     assert updated_prov.url == "http://prov2"
@@ -67,7 +67,7 @@ def test_add_source_metadata_lands_on_node():
         license="CC-BY-4.0",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcs:Source")
+    node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcid:Source")
     assert node.Node == "dcid:source/MySource"
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert node.description == "A test source"
@@ -86,7 +86,9 @@ def test_add_provenance_metadata_lands_on_node():
         lastDataRefreshDate="2024-01-01",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    prov_node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcs:Provenance")
+    prov_node = next(
+        n for n in nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
+    )
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert prov_node.description == "Prov desc"
     assert prov_node.lastDataRefreshDate == "2024-01-01"

--- a/tests/test_explicit_path_characterization.py
+++ b/tests/test_explicit_path_characterization.py
@@ -18,7 +18,6 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     ExplicitSchemaFile,
 )
-from dcp_tools.custom_data.models.sources import Source
 from dcp_tools.gcp_utilities.storage import (
     get_missing_csv_files,
     get_unregistered_csv_files,
@@ -32,7 +31,8 @@ from dcp_tools.gcp_utilities.storage import (
 def _explicit_manager(file_name="exp.csv", *, with_data=True):
     """Manager with one source + one explicit-schema file (optionally with data)."""
     mgr = CustomDataManager()
-    mgr.add_provenance("p1", "http://prov", "s1", source_url="http://src")
+    mgr.add_source(name="s1", url="http://src")
+    mgr.add_provenance(name="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
     mgr.add_explicit_schema_file(
         file_name=file_name,
@@ -46,7 +46,6 @@ def _explicit_manager(file_name="exp.csv", *, with_data=True):
 def _make_explicit_cfg(
     key: str,
     prov: str,
-    source: str,
     *,
     include_subdirs=None,
     custom_namespace=None,
@@ -54,16 +53,15 @@ def _make_explicit_cfg(
     sv_blocklist=None,
 ):
     """Build a minimal Config with one ExplicitSchemaFile."""
-    input_files = {
-        key: ExplicitSchemaFile(
+    input_files = [
+        ExplicitSchemaFile(
+            filename=key,
             provenance=prov,
             columnMappings=ColumnMappings(entity="Country", date="Year", value="Val"),
         )
-    }
-    sources = {source: Source(url="http://src", provenances={prov: "http://p"})}
+    ]
     return Config(
         inputFiles=input_files,
-        sources=sources,
         includeInputSubdirs=include_subdirs,
         customIdNamespace=custom_namespace,
         customSvgPrefix=custom_svg_prefix,
@@ -77,13 +75,12 @@ def _make_explicit_cfg(
 
 
 def test_add_explicit_schema_file_registers_in_config_and_data():
-    """B1 — add_explicit_schema_file registers file in config and data store."""
+    """add_explicit_schema_file registers file in config and data store."""
     manager, df = _explicit_manager()
 
-    assert "exp.csv" in manager._config.inputFiles
-    entry = manager._config.inputFiles["exp.csv"]
+    entry = next(e for e in manager._config.inputFiles if e.filename == "exp.csv")
     assert isinstance(entry, ExplicitSchemaFile)
-    assert entry.provenance == "p1"
+    assert entry.provenance == "dcid:provenance/p1"
     assert entry.columnMappings.entity == "entity"
     assert entry.columnMappings.date == "Year"
     assert entry.columnMappings.value == "Value"
@@ -94,7 +91,7 @@ def test_add_explicit_schema_file_registers_in_config_and_data():
 
 
 def test_add_explicit_schema_file_override_and_duplicate_error():
-    """B1 — re-adding the same file_name without override raises ValueError;
+    """Re-adding the same file_name without override raises ValueError;
     with override=True the data is replaced."""
     manager, _ = _explicit_manager()
 
@@ -116,7 +113,7 @@ def test_add_explicit_schema_file_override_and_duplicate_error():
 
 
 def test_add_data_standalone_success_and_error():
-    """B6 — standalone add_data: success path, duplicate error, override, unregistered error."""
+    """Standalone add_data: success path, duplicate error, override, unregistered error."""
     manager, _ = _explicit_manager(with_data=False)
 
     # Data was not supplied at registration time
@@ -143,7 +140,7 @@ def test_add_data_standalone_success_and_error():
 
 
 def test_export_config_round_trip_explicit(tmp_path):
-    """B5 — export_config writes config.json; Config.from_json reloads it correctly."""
+    """export_config writes config.json; Config.from_json reloads it correctly."""
     manager, _ = _explicit_manager()
 
     manager.export_config(tmp_path)
@@ -154,17 +151,18 @@ def test_export_config_round_trip_explicit(tmp_path):
     loaded = Config.from_json(str(config_file))
     assert isinstance(loaded, Config)
 
-    mappings = loaded.inputFiles["exp.csv"].columnMappings
+    entry = next(e for e in loaded.inputFiles if e.filename == "exp.csv")
+    mappings = entry.columnMappings
     assert mappings.model_dump(exclude_none=True) == {
         "entity": "entity",
         "date": "Year",
         "value": "Value",
     }
-    assert loaded.inputFiles["exp.csv"].data_format == "variablePerRow"
+    assert entry.data_format == "variablePerRow"
 
 
 def test_config_to_dict_explicit_shape():
-    """B5 — config_to_dict returns the expected serialized shape for the explicit path.
+    """config_to_dict returns the expected serialized shape for the explicit path.
 
     Pins the key names and values for the explicit path. The keys use the
     DC-import aliases: 'format' for the data format and the 'dcid:' predicate
@@ -173,10 +171,12 @@ def test_config_to_dict_explicit_shape():
     manager, _ = _explicit_manager()
 
     d = manager.config_to_dict()
-    entry = d["inputFiles"]["exp.csv"]
+    entries = d["inputFiles"]
+    entry = next(e for e in entries if e.get("filename") == "exp.csv")
 
     expected = {
-        "provenance": "p1",
+        "filename": "exp.csv",
+        "provenance": "dcid:provenance/p1",
         "format": "variablePerRow",
         "columnMappings": {
             "dcid:observationAbout": "entity",
@@ -188,7 +188,7 @@ def test_config_to_dict_explicit_shape():
 
 
 def test_export_mcf_file_explicit_path(tmp_path):
-    """B8 (light pin) — variable added via add_variable_to_mcf appears in exported MCF."""
+    """variable added via add_variable_to_mcf appears in exported MCF."""
     manager, _ = _explicit_manager()
     manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
 
@@ -205,43 +205,46 @@ def test_export_mcf_file_explicit_path(tmp_path):
 
 
 def test_explicit_schema_file_default_format():
-    """B2 — ExplicitSchemaFile defaults data_format to 'variablePerRow';
+    """ExplicitSchemaFile defaults data_format to 'variablePerRow';
     by_alias serialization uses key 'format'."""
-    ef = ExplicitSchemaFile(provenance="p", columnMappings=ColumnMappings())
+    ef = ExplicitSchemaFile(
+        filename="a.csv",
+        provenance="p",
+        columnMappings=ColumnMappings(),
+    )
 
     assert ef.data_format == "variablePerRow"
     assert ef.model_dump(by_alias=True)["format"] == "variablePerRow"
 
 
 def test_config_build_and_from_json_round_trip_explicit(tmp_path):
-    """B2 — an explicit-only Config survives a serialize → deserialize cycle."""
+    """An explicit-only Config survives a serialize → deserialize cycle."""
     cfg = Config(
-        inputFiles={
-            "a.csv": ExplicitSchemaFile(
+        inputFiles=[
+            ExplicitSchemaFile(
+                filename="a.csv",
                 provenance="p",
                 columnMappings=ColumnMappings(
                     entity="Country", date="Year", value="Val"
                 ),
             )
-        },
-        sources={"s": Source(url="http://s", provenances={"p": "http://p"})},
+        ],
     )
 
     path = tmp_path / "cfg.json"
-    path.write_text(cfg.model_dump_json())
+    path.write_text(cfg.model_dump_json(by_alias=True))
 
     loaded = Config.from_json(str(path))
     assert loaded.model_dump() == cfg.model_dump()
 
 
 def test_merge_configs_from_directory_explicit(tmp_path):
-    """B7 — from_config_files_in_directory merges two explicit-only configs correctly."""
+    """from_config_files_in_directory merges two explicit-only configs correctly."""
     d1 = tmp_path / "one"
     d1.mkdir()
     cfg1 = _make_explicit_cfg(
         "a.csv",
         "p1",
-        "s",
         custom_namespace="ns",
         sv_blocklist=["measurementDenominator"],
     )
@@ -254,7 +257,6 @@ def test_merge_configs_from_directory_explicit(tmp_path):
     cfg2 = _make_explicit_cfg(
         "b.csv",
         "p2",
-        "s",
         custom_svg_prefix="ns/custom/",
     )
     (d2 / "config.json").write_text(
@@ -263,23 +265,22 @@ def test_merge_configs_from_directory_explicit(tmp_path):
 
     manager = CustomDataManager.from_config_files_in_directory(tmp_path)
 
-    assert set(manager._config.inputFiles.keys()) == {"a.csv", "b.csv"}
-    provs = manager._config.sources["s"].provenances
-    assert set(provs.keys()) == {"p1", "p2"}
+    filenames = {e.filename for e in manager._config.inputFiles}
+    assert filenames == {"a.csv", "b.csv"}
 
 
 def test_merge_configs_from_directory_explicit_duplicate_error(tmp_path):
-    """B7 — from_config_files_in_directory raises ValueError on duplicate keys."""
+    """from_config_files_in_directory raises ValueError on duplicate keys."""
     d1 = tmp_path / "one"
     d1.mkdir()
-    cfg1 = _make_explicit_cfg("a.csv", "p1", "s")
+    cfg1 = _make_explicit_cfg("a.csv", "p1")
     (d1 / "config.json").write_text(
         cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
 
     d2 = tmp_path / "two"
     d2.mkdir()
-    cfg2 = _make_explicit_cfg("a.csv", "p2", "s")
+    cfg2 = _make_explicit_cfg("a.csv", "p2")
     (d2 / "config.json").write_text(
         cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
@@ -289,18 +290,18 @@ def test_merge_configs_from_directory_explicit_duplicate_error(tmp_path):
 
 
 def test_get_unregistered_and_missing_csv_files_explicit():
-    """B9 — get_unregistered_csv_files and get_missing_csv_files work with
-    an explicit-only Config (depend only on inputFiles.keys(), schema-agnostic)."""
+    """get_unregistered_csv_files and get_missing_csv_files work with
+    an explicit-only Config (depend only on inputFiles, schema-agnostic)."""
     cfg = Config(
-        inputFiles={
-            "a.csv": ExplicitSchemaFile(
+        inputFiles=[
+            ExplicitSchemaFile(
+                filename="a.csv",
                 provenance="p",
                 columnMappings=ColumnMappings(
                     entity="Country", date="Year", value="Val"
                 ),
             )
-        },
-        sources={"s": Source(url="http://src", provenances={"p": "http://p"})},
+        ],
     )
 
     # --- get_unregistered_csv_files ---
@@ -316,9 +317,12 @@ def test_get_unregistered_and_missing_csv_files_explicit():
     assert unregistered == ["extra.csv"]
 
     # --- get_missing_csv_files ---
-    cfg.inputFiles["extra.csv"] = ExplicitSchemaFile(
-        provenance="p",
-        columnMappings=ColumnMappings(entity="Country", date="Year", value="Val"),
+    cfg.inputFiles.append(
+        ExplicitSchemaFile(
+            filename="extra.csv",
+            provenance="p",
+            columnMappings=ColumnMappings(entity="Country", date="Year", value="Val"),
+        )
     )
 
     bucket2 = Mock()

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -30,6 +30,10 @@ def test_config_json_snapshot(tmp_path):
     manager.set_importName("test_import")
     manager.set_includeInputSubdirs(True).set_groupStatVarsByProperty(False)
 
+    manager.add_source(name="S1", url="http://source1")
+    manager.add_provenance(name="provA", url="http://prova", source="S1")
+    manager.add_provenance(name="provB", url="http://provb", source="S1")
+
     manager.add_explicit_schema_file(
         "a.csv",
         provenance="provA",
@@ -40,14 +44,24 @@ def test_config_json_snapshot(tmp_path):
         provenance="provB",
         columnMappings={"entity": "Country", "date": "Year", "value": "Val"},
     )
-    # add sources
-    manager.add_provenance("provA", "http://prova/", "S1", source_url="http://source1/")
-    manager.add_provenance("provB", "http://provb/", "S1", source_url="http://source1/")
 
     # export
     manager.export_config(str(tmp_path))
     got = json.loads(Path(tmp_path / "config.json").read_text())
     expected = json.loads((GOLDEN_DIR / "config.json").read_text())
+    assert "sources" not in got
+    assert got == expected
+
+
+def test_provenance_mcf_snapshot(tmp_path):
+    manager = CustomDataManager()
+    manager.add_source(name="S1", url="http://source1")
+    manager.add_provenance(name="provA", url="http://prova", source="S1")
+    manager.add_provenance(name="provB", url="http://provb", source="S1")
+
+    manager.export_mfc_file(str(tmp_path), mcf_file_name="provenance.mcf")
+    got = (tmp_path / "provenance.mcf").read_text()
+    expected = (GOLDEN_DIR / "provenance.mcf").read_text()
     assert got == expected
 
 

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic import BaseModel
 
 from dcp_tools.custom_data.models.common import (
@@ -5,6 +6,7 @@ from dcp_tools.custom_data.models.common import (
     _ensure_quoted,
     mcf_quoted_str,
     mcf_str,
+    mint_dcid,
     parse_str_or_list,
 )
 
@@ -66,3 +68,26 @@ def test_str_or_list_str_annotation_serialization():
 def test_parse_str_or_list_honours_quotes():
     assert parse_str_or_list('"A, B"') == "A, B"
     assert parse_str_or_list('"A, B", C') == ["A, B", "C"]
+
+
+def test_mint_dcid_three_way_rule():
+    """Covers each branch of the canonical minting rule."""
+    # Bare name -> dcid:<prefix>/<name> (the real source/provenance callers)
+    assert mint_dcid(prefix="source", name="CustomSource") == "dcid:source/CustomSource"
+    assert mint_dcid(prefix="provenance", name="CustomProv") == "dcid:provenance/CustomProv"
+    # Already dcid:-prefixed -> returned verbatim (escape hatch)
+    assert mint_dcid(prefix="source", name="dcid:bio/y") == "dcid:bio/y"
+    # Contains "/" but no dcid: -> prepended with dcid:
+    assert mint_dcid(prefix="source", name="source/Foo") == "dcid:source/Foo"
+
+
+def test_mint_dcid_rejects_empty_or_whitespace_names():
+    """Empty or whitespace-bearing names violate the strict contract."""
+    with pytest.raises(ValueError):
+        mint_dcid(prefix="source", name="")
+    with pytest.raises(ValueError):
+        mint_dcid(prefix="source", name="has space")
+    with pytest.raises(ValueError):
+        mint_dcid(prefix="source", name="  leading")
+    with pytest.raises(ValueError):
+        mint_dcid(prefix="source", name="trailing\t")

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -74,7 +74,10 @@ def test_mint_dcid_three_way_rule():
     """Covers each branch of the canonical minting rule."""
     # Bare name -> dcid:<prefix>/<name> (the real source/provenance callers)
     assert mint_dcid(prefix="source", name="CustomSource") == "dcid:source/CustomSource"
-    assert mint_dcid(prefix="provenance", name="CustomProv") == "dcid:provenance/CustomProv"
+    assert (
+        mint_dcid(prefix="provenance", name="CustomProv")
+        == "dcid:provenance/CustomProv"
+    )
     # Already dcid:-prefixed -> returned verbatim (escape hatch)
     assert mint_dcid(prefix="source", name="dcid:bio/y") == "dcid:bio/y"
     # Contains "/" but no dcid: -> prepended with dcid:

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -1,31 +1,74 @@
 import pytest
 
 from dcp_tools.custom_data.models.config_file import Config
+from dcp_tools.custom_data.models.data_files import ColumnMappings, ExplicitSchemaFile
 
 
-def test_config_validators_raise_on_invalid_input_files(tmp_path):
+def test_config_validators_raise_on_invalid_input_files():
     """
-    Validates that non-CSV file keys and unknown provenances cause errors.
+    Validates that a non-CSV filename causes an error on ExplicitSchemaFile construction.
     """
-    # Non-CSV file extension
-    config1 = tmp_path / "config1.json"
-    config1.write_text(
-        '{"inputFiles": {"data.txt": {"provenance": "p1"}},'
-        ' "sources": {"s1": {"url": "http://example.com",'
-        ' "provenances": {"p1": "http://ex.com"}}}}'
-    )
     with pytest.raises(ValueError):
-        Config.from_json(str(config1))
+        ExplicitSchemaFile(
+            filename="data.txt",
+            provenance="p1",
+            columnMappings=ColumnMappings(),
+        )
 
-    # Unknown provenance reference
-    config2 = tmp_path / "config2.json"
-    config2.write_text(
-        '{"inputFiles": {"data.csv": {"provenance": "unknown"}},'
-        ' "sources": {"s1": {"url": "http://example.com",'
-        ' "provenances": {"p1": "http://ex.com"}}}}'
-    )
+
+def test_explicit_schema_file_filename_pattern_xor():
+    """Exactly one of filename/pattern must be set; providing both or neither raises."""
+    # Neither provided
     with pytest.raises(ValueError):
-        Config.from_json(str(config2))
+        ExplicitSchemaFile(
+            provenance="p1",
+            columnMappings=ColumnMappings(),
+        )
+
+    # Both provided
+    with pytest.raises(ValueError):
+        ExplicitSchemaFile(
+            filename="a.csv",
+            pattern="a*",
+            provenance="p1",
+            columnMappings=ColumnMappings(),
+        )
+
+    # filename only — valid
+    ef = ExplicitSchemaFile(
+        filename="a.csv",
+        provenance="p1",
+        columnMappings=ColumnMappings(),
+    )
+    assert ef.filename == "a.csv"
+    assert ef.pattern is None
+
+    # pattern only — valid (no .csv check on pattern)
+    ep = ExplicitSchemaFile(
+        pattern="data_*",
+        provenance="p1",
+        columnMappings=ColumnMappings(),
+    )
+    assert ep.pattern == "data_*"
+    assert ep.filename is None
+
+
+def test_explicit_schema_file_provenance_minted():
+    """ExplicitSchemaFile mints the provenance to dcid:provenance/<name>."""
+    ef = ExplicitSchemaFile(
+        filename="a.csv",
+        provenance="myProv",
+        columnMappings=ColumnMappings(),
+    )
+    assert ef.provenance == "dcid:provenance/myProv"
+
+    # Already-minted provenance is returned verbatim
+    ef2 = ExplicitSchemaFile(
+        filename="b.csv",
+        provenance="dcid:provenance/myProv",
+        columnMappings=ColumnMappings(),
+    )
+    assert ef2.provenance == "dcid:provenance/myProv"
 
 
 def test_config_round_trips_import_name(tmp_path):
@@ -33,9 +76,8 @@ def test_config_round_trips_import_name(tmp_path):
     config = tmp_path / "config.json"
     config.write_text(
         '{"importName": "OECD_wage_data",'
-        ' "inputFiles": {"data.csv": {"provenance": "p1", "columnMappings": {}}},'
-        ' "sources": {"s1": {"url": "http://example.com",'
-        ' "provenances": {"p1": "http://ex.com"}}}}'
+        ' "inputFiles": [{"filename": "data.csv", "provenance": "p1", "columnMappings": {},'
+        ' "format": "variablePerRow"}]}'
     )
     loaded = Config.from_json(str(config))
     assert loaded.importName == "OECD_wage_data"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -8,7 +8,6 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     ExplicitSchemaFile,
 )
-from dcp_tools.custom_data.models.sources import Source
 from dcp_tools.gcp_utilities.settings import KGSettings
 from dcp_tools.gcp_utilities.storage import (
     delete_bucket_files,
@@ -22,14 +21,15 @@ from dcp_tools.gcp_utilities.storage import (
 
 
 def _minimal_config(key: str = "a.csv") -> Config:
-    input_files = {
-        key: ExplicitSchemaFile(
-            provenance="prov",
-            columnMappings=ColumnMappings(),
-        )
-    }
-    sources = {"src": Source(url="http://s", provenances={"prov": "http://p"})}
-    return Config(inputFiles=input_files, sources=sources)
+    return Config(
+        inputFiles=[
+            ExplicitSchemaFile(
+                filename=key,
+                provenance="prov",
+                columnMappings=ColumnMappings(),
+            )
+        ]
+    )
 
 
 def test_upload_directory_to_gcs(tmp_path):
@@ -336,9 +336,12 @@ def test_get_missing_csv_files():
     bucket.list_blobs.return_value = [blob_a]
 
     cfg = _minimal_config()
-    cfg.inputFiles["extra.csv"] = ExplicitSchemaFile(
-        provenance="prov",
-        columnMappings=ColumnMappings(),
+    cfg.inputFiles.append(
+        ExplicitSchemaFile(
+            filename="extra.csv",
+            provenance="prov",
+            columnMappings=ColumnMappings(),
+        )
     )
 
     missing = get_missing_csv_files(bucket, cfg, gcs_folder_name="folder")
@@ -353,9 +356,12 @@ def test_get_missing_csv_files_with_prefix_added():
     bucket.list_blobs.return_value = [blob_a]
 
     cfg = _minimal_config("sub/a.csv")
-    cfg.inputFiles["sub/b.csv"] = ExplicitSchemaFile(
-        provenance="prov",
-        columnMappings=ColumnMappings(),
+    cfg.inputFiles.append(
+        ExplicitSchemaFile(
+            filename="sub/b.csv",
+            provenance="prov",
+            columnMappings=ColumnMappings(),
+        )
     )
 
     missing = get_missing_csv_files(bucket, cfg, gcs_folder_name="prefix")
@@ -392,9 +398,12 @@ def test_get_missing_csv_files_per_import():
     bucket.name = "my-bucket"
 
     cfg = _minimal_config("a.csv")
-    cfg.inputFiles["b.csv"] = ExplicitSchemaFile(
-        provenance="prov",
-        columnMappings=ColumnMappings(),
+    cfg.inputFiles.append(
+        ExplicitSchemaFile(
+            filename="b.csv",
+            provenance="prov",
+            columnMappings=ColumnMappings(),
+        )
     )
 
     result = get_missing_csv_files(
@@ -412,9 +421,12 @@ def test_registration_checks_fresh_import_empty_prefix():
     bucket.name = "my-bucket"
 
     cfg = _minimal_config("a.csv")
-    cfg.inputFiles["b.csv"] = ExplicitSchemaFile(
-        provenance="prov",
-        columnMappings=ColumnMappings(),
+    cfg.inputFiles.append(
+        ExplicitSchemaFile(
+            filename="b.csv",
+            provenance="prov",
+            columnMappings=ColumnMappings(),
+        )
     )
 
     unregistered = get_unregistered_csv_files(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -313,6 +313,31 @@ def test_get_unregistered_csv_files():
     assert missing == ["extra.csv"]
 
 
+def test_get_unregistered_csv_files_honors_patterns():
+    """Files matched by an inputFile ``pattern`` count as registered, not unregistered."""
+    bucket = Mock()
+    matched = Mock()
+    matched.name = "folder/data_2024.csv"
+    stray = Mock()
+    stray.name = "folder/other.csv"
+    bucket.list_blobs.return_value = [matched, stray]
+    bucket.name = "my-bucket"
+
+    cfg = Config(
+        inputFiles=[
+            ExplicitSchemaFile(
+                pattern="data_*.csv",
+                provenance="prov",
+                columnMappings=ColumnMappings(),
+            )
+        ]
+    )
+
+    # data_2024.csv matches the glob -> registered; only the non-matching file is unregistered.
+    missing = get_unregistered_csv_files(bucket, cfg, gcs_folder_name="folder")
+    assert missing == ["other.csv"]
+
+
 def test_get_unregistered_csv_files_with_prefix_removed():
     bucket = Mock()
     blob_a = Mock()


### PR DESCRIPTION
## What

Implements #107: emit first-class MCF `Source`/`Provenance` nodes and list-format `inputFiles` with `dcid:` provenance references so generated bundles pass DCP strict mode (`DATA_RUN_MODE=dcpbridge`), plus the richer Source/Provenance metadata the platform surfaces through Mixer's `GetVariableMetadata`.

**Breaking change.** The legacy `sources{}` shorthand and the old `add_provenance(...)` signature are removed (not deprecated-in-place).

### New API
- `add_source(*, name, url, …)` and `add_provenance(*, name, url, source, …)` build MCF nodes (`dcid:source/<name>`, `dcid:provenance/<name>`, `typeOf: dcs:Source`/`dcs:Provenance`, `sourceLink`) into a default `provenance.mcf`. A bare name is minted to a `dcid:` id; an already-namespaced value is used verbatim.
- 11 optional metadata kwargs on the builders (license, licenseType, refresh/release/observation dates, curator, isPartOf, …) plus an `additional_properties` escape hatch.
- `add_explicit_schema_file` gains a `pattern` kwarg (config-only, mutually exclusive with `file_name`).
- `inputFiles` is now a JSON list; each entry's `provenance` serializes as `dcid:provenance/<name>`.
- `export_all` fails fast (before writing anything) if an input file references a provenance whose MCF file is not in `mcf_file_names`, so a partial bundle can never reach disk. `export_config` stays guard-free as the "config now, MCF later" escape hatch.

### Removed (breaking)
`Config.sources`, the `Source` model, the old `add_provenance(provenance_name, provenance_url, source_name, source_url)`, and `rename_source` / `remove_source` / `rename_provenance` / `remove_by_source` / `remove_by_provenance`. The provenance↔node integrity check moved from `Config` to `CustomDataManager`.

## Testing
- `uv run ruff format --check`, `ruff check`, `ty check` all clean; `uv run pytest` → **106 passed**.
- Goldens regenerated from real export output; the bundle matches the importer's `single_entity_official_keys` fixture shape (list `inputFiles`, `dcid:` refs, `provenance.mcf` with Source/Provenance, no `sources{}`).
- Confirmed by tracing `datacommonsorg/import` that the strict validator normalizes the `dcs:` namespace on `typeOf` (`kg_util/mcf_parser.py` strips it before any triple reaches validation), so the emitted `dcs:Source`/`dcs:Provenance` form passes.

## Remaining verification (not blocking this PR)
Two of the issue's acceptance criteria live downstream of this repo: end-to-end "passes `DCP_BRIDGE` strict validation" and "metadata surfaces through `GetVariableMetadata`". They're verified here only by fixture-shape matching plus the validator code trace above; a final confirmation by running a generated bundle through the real `dcpbridge` importer / Mixer is recommended before relying on it in production. A local pre-flight check is tracked separately in #110.

Co-authored-by: Claude <noreply@anthropic.com>
