### PR TITLE
feat(custom_data): add typed MCF builders for schema nodes

### DIFF
--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -15,7 +15,7 @@ from dcp_tools.custom_data.config_utils import (
     merge_configs,
     merge_configs_from_directory,
 )
-from dcp_tools.custom_data.models.common import mint_dcid
+from dcp_tools.custom_data.models.common import ensure_dcid, mint_dcid
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
@@ -23,7 +23,14 @@ from dcp_tools.custom_data.models.data_files import (
     MCFFileName,
     ObservationProperties,
 )
-from dcp_tools.custom_data.models.mcf import MCFNodes
+from dcp_tools.custom_data.models.mcf import MCFNode, MCFNodes
+from dcp_tools.custom_data.models.schema_nodes import (
+    EntityTypeMCFNode,
+    EventTypeMCFNode,
+    MeasurementMethodMCFNode,
+    PropertyMCFNode,
+    UnitOfMeasureMCFNode,
+)
 from dcp_tools.custom_data.models.sources import ProvenanceMCFNode, SourceMCFNode
 from dcp_tools.custom_data.models.stat_vars import (
     StatType,
@@ -95,6 +102,23 @@ class CustomDataManager:
     >>>    description="Variable Description",
     >>>    ...
     >>>    )
+
+    Schema nodes (MCF):
+
+    To add custom schema nodes (entity types, event types, properties, units, and
+    measurement methods), use the five typed builders. All five accept bare or
+    ``dcid:``-prefixed ``Node`` tokens. Note: ``add_measurement_method`` is the only
+    builder where ``name`` is optional — only ``Node`` is required.
+    >>> dc_manager.add_entity_type(Node="MyClass", name="My Class")
+    >>> dc_manager.add_event_type(Node="MyEvent", name="My Event")
+    >>> dc_manager.add_property(
+    >>>     Node="myProp",
+    >>>     name="My Property",
+    >>>     domainIncludes="Person",
+    >>>     rangeIncludes="Number",
+    >>> )
+    >>> dc_manager.add_unit(Node="USD", name="US Dollar", shortDisplayName="$")
+    >>> dc_manager.add_measurement_method(Node="MyCensus")
 
     You can also add variables for export to an MCF file using a CSV file. The CSV file should
     contain the variables you want to add.
@@ -575,6 +599,265 @@ class CustomDataManager:
         self._mcf_nodes.setdefault(name, MCFNodes()).add(node, override=override)
         return self
 
