### PR TITLE
refactor(custom_data)!: drop explicit/implicit schema naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,17 +22,32 @@
 - Re-pointed the data load flow at the DCP prep job, using the `IngestionJobClient`.
 - Renamed load job settings: `CLOUD_RUN_JOB_NAME` -> `LOAD_JOB_NAME` and
   `CLOUD_JOB_REGION` -> `LOAD_JOB_REGION`.
-- `Config.inputFiles` is now `Dict[str, ExplicitSchemaFile]` — the implicit
-  (`variablePerColumn`) path is no longer supported. Loading a legacy config that contains
+- `Config.inputFiles` is now `list[InputFile]` (was a dict keyed by file name). Only the
+  variable-per-row format is supported: loading a legacy config that contains
   `"format": "variablePerColumn"` now raises a clear `ValueError` with a migration message
   instead of a generic Pydantic `ValidationError`.
-- `ExplicitSchemaFile` now rejects unknown keys (`extra="forbid"`).
+- `InputFile` now rejects unknown keys (`extra="forbid"`).
+- **Renamed `export_mfc_file` to `export_mcf_file`**, correcting a transposition in the
+  method name. The old spelling is gone; update any calls.
+- **Renamed the input-file API now that there is a single import format.** The
+  `ExplicitSchemaFile` model is now `InputFile`, and `CustomDataManager.add_explicit_schema_file`
+  is now `add_input_file`. The "explicit schema" name only made sense as a contrast with the
+  removed implicit (`variablePerColumn`) schema. Signatures, field names, and the serialized
+  `config.json` are unchanged.
 - Single-entity StatVars don't emit `observationProperties` by default.
+
+### Fixed
+- `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
+  `remove_indicator` raised "not found" for the renamed node and still resolved the old
+  name. The rename now goes through a new `MCFNodes.rename`, which keeps the index in step.
 
 ### Removed
 - `add_implicit_schema_file` method on `CustomDataManager`.
 - `add_variable_to_config` method on `CustomDataManager`.
-- `ImplicitSchemaFile`, `ObservationProperties`, and `Variable` model classes.
+- `ImplicitSchemaFile` and `Variable` model classes. `ObservationProperties` is retained but
+  repurposed: it is no longer nested under a variable definition, and now carries the
+  file-level constant observation properties on `InputFile`. It also accepts custom keys
+  (`extra="allow"`, was `extra="forbid"`); the four standard fields are unchanged.
 - The `redeploy` CLI command and the `redeploy_service` and
   `redeploy_cloud_run_service` functions. The service restart is now owned by the
   ingestion workflow.
@@ -42,13 +57,16 @@
   `custom:<name>` for multi-entity dimensions.
 
 **Migration:**
-- Replace `add_implicit_schema_file` calls with `add_explicit_schema_file` and supply a
-  `columnMappings` argument. See the [Data Commons custom data documentation](https://docs.datacommons.org/custom_dc/custom_data.html) for the
-  explicit-schema format.
+- Replace `add_implicit_schema_file` calls with `add_input_file` and supply a
+  `columnMappings` argument. Data must be in the variable-per-row format (one observation
+  per row). See the [Data Commons custom data documentation](https://docs.datacommons.org/custom_dc/custom_data.html).
 - Drop any `redeploy` calls, and update your settings: rename
   `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME` and `CLOUD_JOB_REGION` → `LOAD_JOB_REGION`, add
   `LOAD_JOB_SERVICE_ACCOUNT` if the job runs under an impersonated service account.
 - Replace `entity` on `ColumnMappings` with `observationAbout`.
+- Rename `ExplicitSchemaFile` → `InputFile` and `add_explicit_schema_file` → `add_input_file`.
+  Names only; arguments and behaviour are unchanged.
+- Rename `export_mfc_file` → `export_mcf_file`.
 
 ## [0.1.1] - 2026-02-19
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -2,11 +2,19 @@
 
 ## v1.0.0 (in development)
 - Stable release of the `dcp-tools` package
-- **Breaking:** removed implicit-schema support — `add_implicit_schema_file`,
-  `add_variable_to_config`, and the `ImplicitSchemaFile` / `ObservationProperties` / `Variable`
-  model classes are gone. Loading a legacy `variablePerColumn` config now raises `ValueError`.
-  Migrate by using `add_explicit_schema_file` with `columnMappings`; see
+- **Breaking:** removed support for the second, implicit import mechanism —
+  `add_implicit_schema_file`, `add_variable_to_config`, and the `ImplicitSchemaFile` /
+  `Variable` model classes are gone (`ObservationProperties` is retained, but now carries
+  file-level constants on `InputFile`). Loading a legacy
+  `variablePerColumn` config now raises `ValueError`. Migrate by using `add_input_file` with
+  `columnMappings`; see
   [Data Commons custom data docs](https://docs.datacommons.org/custom_dc/custom_data.html).
+- **Breaking:** with a single import format left, the input-file API drops the "explicit"
+  qualifier: `ExplicitSchemaFile` is now `InputFile` and `add_explicit_schema_file` is now
+  `add_input_file`. Arguments and the generated `config.json` are unchanged.
+- **Breaking:** `export_mfc_file` is now spelled `export_mcf_file`.
+- Fixed `rename_variable`, which left the renamed node unreachable by its new name. A
+  following `remove_indicator` raised "not found" until you passed the pre-rename name.
 - **Breaking:** re-pointed the data load flow at the DCP v1.1.0 prep job. `run_data_load`
   now triggers the preprocessing job. The `redeploy` command and `redeploy_service` are removed.
   Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME`,

--- a/src/dcp_tools/custom_data/config_utils.py
+++ b/src/dcp_tools/custom_data/config_utils.py
@@ -78,7 +78,7 @@ def _merge_input_files(existing: Config, new: Config, policy: DuplicatePolicy) -
     for entry in new.inputFiles:
         key = entry.filename or entry.pattern
         if key is None:
-            # Should not happen: ExplicitSchemaFile enforces filename XOR pattern.
+            # Should not happen: InputFile enforces filename XOR pattern.
             continue
         if key not in existing_by_key:
             logger.info(f"Added input file '{key}'")

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -19,7 +19,7 @@ from dcp_tools.custom_data.models.common import ensure_dcid, mint_dcid
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
-    ExplicitSchemaFile,
+    InputFile,
     MCFFileName,
     ObservationProperties,
 )
