### PR TITLE
feat(custom_data): support remaining config.json fields

### DIFF
--- a/src/dcp_tools/custom_data/config_utils.py
+++ b/src/dcp_tools/custom_data/config_utils.py
@@ -31,6 +31,7 @@ def _merge_simple_attrs(existing: Config, new: Config, policy: DuplicatePolicy) 
         "defaultCustomRootStatVarGroupName",
         "customIdNamespace",
         "customSvgPrefix",
+        "verticalSpecsFile",
     ):
         _merge_attribute(existing, new, attr, policy)
 
@@ -38,6 +39,13 @@ def _merge_simple_attrs(existing: Config, new: Config, policy: DuplicatePolicy) 
         existing=existing,
         new=new,
         attribute="svHierarchyPropsBlocklist",
+        policy=policy,
+    )
+
+    _merge_sequence_attribute(
+        existing=existing,
+        new=new,
+        attribute="dataDownloadUrl",
         policy=policy,
     )
 

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
 from os import PathLike
 from pathlib import Path
@@ -29,6 +30,7 @@ from dcp_tools.custom_data.models.stat_vars import (
     StatVarGroupMCFNode,
     StatVarMCFNode,
 )
+from dcp_tools.custom_data.models.vertical_specs import VerticalSpec
 from dcp_tools.custom_data.schema_tools import (
     build_stat_var_groups_from_strings,
     csv_metadata_to_nodes,
@@ -38,6 +40,7 @@ from dcp_tools.custom_data.schema_tools import (
 DEFAULT_STATVAR_MCF_NAME: str = "custom_nodes.mcf"
 DEFAULT_GROUP_NAME: str = "custom_groups.mcf"
 DEFAULT_PROVENANCE_MCF_NAME: str = "provenance.mcf"
+DEFAULT_VERTICAL_SPECS_NAME: str = "vertical_specs.json"
 
 
 def _parse_kwargs_into_properties(
@@ -174,6 +177,7 @@ class CustomDataManager:
             }
 
         self._data = {}
+        self._vertical_specs: list[VerticalSpec] = []
 
     def __repr__(self) -> str:
         input_files_count = len(self._config.inputFiles)
@@ -188,6 +192,7 @@ class CustomDataManager:
         variables_count = len(all_nodes) - sources_count - provenances_count
 
         dataframes_count = len(self._data)
+        vertical_specs_count = len(self._vertical_specs)
 
         import_name = self._config.importName
         include_input_subdirs = self._config.includeInputSubdirs
@@ -205,6 +210,7 @@ class CustomDataManager:
             f"\n{sources_count} sources"
             f"\n{provenances_count} provenances"
             f"\n{variables_count} variables"
+            f"\n{vertical_specs_count} vertical specs"
             f"\nflags: importName={import_name}, "
             f"includeInputSubdirs={include_input_subdirs}, "
             f"groupStatVarsByProperty={group_statvars}, "
@@ -313,6 +319,44 @@ class CustomDataManager:
         Plain filename string (no ``.json``-suffix enforcement). Pass ``None`` to unset.
         """
         self._config.verticalSpecsFile = file_name
+        return self
+
+    def add_vertical_spec(
+        self,
+        *,
+        verticals: list[str],
+        population_type: str = "Thing",
+        measured_properties: list[str] | None = None,
+        file_name: str | None = None,
+    ) -> CustomDataManager:
+        """Add a vertical-specs entry guiding StatVar hierarchy generation.
+
+        Appends one spec to the vertical-specs file written by ``export_all`` (or
+        ``export_vertical_specs``) and points the config's ``verticalSpecsFile`` at the
+        file. The importer reads it only when ``groupStatVarsByProperty`` is set.
+
+        The config's ``verticalSpecsFile`` is set to ``file_name`` when given; otherwise
+        it defaults to ``"vertical_specs.json"`` on first use and an existing value
+        (e.g. one set via ``set_verticalSpecsFile``) is left untouched.
+
+        Args:
+            verticals: Vertical (top-level group) names to file matching stat vars under.
+            population_type: Population type the spec applies to. Defaults to ``"Thing"``.
+            measured_properties: Measured properties the spec applies to (optional).
+            file_name: Name of the vertical-specs file to write. When omitted, uses the
+                config's existing ``verticalSpecsFile`` or ``"vertical_specs.json"``.
+        """
+        self._vertical_specs.append(
+            VerticalSpec(
+                populationType=population_type,
+                measuredProperties=measured_properties or [],
+                verticals=verticals,
+            )
+        )
+        if file_name is not None:
+            self._config.verticalSpecsFile = file_name
+        elif self._config.verticalSpecsFile is None:
+            self._config.verticalSpecsFile = DEFAULT_VERTICAL_SPECS_NAME
         return self
 
     def add_source(
@@ -985,6 +1029,30 @@ class CustomDataManager:
         for file, data in self._data.items():
             data.to_csv(Path(dir_path) / file, index=False)
 
+    def export_vertical_specs(self, dir_path: str | PathLike[str]) -> None:
+        """Export the vertical-specs file as ``{"specs": [...]}`` JSON.
+
+        Written to the name in the config's ``verticalSpecsFile`` (falling back to
+        ``"vertical_specs.json"``). ``export_all`` calls this automatically when any
+        spec has been added.
+
+        Args:
+            dir_path: Path to the directory where the file will be exported.
+
+        Raises:
+            ValueError: If no vertical specs have been added.
+        """
+
+        if not self._vertical_specs:
+            raise ValueError("No vertical specs to export")
+
+        file_name = self._config.verticalSpecsFile or DEFAULT_VERTICAL_SPECS_NAME
+        payload = {
+            "specs": [spec.model_dump(mode="json") for spec in self._vertical_specs]
+        }
+        with (Path(dir_path) / file_name).open("w") as f:
+            f.write(json.dumps(payload, indent=4))
+
     def validate_all_input_files_have_data(self) -> CustomDataManager:
         """Validate that every declared input file has a corresponding data entry.
 
@@ -1052,6 +1120,9 @@ class CustomDataManager:
 
         if self._data:
             self.export_data(dir_path)
+
+        if self._vertical_specs:
+            self.export_vertical_specs(dir_path)
 
         for mcf_file_name in mcf_file_names or ():
             self.export_mfc_file(

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -20,6 +20,7 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     ExplicitSchemaFile,
     MCFFileName,
+    ObservationProperties,
 )
 from dcp_tools.custom_data.models.mcf import MCFNodes
 from dcp_tools.custom_data.models.sources import ProvenanceMCFNode, SourceMCFNode
@@ -195,6 +196,8 @@ class CustomDataManager:
         namespace = self._config.customIdNamespace
         svg_prefix = self._config.customSvgPrefix
         blocklist = self._config.svHierarchyPropsBlocklist
+        data_download_url = self._config.dataDownloadUrl
+        vertical_specs_file = self._config.verticalSpecsFile
 
         return (
             f"<CustomDataManager config: "
@@ -207,7 +210,9 @@ class CustomDataManager:
             f"groupStatVarsByProperty={group_statvars}, "
             f"defaultCustomRootStatVarGroupName={root_group_name}, "
             f"customIdNamespace={namespace}, customSvgPrefix={svg_prefix}, "
-            f"svHierarchyPropsBlocklist={blocklist}>"
+            f"svHierarchyPropsBlocklist={blocklist}, "
+            f"dataDownloadUrl={data_download_url}, "
+            f"verticalSpecsFile={vertical_specs_file}>"
         )
 
     def set_importName(self, name: str | None) -> CustomDataManager:
@@ -282,6 +287,32 @@ class CustomDataManager:
                     seen.add(prop)
                     deduped.append(prop)
             self._config.svHierarchyPropsBlocklist = deduped
+        return self
+
+    def set_dataDownloadUrl(self, urls: list[str] | None) -> CustomDataManager:
+        """Set the data download URLs in the config.
+
+        Replaces any existing list. Pass ``None`` to unset the field (absent from the
+        exported ``config.json``).
+        """
+        self._config.dataDownloadUrl = urls
+        return self
+
+    def add_dataDownloadUrl(self, url: str) -> CustomDataManager:
+        """Append a single data download URL to the config.
+
+        Initializes the list to ``[url]`` when the field is unset.
+        """
+        existing = self._config.dataDownloadUrl or []
+        self._config.dataDownloadUrl = [*existing, url]
+        return self
+
+    def set_verticalSpecsFile(self, file_name: str | None) -> CustomDataManager:
+        """Set the vertical-specs filename in the config.
+
+        Plain filename string (no ``.json``-suffix enforcement). Pass ``None`` to unset.
+        """
+        self._config.verticalSpecsFile = file_name
         return self
 
     def add_source(
@@ -573,6 +604,7 @@ class CustomDataManager:
         provenance: str,
         data: pd.DataFrame | None = None,
         columnMappings: dict[str, str] | None = None,
+        observationProperties: dict[str, str] | None = None,
         ignoreColumns: list[str] | None = None,
         pattern: str | None = None,
         override: bool = False,
@@ -601,6 +633,10 @@ class CustomDataManager:
             columnMappings: Column mappings. Match the headings in the CSV file to the
                 allowed properties. Allowed keys are [entity, date, value, unit,
                 scalingFactor, measurementMethod, observationPeriod].
+            observationProperties: Optional file-level constant observation properties applied
+                to every observation (e.g. ``{"unit": "USDollar"}``). Standard keys are
+                ``unit``/``scalingFactor``/``measurementMethod``/``observationPeriod``; custom
+                keys are preserved verbatim.
             ignoreColumns: List of columns to ignore (optional).
             pattern: Glob pattern matching one or more input files. Mutually exclusive
                 with ``file_name``. Pattern entries carry no local data.
@@ -624,6 +660,11 @@ class CustomDataManager:
             pattern=pattern,
             provenance=provenance,
             columnMappings=ColumnMappings(**(columnMappings or {})),
+            observationProperties=(
+                ObservationProperties(**observationProperties)
+                if observationProperties is not None
+                else None
+            ),
             ignoreColumns=ignoreColumns,
         )
 

--- a/src/dcp_tools/custom_data/models/config_file.py
+++ b/src/dcp_tools/custom_data/models/config_file.py
@@ -26,6 +26,10 @@ class Config(BaseModel):
             and column mapping information.
         svHierarchyPropsBlocklist: Array of additional property dcids to exclude from hierarchy generation.
             These are added to the internal blocklist used by Data Commons.
+        dataDownloadUrl: Optional list of URLs the importer fetches input data from.
+            Serialized as a JSON list; passthrough config value (no fetching/validation here).
+        verticalSpecsFile: Optional filename of the vertical-specs JSON file the importer reads
+            when grouping stat vars. Plain filename string; the file itself is not managed here.
     """
 
     importName: str | None = None
@@ -35,6 +39,8 @@ class Config(BaseModel):
     customIdNamespace: str | None = None
     customSvgPrefix: str | None = None
     svHierarchyPropsBlocklist: list[str] | None = None
+    dataDownloadUrl: list[str] | None = None
+    verticalSpecsFile: str | None = None
     inputFiles: list[ExplicitSchemaFile]
 
     # model configuration - populate by name (for the "format" field alias)

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -78,6 +78,29 @@ class ColumnMappings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class ObservationProperties(BaseModel):
+    """File-level constant observation properties for an explicit-schema input file.
+
+    Applied as constants to every observation in the file (the only working route to a
+    constant ``unit``/``scalingFactor``/``measurementMethod``/``observationPeriod``). Keys
+    are emitted verbatim with no ``dcid:`` aliasing; the DCP importer reads the four standard
+    keys directly and passes any custom keys through unchanged.
+
+    Attributes:
+        unit: Unit applied to every observation.
+        scalingFactor: Scaling factor applied to every observation.
+        measurementMethod: Measurement method applied to every observation.
+        observationPeriod: Observation period applied to every observation.
+    """
+
+    unit: str | None = None
+    scalingFactor: str | None = None
+    measurementMethod: str | None = None
+    observationPeriod: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
 class ExplicitSchemaFile(BaseModel):
     """Representation of an input file using the explicit (variable-per-row) schema.
 
@@ -95,6 +118,8 @@ class ExplicitSchemaFile(BaseModel):
         ignoreColumns: List of columns to ignore.
         columnMappings: If headings in the CSV file do not use the default names,
             the equivalent names for each column.
+        observationProperties: File-level constant observation properties applied to every
+            observation (constants such as unit or measurementMethod). Optional.
         data_format: Format of the data (variable per row).
             This attribute is represented as "format" in the JSON.
     """
@@ -104,6 +129,7 @@ class ExplicitSchemaFile(BaseModel):
     provenance: str
     ignoreColumns: list[str] | None = None
     columnMappings: ColumnMappings
+    observationProperties: ObservationProperties | None = None
     data_format: Literal["variablePerRow"] = Field(
         default="variablePerRow", alias="format"
     )

--- a/src/dcp_tools/custom_data/models/vertical_specs.py
+++ b/src/dcp_tools/custom_data/models/vertical_specs.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class VerticalSpec(BaseModel):
+    """A single entry in the vertical-specs file guiding StatVar hierarchy generation.
+
+    Each spec maps stat vars about a ``populationType`` with the given
+    ``measuredProperties`` to one or more ``verticals`` (top-level groups) in the
+    hierarchy the importer generates when ``groupStatVarsByProperty`` is set. Specs are
+    serialized as the objects in the ``{"specs": [...]}`` JSON file the importer reads;
+    the field names match the keys the importer expects (``data.py:VerticalSpec``).
+
+    Attributes:
+        populationType: Population type the spec applies to. Defaults to ``"Thing"``,
+            matching the importer's own default.
+        measuredProperties: Measured properties the spec applies to.
+        verticals: Vertical (top-level group) names to file matching stat vars under.
+    """
+
+    populationType: str = "Thing"
+    measuredProperties: list[str] = Field(default_factory=list)
+    verticals: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="forbid")

--- a/tests/goldens/config_all_fields.json
+++ b/tests/goldens/config_all_fields.json
@@ -1,0 +1,27 @@
+{
+    "importName": "test_import_all_fields",
+    "includeInputSubdirs": true,
+    "groupStatVarsByProperty": false,
+    "dataDownloadUrl": [
+        "https://example.org/data/file1.csv",
+        "https://example.org/data/file2.csv"
+    ],
+    "verticalSpecsFile": "vertical_specs.json",
+    "inputFiles": [
+        {
+            "filename": "a.csv",
+            "provenance": "dcid:provenance/provA",
+            "columnMappings": {
+                "dcid:observationAbout": "Country",
+                "dcid:observationDate": "Year",
+                "dcid:value": "Val"
+            },
+            "observationProperties": {
+                "unit": "USDollar",
+                "measurementMethod": "dcAggregate/Census",
+                "customProp": "customValue"
+            },
+            "format": "variablePerRow"
+        }
+    ]
+}

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -6,7 +6,10 @@ import pandas as pd
 import pytest
 
 from dcp_tools import CustomDataManager
-from dcp_tools.custom_data.data_management import DEFAULT_GROUP_NAME
+from dcp_tools.custom_data.data_management import (
+    DEFAULT_GROUP_NAME,
+    DEFAULT_VERTICAL_SPECS_NAME,
+)
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
@@ -407,6 +410,73 @@ def test_set_vertical_specs_file():
 
     manager.set_verticalSpecsFile(None)
     assert manager._config.verticalSpecsFile is None
+
+
+def test_add_vertical_spec_appends_and_wires_config():
+    manager = CustomDataManager()
+    manager.add_vertical_spec(
+        verticals=["PersonCountVertical"],
+        population_type="Person",
+        measured_properties=["count"],
+    )
+
+    # Auto-wires verticalSpecsFile to the default name on first use
+    assert manager._config.verticalSpecsFile == DEFAULT_VERTICAL_SPECS_NAME
+    assert len(manager._vertical_specs) == 1
+    spec = manager._vertical_specs[0]
+    assert spec.populationType == "Person"
+    assert spec.measuredProperties == ["count"]
+    assert spec.verticals == ["PersonCountVertical"]
+
+
+def test_add_vertical_spec_respects_existing_and_explicit_filename():
+    # A filename set beforehand is left untouched by the default path
+    manager = CustomDataManager()
+    manager.set_verticalSpecsFile("custom.json")
+    manager.add_vertical_spec(verticals=["v"])
+    assert manager._config.verticalSpecsFile == "custom.json"
+
+    # An explicit file_name overrides
+    manager.add_vertical_spec(verticals=["v2"], file_name="other.json")
+    assert manager._config.verticalSpecsFile == "other.json"
+
+
+def test_export_vertical_specs_writes_specs_json(tmp_path):
+    manager = CustomDataManager()
+    manager.add_vertical_spec(
+        verticals=["PersonCountVertical"],
+        population_type="Person",
+        measured_properties=["count"],
+    )
+    manager.export_vertical_specs(tmp_path)
+
+    written = json.loads((tmp_path / DEFAULT_VERTICAL_SPECS_NAME).read_text())
+    assert written == {
+        "specs": [
+            {
+                "populationType": "Person",
+                "measuredProperties": ["count"],
+                "verticals": ["PersonCountVertical"],
+            }
+        ]
+    }
+
+
+def test_export_vertical_specs_raises_when_empty(tmp_path):
+    manager = CustomDataManager()
+    with pytest.raises(ValueError):
+        manager.export_vertical_specs(tmp_path)
+
+
+def test_export_all_includes_vertical_specs(tmp_path):
+    manager = CustomDataManager()
+    manager.add_vertical_spec(verticals=["PersonCountVertical"])
+
+    manager.export_all(tmp_path)
+
+    assert (tmp_path / DEFAULT_VERTICAL_SPECS_NAME).exists()
+    config = json.loads((tmp_path / "config.json").read_text())
+    assert config["verticalSpecsFile"] == DEFAULT_VERTICAL_SPECS_NAME
 
 
 def test_add_explicit_schema_file_observation_properties():

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -351,6 +351,8 @@ def _make_cfg(
     custom_namespace: str | None = None,
     custom_svg_prefix: str | None = None,
     sv_blocklist: list[str] | None = None,
+    data_download_url: list[str] | None = None,
+    vertical_specs_file: str | None = None,
 ):
     input_files = [
         ExplicitSchemaFile(
@@ -367,7 +369,121 @@ def _make_cfg(
         customIdNamespace=custom_namespace,
         customSvgPrefix=custom_svg_prefix,
         svHierarchyPropsBlocklist=sv_blocklist,
+        dataDownloadUrl=data_download_url,
+        verticalSpecsFile=vertical_specs_file,
     )
+
+
+def test_set_data_download_url():
+    manager = CustomDataManager()
+    manager.set_dataDownloadUrl(["u1", "u2"])
+    assert manager._config.dataDownloadUrl == ["u1", "u2"]
+
+    manager.set_dataDownloadUrl(None)
+    assert manager._config.dataDownloadUrl is None
+
+
+def test_add_data_download_url_initializes_and_appends():
+    manager = CustomDataManager()
+
+    # Initializes from unset
+    manager.add_dataDownloadUrl("u1")
+    assert manager._config.dataDownloadUrl == ["u1"]
+
+    # Appends to existing list
+    manager.add_dataDownloadUrl("u2")
+    assert manager._config.dataDownloadUrl == ["u1", "u2"]
+
+    # Unset then re-initialize
+    manager.set_dataDownloadUrl(None)
+    manager.add_dataDownloadUrl("u3")
+    assert manager._config.dataDownloadUrl == ["u3"]
+
+
+def test_set_vertical_specs_file():
+    manager = CustomDataManager()
+    manager.set_verticalSpecsFile("vs.json")
+    assert manager._config.verticalSpecsFile == "vs.json"
+
+    manager.set_verticalSpecsFile(None)
+    assert manager._config.verticalSpecsFile is None
+
+
+def test_add_explicit_schema_file_observation_properties():
+    manager = CustomDataManager()
+
+    manager.add_explicit_schema_file(
+        "data.csv",
+        provenance="prov1",
+        columnMappings={"entity": "Country", "date": "Year"},
+        observationProperties={"unit": "USDollar", "customProp": "x"},
+    )
+
+    entry = manager._config.inputFiles[0]
+    assert entry.observationProperties is not None
+    assert entry.observationProperties.unit == "USDollar"
+    assert entry.observationProperties.__pydantic_extra__["customProp"] == "x"
+    # columnMappings coexists
+    assert entry.columnMappings is not None
+
+    # Omitting the kwarg leaves observationProperties absent (None)
+    manager.add_explicit_schema_file(
+        "other.csv",
+        provenance="prov1",
+    )
+    other_entry = manager._config.inputFiles[1]
+    assert other_entry.observationProperties is None
+
+
+def test_merge_data_download_url(tmp_path):
+    d1 = tmp_path / "one"
+    d1.mkdir()
+    cfg1 = _make_cfg("a.csv", "p1", data_download_url=["u1"])
+    (d1 / "config.json").write_text(
+        cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    d2 = tmp_path / "two"
+    d2.mkdir()
+    cfg2 = _make_cfg("b.csv", "p2")
+    (d2 / "config.json").write_text(
+        cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    manager = CustomDataManager.from_config_files_in_directory(tmp_path)
+    assert manager._config.dataDownloadUrl == ["u1"]
+
+    # Override policy: second config has different urls → takes the new list
+    d3 = tmp_path / "three"
+    d3.mkdir()
+    cfg3 = _make_cfg("c.csv", "p3", data_download_url=["u2"])
+    (d3 / "config.json").write_text(
+        cfg3.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    manager2 = CustomDataManager.from_config_files_in_directory(
+        tmp_path, policy="override"
+    )
+    assert manager2._config.dataDownloadUrl == ["u2"]
+
+
+def test_merge_vertical_specs_file(tmp_path):
+    d1 = tmp_path / "one"
+    d1.mkdir()
+    cfg1 = _make_cfg("a.csv", "p1", vertical_specs_file="vs.json")
+    (d1 / "config.json").write_text(
+        cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    d2 = tmp_path / "two"
+    d2.mkdir()
+    cfg2 = _make_cfg("b.csv", "p2")
+    (d2 / "config.json").write_text(
+        cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
+    )
+
+    manager = CustomDataManager.from_config_files_in_directory(tmp_path)
+    assert manager._config.verticalSpecsFile == "vs.json"
 
 
 def test_merge_configs_from_directory(tmp_path):

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -103,3 +103,13 @@ def test_round_trip_config_snapshot(tmp_path):
     got = config_file.model_dump_json(indent=4, exclude_none=True, by_alias=True)
     expected = json.dumps(data, indent=4)
     assert json.loads(got) == json.loads(expected)
+
+
+def test_round_trip_config_all_fields_snapshot(tmp_path):
+    data = json.loads((GOLDEN_DIR / "config_all_fields.json").read_text())
+    config_file = tmp_path / "c.json"
+    config_file.write_text(json.dumps(data))
+
+    loaded = Config.from_json(str(config_file))
+    got = loaded.model_dump_json(indent=4, exclude_none=True, by_alias=True)
+    assert json.loads(got) == data

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -1,7 +1,13 @@
+import json
+
 import pytest
 
 from dcp_tools.custom_data.models.config_file import Config
-from dcp_tools.custom_data.models.data_files import ColumnMappings, ExplicitSchemaFile
+from dcp_tools.custom_data.models.data_files import (
+    ColumnMappings,
+    ExplicitSchemaFile,
+    ObservationProperties,
+)
 
 
 def test_config_validators_raise_on_invalid_input_files():
@@ -82,3 +88,77 @@ def test_config_round_trips_import_name(tmp_path):
     loaded = Config.from_json(str(config))
     assert loaded.importName == "OECD_wage_data"
     assert loaded.model_dump(exclude_none=True)["importName"] == "OECD_wage_data"
+
+
+def test_observation_properties_preserves_custom_keys():
+    """ObservationProperties with a custom key round-trips with the key intact."""
+    op = ObservationProperties(unit="USD", customKey="v")
+    dumped = op.model_dump(exclude_none=True, by_alias=True)
+    assert dumped == {"unit": "USD", "customKey": "v"}
+
+    # JSON load→dump also preserves the custom key
+    raw = json.dumps({"unit": "USD", "customKey": "v"})
+    reloaded = ObservationProperties.model_validate_json(raw)
+    assert reloaded.model_dump(exclude_none=True, by_alias=True) == {
+        "unit": "USD",
+        "customKey": "v",
+    }
+
+
+def test_observation_properties_exclude_none_drops_unset_standard_fields():
+    """Unset standard fields are absent from the serialised output."""
+    op = ObservationProperties(unit="USDollar")
+    dumped = op.model_dump(exclude_none=True, by_alias=True)
+    assert dumped == {"unit": "USDollar"}
+    assert "scalingFactor" not in dumped
+    assert "measurementMethod" not in dumped
+    assert "observationPeriod" not in dumped
+
+
+def test_config_accepts_data_download_url_and_vertical_specs_file(tmp_path):
+    """Config.from_json accepts both new top-level fields (no extra='forbid' rejection)."""
+    config_data = {
+        "importName": "test_import",
+        "dataDownloadUrl": ["https://example.org/data.csv"],
+        "verticalSpecsFile": "vert.json",
+        "inputFiles": [
+            {
+                "filename": "data.csv",
+                "provenance": "p1",
+                "columnMappings": {},
+                "format": "variablePerRow",
+            }
+        ],
+    }
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(config_data))
+
+    loaded = Config.from_json(str(config_file))
+    assert loaded.dataDownloadUrl == ["https://example.org/data.csv"]
+    assert loaded.verticalSpecsFile == "vert.json"
+
+    # Both fields survive a round-trip through model_dump
+    dumped = loaded.model_dump(exclude_none=True, by_alias=True)
+    assert dumped["dataDownloadUrl"] == ["https://example.org/data.csv"]
+    assert dumped["verticalSpecsFile"] == "vert.json"
+
+
+def test_explicit_schema_file_observation_properties_roundtrip():
+    """observationProperties coexists with columnMappings; custom keys survive dump+reload."""
+    ef = ExplicitSchemaFile(
+        filename="data.csv",
+        provenance="prov1",
+        columnMappings=ColumnMappings(entity="Country", date="Year"),
+        observationProperties=ObservationProperties(unit="USD", customProp="x"),
+    )
+    dumped = ef.model_dump(exclude_none=True, by_alias=True)
+    assert "observationProperties" in dumped
+    assert dumped["observationProperties"]["unit"] == "USD"
+    assert dumped["observationProperties"]["customProp"] == "x"
+    assert "columnMappings" in dumped
+
+    # Reload from the dumped dict
+    reloaded = ExplicitSchemaFile.model_validate(dumped)
+    assert reloaded.observationProperties is not None
+    assert reloaded.observationProperties.unit == "USD"
+    assert reloaded.observationProperties.__pydantic_extra__["customProp"] == "x"

--- a/tests/test_models_vertical_specs.py
+++ b/tests/test_models_vertical_specs.py
@@ -1,0 +1,31 @@
+import pytest
+from pydantic import ValidationError
+
+from dcp_tools.custom_data.models.vertical_specs import VerticalSpec
+
+
+def test_vertical_spec_defaults():
+    spec = VerticalSpec(verticals=["PersonCountVertical"])
+    assert spec.populationType == "Thing"
+    assert spec.measuredProperties == []
+    assert spec.verticals == ["PersonCountVertical"]
+
+
+def test_vertical_spec_round_trips():
+    spec = VerticalSpec(
+        populationType="Person",
+        measuredProperties=["count"],
+        verticals=["PersonCountVertical"],
+    )
+    dumped = spec.model_dump(mode="json")
+    assert dumped == {
+        "populationType": "Person",
+        "measuredProperties": ["count"],
+        "verticals": ["PersonCountVertical"],
+    }
+    assert VerticalSpec.model_validate(dumped) == spec
+
+
+def test_vertical_spec_rejects_unknown_field():
+    with pytest.raises(ValidationError):
+        VerticalSpec(verticals=["v"], unexpected="x")


### PR DESCRIPTION
Adds three config.json fields the importer supports but the package rejected under `extra="forbid"`, plus a builder for the vertical-specs file, so generated bundles can carry them and round-trip cleanly.

## What changed

- **`dataDownloadUrl`** (top-level list): `set_dataDownloadUrl(urls | None)` replaces or unsets; `add_dataDownloadUrl(url)` appends, initialising the list when unset.
- **`verticalSpecsFile`** (top-level string): `set_verticalSpecsFile(name | None)`.
- **`observationProperties`** (per input file): a typed `ObservationProperties` model (`unit`, `scalingFactor`, `measurementMethod`, `observationPeriod`) with `extra="allow"`, surfaced through a new `observationProperties=` kwarg on `add_explicit_schema_file`. Keys are written verbatim with no `dcid:` aliasing and custom keys pass through, which is how the importer reads them.
- **Vertical-specs builder**: `add_vertical_spec(verticals=..., population_type="Thing", measured_properties=...)` appends typed `VerticalSpec` entries, points `verticalSpecsFile` at the output file, and `export_vertical_specs` (called by `export_all`) writes the `{"specs": [...]}` JSON the importer reads when `groupStatVarsByProperty` is set. Lets users generate that file instead of hand-writing it.

While adding the two top-level fields I found that `_merge_simple_attrs` only copied the fields it enumerated by name, so any field not in that list was silently dropped on merge. Both new fields are now wired into the merge path (scalar for `verticalSpecsFile`, sequence for `dataDownloadUrl`).

Docs are intentionally left out — the loading-data docs are being rewritten under #105, so documenting these here would just be redone.

## Testing

`ruff format --check`, `ruff check`, `ty check` all clean; `uv run pytest` → 129 passed. New coverage: model round-trips for all three fields, custom-key preservation, nested `exclude_none`, the absent-when-unset contract, both `dataDownloadUrl` setters, merge preservation, and the vertical-specs builder (config wiring, `{"specs": [...]}` export content, and the `export_all` hook). A new golden fixture (`tests/goldens/config_all_fields.json`) proves a config with all three fields survives load→dump unchanged.

Closes #113.

Co-authored-by: Claude <noreply@anthropic.com>