+    def add_entity_type(
+        self,
+        *,
+        Node: str,
+        name: str,
+        description: str | None = None,
+        includedIn: str | list[str] | None = None,
+        additional_properties: dict[str, str] | None = None,
+        override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
+    ) -> CustomDataManager:
+        """Add a custom entity-type (Class) MCF node.
+
+        Emits a ``dcid:Class`` node to the MCF collection (default: ``custom_nodes.mcf``).
+
+        Args:
+            Node: Identifier token for the Class. Bare tokens are normalized to
+                ``dcid:<token>`` (e.g. ``"MyClass"`` → ``"dcid:MyClass"``); already
+                ``dcid:``-prefixed values are passed through verbatim. Names must be
+                valid dcid tokens (no whitespace).
+            name: Human-readable name for the entity type.
+            description: Optional human-readable description. (Optional)
+            includedIn: Bare provenance name (or list of names) the entity type is
+                defined in. **Important:** this takes the bare provenance name (not a
+                dcid, unlike the other ref params). The provenance must already be
+                registered via ``add_provenance``. The builder emits ``includedIn`` for
+                **both** the provenance and its linked Source (one bare name → two
+                dcids out). (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"custom_nodes.mcf"``.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If Node contains whitespace, if a node with the same id already
+                exists and ``override`` is False, if the file name is invalid, or if any
+                provenance referenced by ``includedIn`` has not been registered.
+        """
+        Node = ensure_dcid(Node)
+        if includedIn is not None:
+            includedIn = self._expand_included_in(includedIn)
+        props = _parse_kwargs_into_properties(locals())
+        node = EntityTypeMCFNode(**props)
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        return self
+
+    def add_event_type(
+        self,
+        *,
+        Node: str,
+        name: str,
+        description: str | None = None,
+        subClassOf: str = "dcid:Event",
+        includedIn: str | list[str] | None = None,
+        additional_properties: dict[str, str] | None = None,
+        override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
+    ) -> CustomDataManager:
+        """Add a custom event-type (Class) MCF node.
+
+        Emits a ``dcid:Class`` node with ``subClassOf`` defaulting to ``dcid:Event``
+        (default: ``custom_nodes.mcf``).
+
+        Args:
+            Node: Identifier token for the event type. Bare tokens are normalized to
+                ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
+                verbatim. Names must be valid dcid tokens (no whitespace).
+            name: Human-readable name for the event type.
+            description: Optional human-readable description. (Optional)
+            subClassOf: Parent class DCID. Bare tokens are normalized to ``dcid:<token>``.
+                Defaults to ``"dcid:Event"``. (Optional)
+            includedIn: Bare provenance name (or list of names) the event type is
+                defined in. **Important:** this takes the bare provenance name (not a
+                dcid, unlike the other ref params). The provenance must already be
+                registered via ``add_provenance``. The builder emits ``includedIn`` for
+                **both** the provenance and its linked Source (one bare name → two
+                dcids out). (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"custom_nodes.mcf"``.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If Node contains whitespace, if a node with the same id already
+                exists and ``override`` is False, if the file name is invalid, or if any
+                provenance referenced by ``includedIn`` has not been registered.
+        """
+        Node = ensure_dcid(Node)
+        subClassOf = ensure_dcid(subClassOf)
+        if includedIn is not None:
+            includedIn = self._expand_included_in(includedIn)
+        props = _parse_kwargs_into_properties(locals())
+        node = EventTypeMCFNode(**props)
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        return self
+
+    def add_property(
+        self,
+        *,
+        Node: str,
+        name: str,
+        domainIncludes: str | list[str] | None = None,
+        rangeIncludes: str | list[str] | None = None,
+        subPropertyOf: str | list[str] | None = None,
+        description: str | None = None,
+        additional_properties: dict[str, str] | None = None,
+        override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
+    ) -> CustomDataManager:
+        """Add a custom Property MCF node.
+
+        Emits a ``dcid:Property`` node to the MCF collection (default: ``custom_nodes.mcf``).
+
+        Args:
+            Node: Identifier token for the property. Bare tokens are normalized to
+                ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
+                verbatim. Names must be valid dcid tokens (no whitespace).
+            name: Human-readable name for the property.
+            domainIncludes: DCID(s) of classes the property applies to. Bare tokens or
+                lists are normalized to ``dcid:`` (same as ``Node``); already
+                ``dcid:``-prefixed values are passed through verbatim. (Optional)
+            rangeIncludes: DCID(s) of classes that are the value type. Bare tokens or
+                lists are normalized to ``dcid:`` (same as ``Node``); already
+                ``dcid:``-prefixed values are passed through verbatim. (Optional)
+            subPropertyOf: DCID(s) of parent properties. Bare tokens or lists are
+                normalized to ``dcid:`` (same as ``Node``); already ``dcid:``-prefixed
+                values are passed through verbatim. (Optional)
+            description: Optional human-readable description. (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"custom_nodes.mcf"``.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If Node contains whitespace, if a node with the same id already
+                exists and ``override`` is False, or if the file name is invalid.
+        """
+        Node = ensure_dcid(Node)
+        if domainIncludes is not None:
+            domainIncludes = ensure_dcid(domainIncludes)
+        if rangeIncludes is not None:
+            rangeIncludes = ensure_dcid(rangeIncludes)
+        if subPropertyOf is not None:
+            subPropertyOf = ensure_dcid(subPropertyOf)
+        props = _parse_kwargs_into_properties(locals())
+        node = PropertyMCFNode(**props)
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        return self
+
+    def add_unit(
+        self,
+        *,
+        Node: str,
+        name: str,
+        shortDisplayName: str | None = None,
+        description: str | None = None,
+        typeOf: str = "dcid:UnitOfMeasure",
+        additional_properties: dict[str, str] | None = None,
+        override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
+    ) -> CustomDataManager:
+        """Add a custom unit-of-measure MCF node.
+
+        Emits a ``dcid:UnitOfMeasure`` node (or the overridden ``typeOf``) to the MCF
+        collection (default: ``custom_nodes.mcf``).
+
+        Args:
+            Node: Identifier token for the unit. Bare tokens are normalized to
+                ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
+                verbatim. Names must be valid dcid tokens (no whitespace).
+            name: Human-readable name for the unit.
+            shortDisplayName: Optional short display name (e.g. ``"$"``). (Optional)
+            description: Optional human-readable description. (Optional)
+            typeOf: Type DCID. Bare tokens are normalized to ``dcid:<token>``. Defaults to
+                ``"dcid:UnitOfMeasure"``; override for sub-types such as
+                ``"dcid:CurrencyUnitOfMeasure"``. (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"custom_nodes.mcf"``.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If Node contains whitespace, if a node with the same id already
+                exists and ``override`` is False, or if the file name is invalid.
+        """
+        Node = ensure_dcid(Node)
+        typeOf = ensure_dcid(typeOf)
+        props = _parse_kwargs_into_properties(locals())
+        node = UnitOfMeasureMCFNode(**props)
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        return self
+
+    def add_measurement_method(
+        self,
+        *,
+        Node: str,
+        name: str | None = None,
+        description: str | None = None,
+        typeOf: str = "dcid:MeasurementMethodEnum",
+        additional_properties: dict[str, str] | None = None,
+        override: bool = False,
+        mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
+    ) -> CustomDataManager:
+        """Add a custom measurement-method MCF node.
+
+        Emits a ``dcid:MeasurementMethodEnum`` node (or the overridden ``typeOf``) to the
+        MCF collection (default: ``custom_nodes.mcf``). Unlike the other four builders,
+        ``name`` is optional here — only ``Node`` is required.
+
+        Args:
+            Node: Identifier token for the measurement method. Bare tokens are normalized
+                to ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
+                verbatim. Names must be valid dcid tokens (no whitespace).
+            name: Optional human-readable name. (Optional)
+            description: Optional human-readable description. (Optional)
+            typeOf: Measurement-method enum type DCID. Bare tokens are normalized to
+                ``dcid:<token>``. Defaults to ``"dcid:MeasurementMethodEnum"``; override
+                for sub-types such as ``"dcid:CensusSurveyEnum"``. (Optional)
+            additional_properties: Additional MCF properties, passed as a dictionary
+                with the target property as key. (Optional)
+            override: If True, overwrite the existing node if it exists. Defaults to False.
+            mcf_file_name: Name of the MCF file (must end in .mcf).
+                Defaults to ``"custom_nodes.mcf"``.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If Node contains whitespace, if a node with the same id already
+                exists and ``override`` is False, or if the file name is invalid.
+        """
+        Node = ensure_dcid(Node)
+        typeOf = ensure_dcid(typeOf)
+        props = _parse_kwargs_into_properties(locals())
+        node = MeasurementMethodMCFNode(**props)
+        mcf_name = validate_mcf_file_name(mcf_file_name)
+        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        return self
+
     def add_variables_to_mcf_from_csv(
         self,
         csv_file_path: str | Path,
@@ -859,6 +1142,59 @@ class CustomDataManager:
             raise ValueError(f"Indicator '{indicator_id}' not found")
 
         return self
+
+    def _require_provenance_exists(
+        self, provenance: str, provenance_link: str
+    ) -> MCFNode:
+        """Return the Provenance MCF node with id ``provenance_link``, or raise ValueError.
+
+        Args:
+            provenance: The bare user-facing provenance ref (used in the error message).
+            provenance_link: The minted dcid for the provenance (used for the lookup).
+        """
+        for nodes in self._mcf_nodes.values():
+            for n in nodes.nodes:
+                if (
+                    getattr(n, "typeOf", None) == "dcid:Provenance"
+                    and n.Node == provenance_link
+                ):
+                    return n
+        raise ValueError(
+            f"Provenance '{provenance}' not found. "
+            f"Call add_provenance(name={provenance!r}, url=..., source=...) "
+            f"before referencing it in includedIn."
+        )
+
+    def _expand_included_in(self, included_in: str | list[str]) -> list[str]:
+        """Expand provenance reference(s) into includedIn dcids.
+
+        For each reference: mint to ``dcid:provenance/<name>``, require the Provenance node
+        to exist, and emit includedIn for BOTH the provenance and its linked Source
+        (``sourceLink``). Order is preserved and duplicate dcids are collapsed (so two
+        provenances sharing a source emit that source once).
+
+        Args:
+            included_in: A bare provenance name or list of names. Each name is minted to
+                ``dcid:provenance/<name>``; the referenced Provenance node must already
+                exist (added via ``add_provenance``).
+
+        Returns:
+            Ordered list of unique dcid strings (provenances + their sources).
+
+        Raises:
+            ValueError: If any referenced provenance has not been registered.
+        """
+        refs = [included_in] if isinstance(included_in, str) else list(included_in)
+        expanded: list[str] = []
+        seen: set[str] = set()
+        for ref in refs:
+            prov_link = mint_dcid(prefix="provenance", name=ref)
+            prov_node = self._require_provenance_exists(ref, prov_link)
+            for dcid in (prov_link, getattr(prov_node, "sourceLink", None)):
+                if dcid is not None and dcid not in seen:
+                    seen.add(dcid)
+                    expanded.append(dcid)
+        return expanded
 
     def _require_source_exists(self, source: str, source_link: str) -> None:
         """Raise ValueError if no Source MCF node with id ``source_link`` exists.

--- a/src/dcp_tools/custom_data/models/common.py
+++ b/src/dcp_tools/custom_data/models/common.py
@@ -1,5 +1,5 @@
 import csv
-from typing import Annotated, Any
+from typing import Annotated, Any, overload
 
 from pydantic import BeforeValidator, PlainSerializer, PlainValidator, StringConstraints
 
@@ -144,6 +144,51 @@ TopicDcidOrListTopicDcid = Annotated[
     PlainSerializer(mcf_str, return_type=TopicDcid | None, when_used="always"),
 ]
 """Accepts a string or list and serialises to a comma-separated string."""
+
+
+@overload
+def ensure_dcid(value: str) -> str: ...
+
+
+@overload
+def ensure_dcid(value: list[str]) -> list[str]: ...
+
+
+def ensure_dcid(value: str | list[str]) -> str | list[str]:
+    """Normalize a node/typeOf/ref token (or list) to a bare dcid.
+
+    Schema nodes (Class, Property, units, measurement methods) and their refs use bare
+    dcids (``dcid:MyClass``), not slug-namespaced ones (``dcid:source/<name>``). Use this
+    for ``Node``/``typeOf``/``subClassOf`` and the Property ref fields
+    (``domainIncludes``/``rangeIncludes``/``subPropertyOf``); use ``mint_dcid`` for
+    slug-namespaced refs (sources, provenances).
+
+    A list is mapped element-wise (so ``DcidOrListDcid`` fields accept bare lists).
+
+    Rules (per element):
+        Already ``dcid:``-prefixed -> returned verbatim.
+        Bare token                 -> prefixed with ``dcid:`` (e.g. ``'MyClass'`` ->
+                                       ``'dcid:MyClass'``).
+        Empty or whitespace-bearing -> ``ValueError`` (mirrors ``mint_dcid``).
+
+    Args:
+        value: A bare token, an already ``dcid:``-prefixed string, or a list of either.
+
+    Returns:
+        A ``dcid:``-prefixed string, or a list of them when given a list.
+
+    Raises:
+        ValueError: If any element is empty or contains a whitespace character.
+    """
+    if isinstance(value, list):
+        return [ensure_dcid(v) for v in value]
+    if not value or any(c.isspace() for c in value):
+        raise ValueError(
+            f"ensure_dcid: value must be a non-empty token with no whitespace; got {value!r}"
+        )
+    if value.startswith("dcid:"):
+        return value
+    return f"dcid:{value}"
 
 
 def mint_dcid(*, prefix: str, name: str) -> str:

--- a/src/dcp_tools/custom_data/models/schema_nodes.py
+++ b/src/dcp_tools/custom_data/models/schema_nodes.py
@@ -1,0 +1,114 @@
+from typing import Literal
+
+from dcp_tools.custom_data.models.common import DcidOrListDcid
+from dcp_tools.custom_data.models.mcf import MCFNode
+
+
+class EntityTypeMCFNode(MCFNode):
+    """Represents a custom entity-type (Class) node for MCF.
+
+    typeOf is fixed to ``dcid:Class``. ``includedIn`` references the provenance(s) — and,
+    via the builder, their linked source(s) — the type is defined in.
+
+    Attributes:
+        # Inherited from MCFNode
+        Node: Identifier for the Node (e.g. ``dcid:MyClass``).
+        name: The human-readable name for the Node.
+        description: Optional human-readable description.
+
+        # EntityType-specific
+        typeOf: Fixed type indicating this is a Class (``dcid:Class``).
+        includedIn: Optional provenance/source DCID(s) the entity type is defined in.
+    """
+
+    typeOf: Literal["dcid:Class"] = "dcid:Class"
+    includedIn: DcidOrListDcid | None = None
+
+
+class EventTypeMCFNode(MCFNode):
+    """Represents a custom event-type node for MCF.
+
+    typeOf is fixed to ``dcid:Class``; ``subClassOf`` defaults to ``dcid:Event`` and is
+    overridable. ``includedIn`` mirrors EntityType.
+
+    Attributes:
+        # Inherited from MCFNode
+        Node: Identifier for the Node (e.g. ``dcid:MyEventType``).
+        name: The human-readable name for the Node.
+        description: Optional human-readable description.
+
+        # EventType-specific
+        typeOf: Fixed type indicating this is a Class (``dcid:Class``).
+        subClassOf: Parent class; defaults to ``dcid:Event`` (overridable).
+        includedIn: Optional provenance/source DCID(s) the event type is defined in.
+    """
+
+    typeOf: Literal["dcid:Class"] = "dcid:Class"
+    subClassOf: DcidOrListDcid = "dcid:Event"
+    includedIn: DcidOrListDcid | None = None
+
+
+class PropertyMCFNode(MCFNode):
+    """Represents a custom Property node for MCF.
+
+    typeOf is fixed to ``dcid:Property``. Optional schema refs describe the property's
+    domain, range, and parent property.
+
+    Attributes:
+        # Inherited from MCFNode
+        Node: Identifier for the Node (e.g. ``dcid:myProperty``).
+        name: The human-readable name for the Node.
+        description: Optional human-readable description.
+
+        # Property-specific
+        typeOf: Fixed type indicating this is a Property (``dcid:Property``).
+        domainIncludes: Optional DCID(s) of classes the property applies to.
+        rangeIncludes: Optional DCID(s) of classes that are the value type.
+        subPropertyOf: Optional DCID(s) of parent properties.
+    """
+
+    typeOf: Literal["dcid:Property"] = "dcid:Property"
+    domainIncludes: DcidOrListDcid | None = None
+    rangeIncludes: DcidOrListDcid | None = None
+    subPropertyOf: DcidOrListDcid | None = None
+
+
+class UnitOfMeasureMCFNode(MCFNode):
+    """Represents a custom unit-of-measure node for MCF.
+
+    typeOf defaults to ``dcid:UnitOfMeasure`` and is overridable (e.g.
+    ``dcid:CurrencyUnitOfMeasure``). ``name``/``shortDisplayName``/``description`` are
+    inherited from MCFNode.
+
+    Attributes:
+        # Inherited from MCFNode
+        Node: Identifier for the Node (e.g. ``dcid:MyUnit``).
+        name: The human-readable name for the Node.
+        shortDisplayName: Optional short display name (e.g. ``"$"``).
+        description: Optional human-readable description.
+
+        # UnitOfMeasure-specific
+        typeOf: Type of unit; defaults to ``dcid:UnitOfMeasure`` (overridable).
+    """
+
+    typeOf: DcidOrListDcid = "dcid:UnitOfMeasure"
+
+
+class MeasurementMethodMCFNode(MCFNode):
+    """Represents a custom measurement-method node for MCF.
+
+    typeOf defaults to ``dcid:MeasurementMethodEnum`` and is overridable (e.g.
+    ``dcid:CensusSurveyEnum``). ``name`` is optional (inherited).
+
+    Attributes:
+        # Inherited from MCFNode
+        Node: Identifier for the Node (e.g. ``dcid:MyMethod``).
+        name: Optional human-readable name for the Node.
+        description: Optional human-readable description.
+
+        # MeasurementMethod-specific
+        typeOf: Measurement method enum type; defaults to ``dcid:MeasurementMethodEnum``
+            (overridable).
+    """
+
+    typeOf: DcidOrListDcid = "dcid:MeasurementMethodEnum"

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -816,3 +816,182 @@ def test_column_mappings_accepts_dcid_keys_on_input():
     # Short-key input must also still work
     cm2 = ColumnMappings.model_validate({"entity": "Country"})
     assert cm2.entity == "Country"
+
+
+# --- Schema node builder tests ---
+
+
+def test_add_entity_type_lands_node():
+    """add_entity_type normalizes bare Node to dcid: and sets typeOf."""
+    manager = CustomDataManager()
+    manager.add_entity_type(Node="MyClass", name="My Class")
+    nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
+    node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcid:Class")
+    assert node.Node == "dcid:MyClass"
+    assert node.typeOf == "dcid:Class"
+
+
+def test_add_entity_type_dcid_prefixed_node_verbatim():
+    """An already dcid:-prefixed Node is passed through verbatim."""
+    manager = CustomDataManager()
+    manager.add_entity_type(Node="dcid:Already", name="x")
+    nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
+    node = nodes[0]
+    assert node.Node == "dcid:Already"
+
+
+def test_add_event_type_default_subclassof():
+    """add_event_type defaults subClassOf to dcid:Event."""
+    manager = CustomDataManager()
+    manager.add_event_type(Node="Quake", name="Q")
+    nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
+    node = nodes[0]
+    assert node.typeOf == "dcid:Class"
+    assert node.subClassOf == "dcid:Event"
+
+
+def test_add_event_type_subclassof_override():
+    """A bare subClassOf override is normalized to dcid:."""
+    manager = CustomDataManager()
+    manager.add_event_type(Node="Quake", name="Q", subClassOf="DisasterEvent")
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.subClassOf == "dcid:DisasterEvent"
+
+
+def test_add_property_lands_node():
+    """add_property emits a Property node with dcid:Property typeOf."""
+    manager = CustomDataManager()
+    manager.add_property(
+        Node="myProp",
+        name="My Prop",
+        domainIncludes="dcid:Person",
+        rangeIncludes="dcid:Number",
+    )
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.Node == "dcid:myProp"
+    assert node.typeOf == "dcid:Property"
+    assert node.domainIncludes == "dcid:Person"
+    assert node.rangeIncludes == "dcid:Number"
+
+
+def test_add_property_normalizes_bare_refs():
+    """Bare domainIncludes/rangeIncludes/subPropertyOf refs are normalized to dcid:."""
+    manager = CustomDataManager()
+    manager.add_property(
+        Node="myProp",
+        name="x",
+        domainIncludes="Person",
+        rangeIncludes=["Number", "dcid:Already"],
+        subPropertyOf="baseProp",
+    )
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.domainIncludes == "dcid:Person"
+    assert node.rangeIncludes == ["dcid:Number", "dcid:Already"]
+    assert node.subPropertyOf == "dcid:baseProp"
+
+
+def test_add_unit_lands_node_and_typeof_override():
+    """add_unit normalizes bare typeOf override and stores shortDisplayName."""
+    manager = CustomDataManager()
+    manager.add_unit(
+        Node="USD",
+        name="US Dollar",
+        shortDisplayName="$",
+        typeOf="CurrencyUnitOfMeasure",
+    )
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
+    assert node.shortDisplayName == "$"
+
+
+def test_add_measurement_method_lands_node_and_typeof_override():
+    """add_measurement_method normalizes bare typeOf and allows absent name."""
+    manager = CustomDataManager()
+    manager.add_measurement_method(Node="MyCensus", typeOf="CensusSurveyEnum")
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.typeOf == "dcid:CensusSurveyEnum"
+    assert node.name is None
+
+
+def test_included_in_expands_to_provenance_and_source():
+    """includedIn expands to both the provenance dcid and its linked source dcid."""
+    manager = CustomDataManager()
+    manager.add_source(name="src", url="http://s")
+    manager.add_provenance(name="prov", url="http://p", source="src")
+    manager.add_entity_type(Node="T", name="T", includedIn="prov")
+
+    entity_node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert entity_node.includedIn == ["dcid:provenance/prov", "dcid:source/src"]
+    assert (
+        entity_node.model_dump()["includedIn"]
+        == "dcid:provenance/prov, dcid:source/src"
+    )
+
+
+def test_included_in_accepts_list_of_provenances():
+    """A list of provenance names expands all four dcids in order."""
+    manager = CustomDataManager()
+    manager.add_source(name="srcA", url="http://a")
+    manager.add_source(name="srcB", url="http://b")
+    manager.add_provenance(name="provA", url="http://pa", source="srcA")
+    manager.add_provenance(name="provB", url="http://pb", source="srcB")
+    manager.add_entity_type(Node="T", name="T", includedIn=["provA", "provB"])
+
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.includedIn == [
+        "dcid:provenance/provA",
+        "dcid:source/srcA",
+        "dcid:provenance/provB",
+        "dcid:source/srcB",
+    ]
+
+
+def test_included_in_dedups_shared_source():
+    """Two provenances sharing a source emit that source exactly once."""
+    manager = CustomDataManager()
+    manager.add_source(name="src", url="http://s")
+    manager.add_provenance(name="provA", url="http://pa", source="src")
+    manager.add_provenance(name="provB", url="http://pb", source="src")
+    manager.add_entity_type(Node="T", name="T", includedIn=["provA", "provB"])
+
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    # provA is processed first: emits provenance/provA then source/src.
+    # provB is processed second: emits provenance/provB; source/src already seen → skipped.
+    assert node.includedIn == [
+        "dcid:provenance/provA",
+        "dcid:source/src",
+        "dcid:provenance/provB",
+    ]
+
+
+def test_included_in_raises_for_missing_provenance():
+    """includedIn referencing an unregistered provenance raises ValueError."""
+    manager = CustomDataManager()
+    with pytest.raises(ValueError, match="ghost"):
+        manager.add_event_type(Node="E", name="E", includedIn="ghost")
+
+
+def test_add_entity_type_override():
+    """Duplicate Node without override raises; with override=True replaces."""
+    manager = CustomDataManager()
+    manager.add_entity_type(Node="T", name="First")
+    with pytest.raises(ValueError):
+        manager.add_entity_type(Node="T", name="Second")
+    manager.add_entity_type(Node="T", name="Updated", override=True)
+    node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert node.name == "Updated"
+
+
+def test_add_unit_custom_mcf_file_name():
+    """add_unit with mcf_file_name lands the node in the specified file."""
+    manager = CustomDataManager()
+    manager.add_unit(Node="MyUnit", name="My Unit", mcf_file_name="units.mcf")
+    assert "units.mcf" in manager._mcf_nodes
+    assert "custom_nodes.mcf" not in manager._mcf_nodes or not any(
+        n.Node == "dcid:MyUnit"
+        for n in manager._mcf_nodes.get(
+            "custom_nodes.mcf", type("", (), {"nodes": []})()
+        ).nodes
+    )
+    node = manager._mcf_nodes["units.mcf"].nodes[0]
+    assert node.Node == "dcid:MyUnit"

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -870,6 +870,7 @@ def test_add_property_lands_node():
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.Node == "dcid:myProp"
     assert node.typeOf == "dcid:Property"
+    assert isinstance(node, PropertyMCFNode)
     assert node.domainIncludes == "dcid:Person"
     assert node.rangeIncludes == "dcid:Number"
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -15,6 +15,7 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     ExplicitSchemaFile,
 )
+from dcp_tools.custom_data.models.schema_nodes import PropertyMCFNode
 
 
 def test_custom_data_manager_add_provenance_and_override():

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel
 from dcp_tools.custom_data.models.common import (
     StrOrListStr,
     _ensure_quoted,
+    ensure_dcid,
     mcf_quoted_str,
     mcf_str,
     mint_dcid,
@@ -68,6 +69,29 @@ def test_str_or_list_str_annotation_serialization():
 def test_parse_str_or_list_honours_quotes():
     assert parse_str_or_list('"A, B"') == "A, B"
     assert parse_str_or_list('"A, B", C') == ["A, B", "C"]
+
+
+def test_ensure_dcid_prefixes_bare_token():
+    assert ensure_dcid("MyClass") == "dcid:MyClass"
+
+
+def test_ensure_dcid_passes_prefixed_verbatim():
+    assert ensure_dcid("dcid:bio/Foo") == "dcid:bio/Foo"
+
+
+def test_ensure_dcid_rejects_empty_or_whitespace():
+    with pytest.raises(ValueError):
+        ensure_dcid("")
+    with pytest.raises(ValueError):
+        ensure_dcid("has space")
+    with pytest.raises(ValueError):
+        ensure_dcid("  leading")
+    with pytest.raises(ValueError):
+        ensure_dcid("trailing\t")
+
+
+def test_ensure_dcid_maps_over_list():
+    assert ensure_dcid(["Person", "dcid:Number"]) == ["dcid:Person", "dcid:Number"]
 
 
 def test_mint_dcid_three_way_rule():

--- a/tests/test_models_schema_nodes.py
+++ b/tests/test_models_schema_nodes.py
@@ -1,0 +1,124 @@
+import pytest
+from pydantic import ValidationError
+
+from dcp_tools.custom_data.models.schema_nodes import (
+    EntityTypeMCFNode,
+    EventTypeMCFNode,
+    MeasurementMethodMCFNode,
+    PropertyMCFNode,
+    UnitOfMeasureMCFNode,
+)
+
+# --- EntityTypeMCFNode ---
+
+
+def test_entity_type_default_typeof():
+    node = EntityTypeMCFNode(Node="dcid:MyClass", name="My Class")
+    assert node.typeOf == "dcid:Class"
+    assert "typeOf: dcid:Class" in node.mcf
+
+
+def test_entity_type_accepts_included_in_list():
+    node = EntityTypeMCFNode(
+        Node="dcid:MyClass",
+        name="My Class",
+        includedIn=["dcid:provenance/p", "dcid:source/s"],
+    )
+    assert "includedIn: dcid:provenance/p, dcid:source/s" in node.mcf
+
+
+def test_entity_type_rejects_malformed_node():
+    """Node field enforces dcid: prefix; builder normalizes before construction."""
+    with pytest.raises(ValidationError):
+        EntityTypeMCFNode(Node="MyClass", name="My Class")
+
+
+# --- EventTypeMCFNode ---
+
+
+def test_event_type_default_typeof_and_subclassof():
+    node = EventTypeMCFNode(Node="dcid:MyEvent", name="My Event")
+    assert node.typeOf == "dcid:Class"
+    assert node.subClassOf == "dcid:Event"
+
+
+def test_event_type_subclassof_override():
+    node = EventTypeMCFNode(
+        Node="dcid:MyEvent", name="My Event", subClassOf="dcid:DisasterEvent"
+    )
+    assert node.subClassOf == "dcid:DisasterEvent"
+    assert "subClassOf: dcid:DisasterEvent" in node.mcf
+
+
+# --- PropertyMCFNode ---
+
+
+def test_property_default_typeof():
+    node = PropertyMCFNode(Node="dcid:myProp", name="My Prop")
+    assert node.typeOf == "dcid:Property"
+
+
+def test_property_optional_refs_serialize():
+    node = PropertyMCFNode(
+        Node="dcid:myProp",
+        name="My Prop",
+        domainIncludes="dcid:Person",
+        rangeIncludes="dcid:Number",
+        subPropertyOf="dcid:baseProp",
+    )
+    assert "domainIncludes: dcid:Person" in node.mcf
+    assert "rangeIncludes: dcid:Number" in node.mcf
+    assert "subPropertyOf: dcid:baseProp" in node.mcf
+
+
+def test_property_model_accepts_bare_ref_unvalidated():
+    """DcidOrListDcid uses PlainValidator; the dcid: pattern is NOT enforced on ref fields.
+
+    This documents that the builder (add_property, via ensure_dcid) — not the model — is
+    what guarantees the dcid: prefix on domainIncludes/rangeIncludes/subPropertyOf. Contrast
+    with test_entity_type_rejects_malformed_node: Node is a bare Dcid field and DOES enforce.
+    """
+    node = PropertyMCFNode(Node="dcid:myProp", domainIncludes="Person")
+    assert node.domainIncludes == "Person"
+
+
+# --- UnitOfMeasureMCFNode ---
+
+
+def test_unit_default_typeof():
+    node = UnitOfMeasureMCFNode(Node="dcid:MyUnit", name="My Unit")
+    assert node.typeOf == "dcid:UnitOfMeasure"
+
+
+def test_unit_typeof_override_validates():
+    node = UnitOfMeasureMCFNode(
+        Node="dcid:USD", name="US Dollar", typeOf="dcid:CurrencyUnitOfMeasure"
+    )
+    assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
+    assert "typeOf: dcid:CurrencyUnitOfMeasure" in node.mcf
+
+
+def test_unit_inherits_short_display_name():
+    node = UnitOfMeasureMCFNode(Node="dcid:USD", name="US Dollar", shortDisplayName="$")
+    assert 'shortDisplayName: "$"' in node.mcf
+
+
+# --- MeasurementMethodMCFNode ---
+
+
+def test_measurement_method_default_typeof():
+    node = MeasurementMethodMCFNode(Node="dcid:MyMethod")
+    assert node.typeOf == "dcid:MeasurementMethodEnum"
+
+
+def test_measurement_method_typeof_override_validates():
+    node = MeasurementMethodMCFNode(
+        Node="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum"
+    )
+    assert node.typeOf == "dcid:CensusSurveyEnum"
+    assert "typeOf: dcid:CensusSurveyEnum" in node.mcf
+
+
+def test_measurement_method_allows_missing_name():
+    node = MeasurementMethodMCFNode(Node="dcid:MyMethod")
+    assert "name:" not in node.mcf


### PR DESCRIPTION
## What

Adds five kwargs-only builders on `CustomDataManager` for emitting custom schema nodes to MCF:

- `add_entity_type` — a `Class` node
- `add_event_type` — a `Class` node with `subClassOf` defaulting to `dcid:Event`
- `add_property` — a `Property` node with `domainIncludes` / `rangeIncludes` / `subPropertyOf`
- `add_unit` — a `UnitOfMeasure` node (overridable `typeOf`)
- `add_measurement_method` — a `MeasurementMethodEnum` node (overridable `typeOf`, `name` optional)

Each mints a typed node into the node collection, defaulting to `custom_nodes.mcf`.

## Why

Custom imports need entity types, event types, properties, units, and measurement methods alongside the stat vars they support. Until now these had to be hand-written into MCF; the builders make them first-class and validated.

## How it works

- A new `ensure_dcid` helper normalizes `Node` and reference tokens: bare tokens get a `dcid:` prefix, already-prefixed values pass through, and lists are mapped element-wise. Unlike `mint_dcid`, it does not slug-namespace — schema nodes are bare dcids (`dcid:MyClass`), not `dcid:source/<name>`.
- `add_property` normalizes its three ref fields through `ensure_dcid` so bare refs still emit valid MCF (the `DcidOrListDcid` field type does not enforce the `dcid:` pattern on its own).
- `add_entity_type` / `add_event_type` accept an `includedIn` provenance name. The builder requires that provenance to already be registered and expands it to both the provenance dcid and its linked source dcid, deduping a shared source.

## Testing

`ruff format --check`, `ruff check`, `ty check` clean; `pytest` → 161 passed. New tests cover each builder, ref normalization, `includedIn` expansion/dedup/missing-provenance, `typeOf` overrides, override semantics, and custom MCF file targeting.

Closes #112

Co-authored-by: Claude <noreply@anthropic.com>