@@ -94,10 +94,10 @@ class CustomDataManager:
     >>>     source="ONE Data",
     >>> )
 
-    To add a variable for export to an MCF file (using the explicit schema), use the
-    add_variable_to_mcf method
+    To add a variable for export to an MCF file, use the add_variable_to_mcf method.
+    Unlike the schema-node builders below, ``Node`` here must be ``dcid:``-prefixed:
     >>> dc_manager.add_variable_to_mcf(
-    >>>    Node="StatVar",
+    >>>    Node="dcid:StatVar",
     >>>    name="Variable Name",
     >>>    description="Variable Description",
     >>>    ...
@@ -124,9 +124,8 @@ class CustomDataManager:
     contain the variables you want to add.
     >>> dc_manager.add_variables_to_mcf_from_csv(file_path="path/to/file.csv")
 
-    To add an input file and data to the config, using the explicit (per row) schema,
-    use the add_explicit_schema_file method
-    >>> dc_manager.add_explicit_schema_file(
+    To add an input file and data to the config, use the add_input_file method
+    >>> dc_manager.add_input_file(
     >>>    file_name="input_file.csv",
     >>>    provenance="Provenance Name",
     >>>    data=df,
@@ -135,7 +134,7 @@ class CustomDataManager:
 
     For multi-entity observations, map each dimension with a ``custom:<name>`` key, and declare the
     matching ``dcid:<name>`` properties on the StatVar:
-    >>> dc_manager.add_explicit_schema_file(
+    >>> dc_manager.add_input_file(
     >>>    file_name="input_file.csv",
     >>>    provenance="Provenance Name",
     >>>    data=df,
@@ -176,7 +175,7 @@ class CustomDataManager:
     >>> dc_manager.export_all("path/to/folder")
 
     To export the MCF file, use the export_mcf_file method
-    >>> dc_manager.export_mfc_file("path/to/folder", file_name="custom_nodes.mcf")
+    >>> dc_manager.export_mcf_file("path/to/folder", mcf_file_name="custom_nodes.mcf")
 
     To export only the config, use the export_config method
     >>> dc_manager.export_config("path/to/config")
@@ -947,7 +946,7 @@ class CustomDataManager:
                 "Use a different name or set override as `True`."
             )
 
-    def add_explicit_schema_file(
+    def add_input_file(
         self,
         file_name: str | None = None,
         *,
@@ -966,8 +965,8 @@ class CustomDataManager:
         optional in cases where a user wants to edit the config file without the
         accompanying data. The data can be registered later using the add_data method.
 
-        This method is for the explicit schema approach (variable per row). Read more about
-        the explicit (variable-per-row) schema format here:
+        Data must be in variable-per-row form (one observation per row). Read more about
+        the input file format here:
         https://docs.datacommons.org/custom_dc/custom_data.html
 
         Exactly one of ``file_name`` or ``pattern`` must be provided. Pattern entries are
@@ -1006,7 +1005,7 @@ class CustomDataManager:
         if pattern is not None and data is not None:
             raise ValueError("'data' cannot be provided together with 'pattern'.")
 
-        entry = ExplicitSchemaFile(
+        entry = InputFile(
             filename=file_name,
             pattern=pattern,
             provenance=provenance,
@@ -1065,7 +1064,7 @@ class CustomDataManager:
             raise ValueError(
                 f"File '{file_name}' not found in the config file. Please register the "
                 "file in the config file before adding data, using the "
-                "add_explicit_schema_file method."
+                "add_input_file method."
             )
 
         self._data_override_check(file_name=file_name, override=override)
@@ -1115,9 +1114,8 @@ class CustomDataManager:
             nodes = self._mcf_nodes.get(name)
             if not nodes:
                 continue
-            for idx, node in enumerate(nodes.nodes):
-                if node.Node == old_name:
-                    nodes.nodes[idx].Node = new_name
+            if any(node.Node == old_name for node in nodes.nodes):
+                nodes.rename(old_name, new_name)
 
         return self
 
@@ -1333,7 +1331,7 @@ class CustomDataManager:
         with output_path.open("w") as f:
             f.write(config.model_dump_json(indent=4, exclude_none=True, by_alias=True))
 
-    def export_mfc_file(
+    def export_mcf_file(
         self,
         dir_path: str | PathLike[str],
         mcf_file_name: str = DEFAULT_STATVAR_MCF_NAME,
@@ -1485,7 +1483,7 @@ class CustomDataManager:
             self.export_vertical_specs(dir_path)
 
         for mcf_file_name in mcf_file_names or ():
-            self.export_mfc_file(
+            self.export_mcf_file(
                 dir_path=dir_path, mcf_file_name=mcf_file_name, override=override
             )
 

--- a/src/dcp_tools/custom_data/models/config_file.py
+++ b/src/dcp_tools/custom_data/models/config_file.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
-from dcp_tools.custom_data.models.data_files import ExplicitSchemaFile
+from dcp_tools.custom_data.models.data_files import InputFile
 
 
 class Config(BaseModel):
@@ -41,7 +41,7 @@ class Config(BaseModel):
     svHierarchyPropsBlocklist: list[str] | None = None
     dataDownloadUrl: list[str] | None = None
     verticalSpecsFile: str | None = None
-    inputFiles: list[ExplicitSchemaFile]
+    inputFiles: list[InputFile]
 
     # model configuration - populate by name (for the "format" field alias)
     # and forbid extra fields
@@ -54,8 +54,8 @@ class Config(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
-    def _reject_implicit_schema_files(cls, data: Any) -> Any:
-        """Reject legacy implicit-schema (variablePerColumn) inputFiles with a clear error.
+    def _reject_legacy_variable_per_column(cls, data: Any) -> Any:
+        """Reject legacy 'variablePerColumn' inputFiles with a clear migration error.
 
         Handles both the legacy dict format and the current list format for ``inputFiles``
         so that the friendly migration message fires before any type-coercion error.
@@ -64,18 +64,18 @@ class Config(BaseModel):
             input_files = data.get("inputFiles") or {}
             if isinstance(input_files, dict):
                 # Legacy dict format — use the dict key in the error message so callers
-                # can identify the offending file (e.g. test_loading_legacy_implicit_config).
+                # can identify the offending file.
                 for key, entry in input_files.items():
                     if isinstance(entry, dict) and "variablePerColumn" in {
                         entry.get("format"),
                         entry.get("data_format"),
                     }:
                         raise ValueError(
-                            f"Config contains implicit-schema file '{key}': "
-                            "format 'variablePerColumn' is no longer supported. "
-                            "Migrate to explicit schema before loading. See "
-                            "https://docs.datacommons.org/custom_dc/custom_data.html "
-                            "for the explicit-schema format."
+                            f"Config contains input file '{key}' in the legacy "
+                            "'variablePerColumn' format, which is no longer supported. "
+                            "Convert the file to the variable-per-row format (one "
+                            "observation per row) with a 'columnMappings' block. See "
+                            "https://docs.datacommons.org/custom_dc/custom_data.html"
                         )
             elif isinstance(input_files, list):
                 # Current list format — key off filename or pattern for the message.
@@ -88,11 +88,11 @@ class Config(BaseModel):
                             entry.get("filename") or entry.get("pattern") or "<unknown>"
                         )
                         raise ValueError(
-                            f"Config contains implicit-schema file '{key}': "
-                            "format 'variablePerColumn' is no longer supported. "
-                            "Migrate to explicit schema before loading. See "
-                            "https://docs.datacommons.org/custom_dc/custom_data.html "
-                            "for the explicit-schema format."
+                            f"Config contains input file '{key}' in the legacy "
+                            "'variablePerColumn' format, which is no longer supported. "
+                            "Convert the file to the variable-per-row format (one "
+                            "observation per row) with a 'columnMappings' block. See "
+                            "https://docs.datacommons.org/custom_dc/custom_data.html"
                         )
         return data
 

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -110,7 +110,7 @@ class ColumnMappings(BaseModel):
 
 
 class ObservationProperties(BaseModel):
-    """File-level constant observation properties for an explicit-schema input file.
+    """File-level constant observation properties for an input file.
 
     Applied as constants to every observation in the file (the only working route to a
     constant ``unit``/``scalingFactor``/``measurementMethod``/``observationPeriod``). Keys
@@ -132,8 +132,8 @@ class ObservationProperties(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-class ExplicitSchemaFile(BaseModel):
-    """Representation of an input file using the explicit (variable-per-row) schema.
+class InputFile(BaseModel):
+    """Representation of an input file in variable-per-row form (one observation per row).
 
     Exactly one of ``filename`` or ``pattern`` must be set. The ``.csv``-suffix
     check applies to ``filename`` only; ``pattern`` entries are exempt.
@@ -151,7 +151,7 @@ class ExplicitSchemaFile(BaseModel):
             the equivalent names for each column.
         observationProperties: File-level constant observation properties applied to every
             observation (constants such as unit or measurementMethod). Optional.
-        data_format: Format of the data (variable per row).
+        data_format: Format of the data (variable per row, one observation per row).
             This attribute is represented as "format" in the JSON.
     """
 
@@ -173,7 +173,7 @@ class ExplicitSchemaFile(BaseModel):
         return mint_dcid(prefix="provenance", name=value)
 
     @model_validator(mode="after")
-    def _validate_filename_or_pattern(self) -> "ExplicitSchemaFile":
+    def _validate_filename_or_pattern(self) -> "InputFile":
         if (self.filename is None) == (self.pattern is None):
             raise ValueError("Exactly one of 'filename' or 'pattern' must be set.")
         if self.filename is not None and not self.filename.lower().endswith(".csv"):

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -188,6 +188,26 @@ class MCFNodes(BaseModel):
 
         return self
 
+    def rename(self, old_id: str, new_id: str) -> MCFNodes:
+        """Renames a node in place, keeping the lookup index consistent.
+
+        Args:
+            old_id: The current ID of the node.
+            new_id: The ID to give it.
+
+        Raises:
+            ValueError: If no node has ``old_id``, or if ``new_id`` is already taken.
+        """
+        idx = self._expect_present(old_id)
+        if new_id in self._pos:
+            raise ValueError(f"Node '{new_id}' already exists.")
+
+        self.nodes[idx].Node = new_id
+        self._pos.pop(old_id)
+        self._pos[new_id] = idx
+
+        return self
+
     def export_to_mcf_file(
         self, file_path: str | PathLike, *, override: bool = True
     ) -> MCFNodes:

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -13,7 +13,7 @@ from dcp_tools.custom_data.data_management import (
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
-    ExplicitSchemaFile,
+    InputFile,
 )
 from dcp_tools.custom_data.models.schema_nodes import PropertyMCFNode
 
@@ -103,7 +103,7 @@ def test_validate_provenances_raises_for_unknown_provenance(tmp_path):
     manager = CustomDataManager()
     # Register a file with a provenance that has no corresponding MCF node
     manager._config.inputFiles.append(
-        ExplicitSchemaFile(
+        InputFile(
             filename="x.csv",
             provenance="dcid:provenance/ghost",
             columnMappings=ColumnMappings(),
@@ -165,9 +165,9 @@ def test_import_name_set_and_export_default(tmp_path):
     assert Config.from_json(str(out3 / "config.json")).importName == "toad_data"
 
 
-def test_add_explicit_schema_file_registration_and_override(tmp_path):
+def test_add_input_file_registration_and_override(tmp_path):
     """
-    Verifies explicit schema file registration in config and data,
+    Verifies input file registration in config and data,
     and override/error behaviors.
     """
     manager = CustomDataManager()
@@ -175,62 +175,60 @@ def test_add_explicit_schema_file_registration_and_override(tmp_path):
     manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df3 = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
-    manager.add_explicit_schema_file(
-        file_name="exp.csv",
+    manager.add_input_file(
+        file_name="input.csv",
         provenance="p1",
         data=df3,
         columnMappings={"observationAbout": "entity", "date": "Year", "value": "Value"},
     )
-    assert any(e.filename == "exp.csv" for e in manager._config.inputFiles)
-    assert "exp.csv" in manager._data
+    assert any(e.filename == "input.csv" for e in manager._config.inputFiles)
+    assert "input.csv" in manager._data
 
     with pytest.raises(ValueError):
-        manager.add_explicit_schema_file(
-            file_name="exp.csv",
+        manager.add_input_file(
+            file_name="input.csv",
             provenance="p1",
         )
 
     df_new = pd.DataFrame({"entity": ["e2"], "Year": [2021], "Value": [200]})
-    manager.add_explicit_schema_file(
-        file_name="exp.csv",
+    manager.add_input_file(
+        file_name="input.csv",
         provenance="p1",
         data=df_new,
         override=True,
     )
-    pd.testing.assert_frame_equal(manager._data["exp.csv"], df_new)
+    pd.testing.assert_frame_equal(manager._data["input.csv"], df_new)
 
     df4 = pd.DataFrame({"X": [1]})
     with pytest.raises(ValueError):
         manager.add_data(df4, "no_file.csv")
 
 
-def test_add_explicit_schema_file_without_column_mappings():
+def test_add_input_file_without_column_mappings():
     """Ensure missing columnMappings defaults to empty dict without error."""
     manager = CustomDataManager()
     manager.add_source(name="s1", url="http://src")
     manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1]})
-    manager.add_explicit_schema_file(file_name="exp.csv", provenance="p1", data=df)
+    manager.add_input_file(file_name="input.csv", provenance="p1", data=df)
 
-    entry = next(e for e in manager._config.inputFiles if e.filename == "exp.csv")
+    entry = next(e for e in manager._config.inputFiles if e.filename == "input.csv")
     mappings = entry.columnMappings
     assert mappings.model_dump(exclude_none=True) == {}
 
 
-def test_add_explicit_schema_file_pattern_xor_filename():
-    """add_explicit_schema_file raises when neither or both of file_name/pattern are given."""
+def test_add_input_file_pattern_xor_filename():
+    """add_input_file raises when neither or both of file_name/pattern are given."""
     manager = CustomDataManager()
     manager.add_source(name="s1", url="http://src")
     manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     with pytest.raises(ValueError, match="Exactly one"):
-        manager.add_explicit_schema_file(provenance="p1")
+        manager.add_input_file(provenance="p1")
 
     with pytest.raises(ValueError, match="Exactly one"):
-        manager.add_explicit_schema_file(
-            file_name="a.csv", pattern="a*", provenance="p1"
-        )
+        manager.add_input_file(file_name="a.csv", pattern="a*", provenance="p1")
 
 
 def test_export_methods(tmp_path):
@@ -241,7 +239,7 @@ def test_export_methods(tmp_path):
     manager.add_source(name="s1", url="http://src")
     manager.add_provenance(name="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"A": [1]})
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="data.csv",
         provenance="p1",
         data=df,
@@ -259,7 +257,7 @@ def test_export_methods(tmp_path):
     data_file = tmp_path / "data.csv"
     assert data_file.exists()
 
-    manager.export_mfc_file(tmp_path, mcf_file_name="custom_nodes.mcf")
+    manager.export_mcf_file(tmp_path, mcf_file_name="custom_nodes.mcf")
     mcf_file = tmp_path / "custom_nodes.mcf"
     assert mcf_file.exists()
     assert "Node: dcid:vX" in mcf_file.read_text()
@@ -308,7 +306,7 @@ def test_custom_data_manager_repr():
     manager.add_source(name="s1", url="http://src")
     manager.add_provenance(name="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"A": [1]})
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="f.csv",
         provenance="p1",
         data=df,
@@ -329,7 +327,7 @@ def test_remove_indicator():
     manager.add_provenance(name="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1]})
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="a.csv",
         provenance="p1",
         data=df,
@@ -359,7 +357,7 @@ def _make_cfg(
     vertical_specs_file: str | None = None,
 ):
     input_files = [
-        ExplicitSchemaFile(
+        InputFile(
             filename=key,
             provenance=prov,
             columnMappings=ColumnMappings(),
@@ -480,10 +478,10 @@ def test_export_all_includes_vertical_specs(tmp_path):
     assert config["verticalSpecsFile"] == DEFAULT_VERTICAL_SPECS_NAME
 
 
-def test_add_explicit_schema_file_observation_properties():
+def test_add_input_file_observation_properties():
     manager = CustomDataManager()
 
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         "data.csv",
         provenance="prov1",
         columnMappings={"observationAbout": "Country", "date": "Year"},
@@ -498,7 +496,7 @@ def test_add_explicit_schema_file_observation_properties():
     assert entry.columnMappings is not None
 
     # Omitting the kwarg leaves observationProperties absent (None)
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         "other.csv",
         provenance="prov1",
     )
@@ -655,6 +653,34 @@ def test_rename_variable_mcf_only():
         manager.rename_variable("dcid:v2", "dcid:v3")
 
 
+def test_rename_variable_keeps_lookup_index_consistent():
+    """A renamed node is addressable by its new name, and its old name is freed."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+    manager.rename_variable("dcid:v1", "dcid:v2")
+
+    # The old name no longer resolves...
+    with pytest.raises(ValueError):
+        manager.remove_indicator("dcid:v1")
+
+    # ...and the new one does.
+    manager.remove_indicator("dcid:v2")
+    for nodes in manager._mcf_nodes.values():
+        assert all(n.Node not in {"dcid:v1", "dcid:v2"} for n in nodes.nodes)
+
+
+def test_rename_variable_frees_the_old_name_for_reuse():
+    """After a rename the old name is available again, and both nodes survive."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+    manager.rename_variable("dcid:v1", "dcid:v2")
+
+    manager.add_variable_to_mcf(Node="dcid:v1", name="A different Var1")
+
+    stored = {n.Node for nodes in manager._mcf_nodes.values() for n in nodes.nodes}
+    assert {"dcid:v1", "dcid:v2"} <= stored
+
+
 def test_validate_all_input_files_have_data(tmp_path):
     """Verify the optional data-completeness validation on export_all and the standalone method."""
     manager = CustomDataManager()
@@ -664,12 +690,12 @@ def test_validate_all_input_files_have_data(tmp_path):
     df = pd.DataFrame({"A": [1, 2]})
 
     # Register one file WITH data and one WITHOUT data
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="with_data.csv",
         provenance="p1",
         data=df,
     )
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="no_data.csv",
         provenance="p1",
     )
@@ -702,7 +728,7 @@ def test_export_all_requires_provenance_mcf(tmp_path):
     manager = CustomDataManager()
     manager.add_source(name="s1", url="http://src")
     manager.add_provenance(name="p1", url="http://prov", source="s1")
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="data.csv", provenance="p1", data=pd.DataFrame({"A": [1]})
     )
 
@@ -722,7 +748,7 @@ def test_export_all_requires_linked_source_mcf(tmp_path):
     manager = CustomDataManager()
     manager.add_source(name="s1", url="http://src", mcf_file_name="sources.mcf")
     manager.add_provenance(name="p1", url="http://prov", source="s1")
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         file_name="data.csv", provenance="p1", data=pd.DataFrame({"A": [1]})
     )
 
@@ -737,7 +763,7 @@ def test_export_all_requires_linked_source_mcf(tmp_path):
     assert (tmp_path / "sources.mcf").exists()
 
 
-def test_loading_legacy_implicit_config_raises_with_message():
+def test_loading_legacy_variable_per_column_config_raises_with_message():
     """Loading a JSON config with variablePerColumn format raises ValueError with a clear message."""
     cfg = {
         "inputFiles": {

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -36,12 +36,12 @@ def test_config_json_snapshot(tmp_path):
     manager.add_provenance(name="provA", url="http://prova", source="S1")
     manager.add_provenance(name="provB", url="http://provb", source="S1")
 
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         "a.csv",
         provenance="provA",
         columnMappings={"observationAbout": "Country", "date": "Year", "value": "Val"},
     )
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         "b.csv",
         provenance="provB",
         columnMappings={"observationAbout": "Country", "date": "Year", "value": "Val"},
@@ -60,7 +60,7 @@ def test_config_json_snapshot_multi_entity(tmp_path):
     manager.set_importName("test_import_multi_entity")
     manager.add_source(name="S1", url="http://source1")
     manager.add_provenance(name="provC", url="http://provc", source="S1")
-    manager.add_explicit_schema_file(
+    manager.add_input_file(
         "c.csv",
         provenance="provC",
         columnMappings={
@@ -84,7 +84,7 @@ def test_provenance_mcf_snapshot(tmp_path):
     manager.add_provenance(name="provA", url="http://prova", source="S1")
     manager.add_provenance(name="provB", url="http://provb", source="S1")
 
-    manager.export_mfc_file(str(tmp_path), mcf_file_name="provenance.mcf")
+    manager.export_mcf_file(str(tmp_path), mcf_file_name="provenance.mcf")
     got = (tmp_path / "provenance.mcf").read_text()
     expected = (GOLDEN_DIR / "provenance.mcf").read_text()
     assert got == expected
@@ -101,7 +101,7 @@ def test_full_mcf_export(tmp_path):
         description="Test var",
         memberOf="dcid:one/g/group1",
     )
-    mgr.export_mfc_file(str(tmp_path), mcf_file_name="custom_nodes.mcf")
+    mgr.export_mcf_file(str(tmp_path), mcf_file_name="custom_nodes.mcf")
     got = (tmp_path / "custom_nodes.mcf").read_text()
     expected = (GOLDEN_DIR / "custom_nodes.mcf").read_text()
     assert got == expected
@@ -116,7 +116,7 @@ def test_mcf_export_multi_entity(tmp_path):
         observationProperties=["dcid:originCountry", "dcid:destinationCountry"],
     )
 
-    manager.export_mfc_file(str(tmp_path), mcf_file_name="custom_nodes.mcf")
+    manager.export_mcf_file(str(tmp_path), mcf_file_name="custom_nodes.mcf")
 
     got = (tmp_path / "custom_nodes.mcf").read_text()
     expected = (GOLDEN_DIR / "custom_nodes_multi_entity.mcf").read_text()

--- a/tests/test_input_file_characterization.py
+++ b/tests/test_input_file_characterization.py
@@ -1,10 +1,8 @@
-"""Characterization tests for the explicit-schema path.
+"""Characterization tests for the custom-data input-file path.
 
-These tests pin the CURRENT observable behavior of the explicit-schema path
-using explicit-schema fixtures only (ExplicitSchemaFile / add_explicit_schema_file
-/ ColumnMappings). They must pass against current HEAD and remain green after the
-implicit-schema path is removed (since they never reference ImplicitSchemaFile,
-ObservationProperties, Variable, or add_variable_to_config).
+These tests pin the CURRENT observable behavior of registering, exporting,
+and serializing input files (InputFile / add_input_file / ColumnMappings)
+through CustomDataManager and the config/data-file utilities.
 """
 
 from unittest.mock import Mock
@@ -16,7 +14,7 @@ from dcp_tools import CustomDataManager
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
-    ExplicitSchemaFile,
+    InputFile,
 )
 from dcp_tools.gcp_utilities.storage import (
     get_missing_csv_files,
@@ -28,13 +26,13 @@ from dcp_tools.gcp_utilities.storage import (
 # ---------------------------------------------------------------------------
 
 
-def _explicit_manager(file_name="exp.csv", *, with_data=True):
-    """Manager with one source + one explicit-schema file (optionally with data)."""
+def _manager(file_name="input.csv", *, with_data=True):
+    """Manager with one source + one input file (optionally with data)."""
     mgr = CustomDataManager()
     mgr.add_source(name="s1", url="http://src")
     mgr.add_provenance(name="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
-    mgr.add_explicit_schema_file(
+    mgr.add_input_file(
         file_name=file_name,
         provenance="p1",
         data=df if with_data else None,
@@ -43,7 +41,7 @@ def _explicit_manager(file_name="exp.csv", *, with_data=True):
     return mgr, df
 
 
-def _make_explicit_cfg(
+def _make_cfg(
     key: str,
     prov: str,
     *,
@@ -52,9 +50,9 @@ def _make_explicit_cfg(
     custom_svg_prefix=None,
     sv_blocklist=None,
 ):
-    """Build a minimal Config with one ExplicitSchemaFile."""
+    """Build a minimal Config with one InputFile."""
     input_files = [
-        ExplicitSchemaFile(
+        InputFile(
             filename=key,
             provenance=prov,
             columnMappings=ColumnMappings(
@@ -76,74 +74,74 @@ def _make_explicit_cfg(
 # ---------------------------------------------------------------------------
 
 
-def test_add_explicit_schema_file_registers_in_config_and_data():
-    """add_explicit_schema_file registers file in config and data store."""
-    manager, df = _explicit_manager()
+def test_add_input_file_registers_in_config_and_data():
+    """add_input_file registers file in config and data store."""
+    manager, df = _manager()
 
-    entry = next(e for e in manager._config.inputFiles if e.filename == "exp.csv")
-    assert isinstance(entry, ExplicitSchemaFile)
+    entry = next(e for e in manager._config.inputFiles if e.filename == "input.csv")
+    assert isinstance(entry, InputFile)
     assert entry.provenance == "dcid:provenance/p1"
     assert entry.columnMappings.observationAbout == "entity"
     assert entry.columnMappings.date == "Year"
     assert entry.columnMappings.value == "Value"
     assert entry.data_format == "variablePerRow"
 
-    assert "exp.csv" in manager._data
-    pd.testing.assert_frame_equal(manager._data["exp.csv"], df)
+    assert "input.csv" in manager._data
+    pd.testing.assert_frame_equal(manager._data["input.csv"], df)
 
 
-def test_add_explicit_schema_file_override_and_duplicate_error():
+def test_add_input_file_override_and_duplicate_error():
     """Re-adding the same file_name without override raises ValueError;
     with override=True the data is replaced."""
-    manager, _ = _explicit_manager()
+    manager, _ = _manager()
 
     df_new = pd.DataFrame({"entity": ["e2"], "Year": [2021], "Value": [200]})
 
     # Duplicate without override must raise
     with pytest.raises(ValueError):
-        manager.add_explicit_schema_file("exp.csv", provenance="p1")
+        manager.add_input_file("input.csv", provenance="p1")
 
     # Override succeeds and replaces stored data
-    manager.add_explicit_schema_file(
-        file_name="exp.csv",
+    manager.add_input_file(
+        file_name="input.csv",
         provenance="p1",
         data=df_new,
         columnMappings={"observationAbout": "entity", "date": "Year", "value": "Value"},
         override=True,
     )
-    pd.testing.assert_frame_equal(manager._data["exp.csv"], df_new)
+    pd.testing.assert_frame_equal(manager._data["input.csv"], df_new)
 
 
 def test_add_data_standalone_success_and_error():
     """Standalone add_data: success path, duplicate error, override, unregistered error."""
-    manager, _ = _explicit_manager(with_data=False)
+    manager, _ = _manager(with_data=False)
 
     # Data was not supplied at registration time
-    assert "exp.csv" not in manager._data
+    assert "input.csv" not in manager._data
 
     df = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
 
     # First add_data call succeeds
-    manager.add_data(df, "exp.csv")
-    pd.testing.assert_frame_equal(manager._data["exp.csv"], df)
+    manager.add_data(df, "input.csv")
+    pd.testing.assert_frame_equal(manager._data["input.csv"], df)
 
     # Second call without override raises
     with pytest.raises(ValueError):
-        manager.add_data(df, "exp.csv")
+        manager.add_data(df, "input.csv")
 
     # Override succeeds
     df2 = pd.DataFrame({"entity": ["e2"], "Year": [2021], "Value": [200]})
-    manager.add_data(df2, "exp.csv", override=True)
-    pd.testing.assert_frame_equal(manager._data["exp.csv"], df2)
+    manager.add_data(df2, "input.csv", override=True)
+    pd.testing.assert_frame_equal(manager._data["input.csv"], df2)
 
     # Unregistered file raises
     with pytest.raises(ValueError):
         manager.add_data(df, "unregistered.csv")
 
 
-def test_export_config_round_trip_explicit(tmp_path):
+def test_export_config_round_trip(tmp_path):
     """export_config writes config.json; Config.from_json reloads it correctly."""
-    manager, _ = _explicit_manager()
+    manager, _ = _manager()
 
     manager.export_config(tmp_path)
 
@@ -153,7 +151,7 @@ def test_export_config_round_trip_explicit(tmp_path):
     loaded = Config.from_json(str(config_file))
     assert isinstance(loaded, Config)
 
-    entry = next(e for e in loaded.inputFiles if e.filename == "exp.csv")
+    entry = next(e for e in loaded.inputFiles if e.filename == "input.csv")
     mappings = entry.columnMappings
     assert mappings.model_dump(exclude_none=True) == {
         "observationAbout": "entity",
@@ -163,21 +161,21 @@ def test_export_config_round_trip_explicit(tmp_path):
     assert entry.data_format == "variablePerRow"
 
 
-def test_config_to_dict_explicit_shape():
-    """config_to_dict returns the expected serialized shape for the explicit path.
+def test_config_to_dict_shape():
+    """config_to_dict returns the expected serialized shape for an InputFile entry.
 
-    Pins the key names and values for the explicit path. The keys use the
-    DC-import aliases: 'format' for the data format and the 'dcid:' predicate
-    forms for columnMappings.
+    Pins the key names and values. The keys use the DC-import aliases:
+    'format' for the data format and the 'dcid:' predicate forms for
+    columnMappings.
     """
-    manager, _ = _explicit_manager()
+    manager, _ = _manager()
 
     d = manager.config_to_dict()
     entries = d["inputFiles"]
-    entry = next(e for e in entries if e.get("filename") == "exp.csv")
+    entry = next(e for e in entries if e.get("filename") == "input.csv")
 
     expected = {
-        "filename": "exp.csv",
+        "filename": "input.csv",
         "provenance": "dcid:provenance/p1",
         "format": "variablePerRow",
         "columnMappings": {
@@ -189,12 +187,12 @@ def test_config_to_dict_explicit_shape():
     assert entry == expected
 
 
-def test_export_mcf_file_explicit_path(tmp_path):
+def test_export_mcf_file(tmp_path):
     """variable added via add_variable_to_mcf appears in exported MCF."""
-    manager, _ = _explicit_manager()
+    manager, _ = _manager()
     manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
 
-    manager.export_mfc_file(tmp_path, mcf_file_name="custom_nodes.mcf")
+    manager.export_mcf_file(tmp_path, mcf_file_name="custom_nodes.mcf")
 
     mcf_file = tmp_path / "custom_nodes.mcf"
     assert mcf_file.exists()
@@ -206,24 +204,24 @@ def test_export_mcf_file_explicit_path(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_explicit_schema_file_default_format():
-    """ExplicitSchemaFile defaults data_format to 'variablePerRow';
+def test_input_file_default_format():
+    """InputFile defaults data_format to 'variablePerRow';
     by_alias serialization uses key 'format'."""
-    ef = ExplicitSchemaFile(
+    entry = InputFile(
         filename="a.csv",
         provenance="p",
         columnMappings=ColumnMappings(),
     )
 
-    assert ef.data_format == "variablePerRow"
-    assert ef.model_dump(by_alias=True)["format"] == "variablePerRow"
+    assert entry.data_format == "variablePerRow"
+    assert entry.model_dump(by_alias=True)["format"] == "variablePerRow"
 
 
-def test_config_build_and_from_json_round_trip_explicit(tmp_path):
-    """An explicit-only Config survives a serialize → deserialize cycle."""
+def test_config_build_and_from_json_round_trip(tmp_path):
+    """A Config with one InputFile survives a serialize → deserialize cycle."""
     cfg = Config(
         inputFiles=[
-            ExplicitSchemaFile(
+            InputFile(
                 filename="a.csv",
                 provenance="p",
                 columnMappings=ColumnMappings(
@@ -240,11 +238,11 @@ def test_config_build_and_from_json_round_trip_explicit(tmp_path):
     assert loaded.model_dump() == cfg.model_dump()
 
 
-def test_merge_configs_from_directory_explicit(tmp_path):
-    """from_config_files_in_directory merges two explicit-only configs correctly."""
+def test_merge_configs_from_directory(tmp_path):
+    """from_config_files_in_directory merges two configs correctly."""
     d1 = tmp_path / "one"
     d1.mkdir()
-    cfg1 = _make_explicit_cfg(
+    cfg1 = _make_cfg(
         "a.csv",
         "p1",
         custom_namespace="ns",
@@ -256,7 +254,7 @@ def test_merge_configs_from_directory_explicit(tmp_path):
 
     d2 = tmp_path / "two"
     d2.mkdir()
-    cfg2 = _make_explicit_cfg(
+    cfg2 = _make_cfg(
         "b.csv",
         "p2",
         custom_svg_prefix="ns/custom/",
@@ -271,18 +269,18 @@ def test_merge_configs_from_directory_explicit(tmp_path):
     assert filenames == {"a.csv", "b.csv"}
 
 
-def test_merge_configs_from_directory_explicit_duplicate_error(tmp_path):
+def test_merge_configs_from_directory_duplicate_error(tmp_path):
     """from_config_files_in_directory raises ValueError on duplicate keys."""
     d1 = tmp_path / "one"
     d1.mkdir()
-    cfg1 = _make_explicit_cfg("a.csv", "p1")
+    cfg1 = _make_cfg("a.csv", "p1")
     (d1 / "config.json").write_text(
         cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
 
     d2 = tmp_path / "two"
     d2.mkdir()
-    cfg2 = _make_explicit_cfg("a.csv", "p2")
+    cfg2 = _make_cfg("a.csv", "p2")
     (d2 / "config.json").write_text(
         cfg2.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
@@ -291,12 +289,12 @@ def test_merge_configs_from_directory_explicit_duplicate_error(tmp_path):
         CustomDataManager.from_config_files_in_directory(tmp_path)
 
 
-def test_get_unregistered_and_missing_csv_files_explicit():
+def test_get_unregistered_and_missing_csv_files():
     """get_unregistered_csv_files and get_missing_csv_files work with
-    an explicit-only Config (depend only on inputFiles, schema-agnostic)."""
+    a Config that has one InputFile (they depend only on inputFiles)."""
     cfg = Config(
         inputFiles=[
-            ExplicitSchemaFile(
+            InputFile(
                 filename="a.csv",
                 provenance="p",
                 columnMappings=ColumnMappings(
@@ -320,7 +318,7 @@ def test_get_unregistered_and_missing_csv_files_explicit():
 
     # --- get_missing_csv_files ---
     cfg.inputFiles.append(
-        ExplicitSchemaFile(
+        InputFile(
             filename="extra.csv",
             provenance="p",
             columnMappings=ColumnMappings(

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -5,35 +5,35 @@ import pytest
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
-    ExplicitSchemaFile,
+    InputFile,
     ObservationProperties,
 )
 
 
 def test_config_validators_raise_on_invalid_input_files():
     """
-    Validates that a non-CSV filename causes an error on ExplicitSchemaFile construction.
+    Validates that a non-CSV filename causes an error on InputFile construction.
     """
     with pytest.raises(ValueError):
-        ExplicitSchemaFile(
+        InputFile(
             filename="data.txt",
             provenance="p1",
             columnMappings=ColumnMappings(),
         )
 
 
-def test_explicit_schema_file_filename_pattern_xor():
+def test_input_file_filename_pattern_xor():
     """Exactly one of filename/pattern must be set; providing both or neither raises."""
     # Neither provided
     with pytest.raises(ValueError):
-        ExplicitSchemaFile(
+        InputFile(
             provenance="p1",
             columnMappings=ColumnMappings(),
         )
 
     # Both provided
     with pytest.raises(ValueError):
-        ExplicitSchemaFile(
+        InputFile(
             filename="a.csv",
             pattern="a*",
             provenance="p1",
@@ -41,40 +41,40 @@ def test_explicit_schema_file_filename_pattern_xor():
         )
 
     # filename only — valid
-    ef = ExplicitSchemaFile(
+    by_filename = InputFile(
         filename="a.csv",
         provenance="p1",
         columnMappings=ColumnMappings(),
     )
-    assert ef.filename == "a.csv"
-    assert ef.pattern is None
+    assert by_filename.filename == "a.csv"
+    assert by_filename.pattern is None
 
     # pattern only — valid (no .csv check on pattern)
-    ep = ExplicitSchemaFile(
+    by_pattern = InputFile(
         pattern="data_*",
         provenance="p1",
         columnMappings=ColumnMappings(),
     )
-    assert ep.pattern == "data_*"
-    assert ep.filename is None
+    assert by_pattern.pattern == "data_*"
+    assert by_pattern.filename is None
 
 
-def test_explicit_schema_file_provenance_minted():
-    """ExplicitSchemaFile mints the provenance to dcid:provenance/<name>."""
-    ef = ExplicitSchemaFile(
+def test_input_file_provenance_minted():
+    """InputFile mints the provenance to dcid:provenance/<name>."""
+    entry = InputFile(
         filename="a.csv",
         provenance="myProv",
         columnMappings=ColumnMappings(),
     )
-    assert ef.provenance == "dcid:provenance/myProv"
+    assert entry.provenance == "dcid:provenance/myProv"
 
     # Already-minted provenance is returned verbatim
-    ef2 = ExplicitSchemaFile(
+    already_minted = InputFile(
         filename="b.csv",
         provenance="dcid:provenance/myProv",
         columnMappings=ColumnMappings(),
     )
-    assert ef2.provenance == "dcid:provenance/myProv"
+    assert already_minted.provenance == "dcid:provenance/myProv"
 
 
 def test_config_round_trips_import_name(tmp_path):
@@ -143,22 +143,22 @@ def test_config_accepts_data_download_url_and_vertical_specs_file(tmp_path):
     assert dumped["verticalSpecsFile"] == "vert.json"
 
 
-def test_explicit_schema_file_observation_properties_roundtrip():
+def test_input_file_observation_properties_roundtrip():
     """observationProperties coexists with columnMappings; custom keys survive dump+reload."""
-    ef = ExplicitSchemaFile(
+    entry = InputFile(
         filename="data.csv",
         provenance="prov1",
         columnMappings=ColumnMappings(observationAbout="Country", date="Year"),
         observationProperties=ObservationProperties(unit="USD", customProp="x"),
     )
-    dumped = ef.model_dump(exclude_none=True, by_alias=True)
+    dumped = entry.model_dump(exclude_none=True, by_alias=True)
     assert "observationProperties" in dumped
     assert dumped["observationProperties"]["unit"] == "USD"
     assert dumped["observationProperties"]["customProp"] == "x"
     assert "columnMappings" in dumped
 
     # Reload from the dumped dict
-    reloaded = ExplicitSchemaFile.model_validate(dumped)
+    reloaded = InputFile.model_validate(dumped)
     assert reloaded.observationProperties is not None
     assert reloaded.observationProperties.unit == "USD"
     assert reloaded.observationProperties.__pydantic_extra__["customProp"] == "x"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,7 +6,7 @@ import pytest
 from dcp_tools.custom_data.models.config_file import Config
 from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
-    ExplicitSchemaFile,
+    InputFile,
 )
 from dcp_tools.gcp_utilities.settings import KGSettings
 from dcp_tools.gcp_utilities.storage import (
@@ -23,7 +23,7 @@ from dcp_tools.gcp_utilities.storage import (
 def _minimal_config(key: str = "a.csv") -> Config:
     return Config(
         inputFiles=[
-            ExplicitSchemaFile(
+            InputFile(
                 filename=key,
                 provenance="prov",
                 columnMappings=ColumnMappings(),
@@ -325,7 +325,7 @@ def test_get_unregistered_csv_files_honors_patterns():
 
     cfg = Config(
         inputFiles=[
-            ExplicitSchemaFile(
+            InputFile(
                 pattern="data_*.csv",
                 provenance="prov",
                 columnMappings=ColumnMappings(),
@@ -362,7 +362,7 @@ def test_get_missing_csv_files():
 
     cfg = _minimal_config()
     cfg.inputFiles.append(
-        ExplicitSchemaFile(
+        InputFile(
             filename="extra.csv",
             provenance="prov",
             columnMappings=ColumnMappings(),
@@ -382,7 +382,7 @@ def test_get_missing_csv_files_with_prefix_added():
 
     cfg = _minimal_config("sub/a.csv")
     cfg.inputFiles.append(
-        ExplicitSchemaFile(
+        InputFile(
             filename="sub/b.csv",
             provenance="prov",
             columnMappings=ColumnMappings(),
@@ -424,7 +424,7 @@ def test_get_missing_csv_files_per_import():
 
     cfg = _minimal_config("a.csv")
     cfg.inputFiles.append(
-        ExplicitSchemaFile(
+        InputFile(
             filename="b.csv",
             provenance="prov",
             columnMappings=ColumnMappings(),
@@ -447,7 +447,7 @@ def test_registration_checks_fresh_import_empty_prefix():
 
     cfg = _minimal_config("a.csv")
     cfg.inputFiles.append(
-        ExplicitSchemaFile(
+        InputFile(
             filename="b.csv",
             provenance="prov",
             columnMappings=ColumnMappings(),


### PR DESCRIPTION
Data Commons had two import mechanisms. The implicit (`variablePerColumn`) one is gone, leaving a single format, but the "explicit" qualifier survived in class names, method names, tests and docstrings, implying a choice the caller no longer has.

Behaviour is unchanged apart from one bug fix, noted below. Arguments, field names and the serialized `config.json` are identical.

## Renames

- `ExplicitSchemaFile` → `InputFile`
- `add_explicit_schema_file` → `add_input_file`
- `export_mfc_file` → `export_mcf_file`, correcting a transposition
- `_reject_implicit_schema_files` → `_reject_legacy_variable_per_column`, plus test helpers and seven `*_explicit` test names

## What was deliberately left alone

The `variablePerColumn` vocabulary stays where it is load-bearing: the validator that rejects a legacy config, and its test. That code exists to give someone with an old config a useful error, so it now names the dead *format* rather than a dead *mechanism*.

Ordinary-English uses of "explicit" are untouched (`isn't explicitly defined yet`, `an explicit file_name overrides`). They mean "stated outright"; replacing them was the easy way to get this wrong.

`InputFile.data_format` remains a single-valued `Literal["variablePerRow"]`. It still pins the `format` key the importer expects, so removing it would change serialization.

## Bug fix

`rename_variable` mutated `node.Node` in place while `MCFNodes._pos` stayed keyed by the old name. `remove_indicator` looks up through that index, so after a rename it raised "not found" for the new name and still resolved the old one.

The root cause was an encapsulation break: the caller reached past the collection that owns the index. The rename now goes through a new `MCFNodes.rename`, alongside `add` and `remove`.

## Testing

177 pass, up from 175. `ruff check` and `ruff format --check` clean.

The two new tests cover the `rename_variable` fix. Both were confirmed to fail against the old code and pass against the fix. The existing `test_rename_variable_mcf_only` only walked the `nodes` list and never exercised a lookup, which is why the bug survived.

## Related

Two pre-existing bugs found while verifying, filed rather than fixed here since both are behaviour changes: #127 (`export_all` writes a partial bundle when a file name contains a subdirectory) and #128 (`add_variable_to_mcf` is the only builder that does not mint the `dcid:` prefix on `Node`). #128 overlaps #126 without duplicating it.

Co-authored-by: Claude <noreply@anthropic.com>