### PR TITLE
fix(custom_data): create parent dirs on export and mint dcid: on statvar refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@
   `"format": "variablePerColumn"` now raises a clear `ValueError` with a migration message
   instead of a generic Pydantic `ValidationError`.
 - `InputFile` now rejects unknown keys (`extra="forbid"`).
-- **Renamed `export_mfc_file` to `export_mcf_file`**, correcting a transposition in the
-  method name. The old spelling is gone; update any calls.
+- **Renamed `export_mfc_file` to `export_mcf_file` and `csv_metadata_to_mfc_file` to
+  `csv_metadata_to_mcf_file`**, correcting a transposition in both names
+  (`csv_metadata_to_mcf_file` is exported from the package root). The old spellings are
+  gone; update any calls.
 - **Renamed the input-file API now that there is a single import format.** The
   `ExplicitSchemaFile` model is now `InputFile`, and `CustomDataManager.add_explicit_schema_file`
   is now `add_input_file`. The "explicit schema" name only made sense as a contrast with the
@@ -40,6 +42,15 @@
 - `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
   `remove_indicator` raised "not found" for the renamed node and still resolved the old
   name. The rename now goes through a new `MCFNodes.rename`, which keeps the index in step.
+- `export_data`, `export_mcf_file`, and `export_vertical_specs` raised `OSError` when the
+  target file name (an `add_input_file` path, an `mcf_file_name`, or a `verticalSpecsFile`)
+  nested in a subdirectory that did not yet exist. Each now creates the parent directory
+  before writing.
+- `add_variable_to_mcf` did not normalize a bare `Node` to `dcid:<token>`, unlike the
+  schema-node builders, so a bare token raised a `ValidationError` there while working
+  everywhere else. It now goes through the same `ensure_dcid` normalization, as do its
+  `populationType`, `measuredProperty`, `measurementQualifier` and
+  `measurementDenominator` arguments, which had the same gap.
 
 ### Removed
 - `add_implicit_schema_file` method on `CustomDataManager`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ introduction to the package, and to learn how to use it.
 
 ### 1. Create a CustomDataManager object. 
 
-The CustomDataManager object will handle generating the `config.json` file, as well as (optionally) taking Pandas DataFrames and exporting them as CSVs (in the right format) for loading to the Knowlede Graph.
+The CustomDataManager object will handle generating the `config.json` file, as well as (optionally) taking Pandas DataFrames and exporting them as CSVs (in the right format) for loading to the Knowledge Graph.
 
 In this example, we assume a `config.json` does not yet exist.
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -12,9 +12,19 @@
 - **Breaking:** with a single import format left, the input-file API drops the "explicit"
   qualifier: `ExplicitSchemaFile` is now `InputFile` and `add_explicit_schema_file` is now
   `add_input_file`. Arguments and the generated `config.json` are unchanged.
-- **Breaking:** `export_mfc_file` is now spelled `export_mcf_file`.
+- **Breaking:** `export_mfc_file` is now spelled `export_mcf_file`, and
+  `csv_metadata_to_mfc_file` is now `csv_metadata_to_mcf_file`.
 - Fixed `rename_variable`, which left the renamed node unreachable by its new name. A
   following `remove_indicator` raised "not found" until you passed the pre-rename name.
+- Fixed `export_data`, `export_mcf_file`, and `export_vertical_specs` raising `OSError`
+  when the target file name nested in a subdirectory that did not yet exist (for example
+  an `add_input_file` name such as `"sub/gdp.csv"`). Each now creates the parent
+  directory before writing.
+- Fixed `add_variable_to_mcf`, which did not normalize a bare `Node` to `dcid:<token>`
+  like the schema-node builders do, so a bare token raised a `ValidationError` there
+  while working everywhere else. Its `populationType`, `measuredProperty`,
+  `measurementQualifier` and `measurementDenominator` arguments had the same gap and
+  now accept bare tokens too.
 - **Breaking:** re-pointed the data load flow at the DCP v1.1.0 prep job. `run_data_load`
   now triggers the preprocessing job. The `redeploy` command and `redeploy_service` are removed.
   Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME`,

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,7 +1,7 @@
 # Getting started with `dcp-tools`
 
 This page walks you through the basic steps to install and start using 
-`bblocks-datacommonst-tools` to prepare and load the data for your custom instance.
+`bblocks-datacommons-tools` to prepare and load the data for your custom instance.
 
 ## About custom Data Commons instances
 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -201,7 +201,7 @@ manager.set_svHierarchyPropsBlocklist([
 
 ## Validating and exporting files
 
-To ensure that your `config.json` is correctly strucured, you can validate it using the `validate_config` method:
+To ensure that your `config.json` is correctly structured, you can validate it using the `validate_config` method:
 
 ```python
 manager.validate_config()

--- a/src/dcp_tools/__init__.py
+++ b/src/dcp_tools/__init__.py
@@ -2,14 +2,14 @@ from importlib.metadata import version
 
 from .custom_data.config_utils import merge_configs_from_directory
 from .custom_data.data_management import CustomDataManager
-from .custom_data.schema_tools import csv_metadata_to_mfc_file, csv_metadata_to_nodes
+from .custom_data.schema_tools import csv_metadata_to_mcf_file, csv_metadata_to_nodes
 
 __version__ = version("dcp-tools")
 
 
 __all__ = [
     "CustomDataManager",
-    "csv_metadata_to_mfc_file",
+    "csv_metadata_to_mcf_file",
     "csv_metadata_to_nodes",
     "merge_configs_from_directory",
 ]

--- a/src/dcp_tools/cli/csv2mcf.py
+++ b/src/dcp_tools/cli/csv2mcf.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from dcp_tools.custom_data.schema_tools import (
     NodeTypes,
-    csv_metadata_to_mfc_file,
+    csv_metadata_to_mcf_file,
 )
 
 __all__ = ["add_parser", "run"]
@@ -81,7 +81,7 @@ def run(args: argparse.Namespace) -> int:
     column_mapping = dict(args.column_mapping) if args.column_mapping else None
     csv_options = dict(args.csv_option) if args.csv_option else None
 
-    csv_metadata_to_mfc_file(
+    csv_metadata_to_mcf_file(
         csv_path=args.csv,
         mcf_path=args.mcf,
         node_type=args.node_type,

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -95,9 +95,9 @@ class CustomDataManager:
     >>> )
 
     To add a variable for export to an MCF file, use the add_variable_to_mcf method.
-    Unlike the schema-node builders below, ``Node`` here must be ``dcid:``-prefixed:
+    ``Node`` accepts a bare or ``dcid:``-prefixed token, as the schema-node builders below do:
     >>> dc_manager.add_variable_to_mcf(
-    >>>    Node="dcid:StatVar",
+    >>>    Node="StatVar",
     >>>    name="Variable Name",
     >>>    description="Variable Description",
     >>>    ...
@@ -548,7 +548,11 @@ class CustomDataManager:
         """Add a StatVar node for the MCF file
 
         Args:
-            Node: The identifier of the statistical variable.
+            Node: The identifier of the statistical variable. A bare token is
+                normalized to ``dcid:<token>`` and an already ``dcid:``-prefixed token
+                is kept as-is; either way whitespace raises ``ValueError``. The same
+                applies to ``populationType``, ``measuredProperty``,
+                ``measurementQualifier`` and ``measurementDenominator``.
             name: Name of the variable (Optional)
             memberOf: Member of group for the variable (Optional)
             statType: Type of the statistical variable (Optional)
@@ -570,6 +574,16 @@ class CustomDataManager:
         Returns:
             CustomDataManager object
         """
+
+        Node = ensure_dcid(Node)
+        if populationType is not None:
+            populationType = ensure_dcid(populationType)
+        if measuredProperty is not None:
+            measuredProperty = ensure_dcid(measuredProperty)
+        if measurementQualifier is not None:
+            measurementQualifier = ensure_dcid(measurementQualifier)
+        if measurementDenominator is not None:
+            measurementDenominator = ensure_dcid(measurementDenominator)
 
         props = _parse_kwargs_into_properties(locals())
         node = StatVarMCFNode(**props)
@@ -1352,6 +1366,7 @@ class CustomDataManager:
         if not nodes:
             raise ValueError(f"No data available for '{mcf_file_name}'")
 
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         nodes.export_to_mcf_file(file_path=output_path, override=override)
 
     def config_to_dict(self) -> dict:
@@ -1385,7 +1400,9 @@ class CustomDataManager:
             raise ValueError("No data to export")
 
         for file, data in self._data.items():
-            data.to_csv(Path(dir_path) / file, index=False)
+            path = Path(dir_path) / file
+            path.parent.mkdir(parents=True, exist_ok=True)
+            data.to_csv(path, index=False)
 
     def export_vertical_specs(self, dir_path: str | PathLike[str]) -> None:
         """Export the vertical-specs file as ``{"specs": [...]}`` JSON.
@@ -1408,7 +1425,9 @@ class CustomDataManager:
         payload = {
             "specs": [spec.model_dump(mode="json") for spec in self._vertical_specs]
         }
-        with (Path(dir_path) / file_name).open("w") as f:
+        output_path = Path(dir_path) / file_name
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w") as f:
             f.write(json.dumps(payload, indent=4))
 
     def validate_all_input_files_have_data(self) -> CustomDataManager:

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -210,7 +210,7 @@ def validate_mcf_file_name(file_name: str | MCFFileName) -> str:
     return file_name.file_name
 
 
-def csv_metadata_to_mfc_file(
+def csv_metadata_to_mcf_file(
     csv_path: str | PathLike[str],
     mcf_path: str | PathLike[str],
     node_type: NodeTypes | str,

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -8,6 +8,7 @@ import pytest
 from dcp_tools import CustomDataManager
 from dcp_tools.custom_data.data_management import (
     DEFAULT_GROUP_NAME,
+    DEFAULT_STATVAR_MCF_NAME,
     DEFAULT_VERTICAL_SPECS_NAME,
 )
 from dcp_tools.custom_data.models.config_file import Config
@@ -261,6 +262,68 @@ def test_export_methods(tmp_path):
     mcf_file = tmp_path / "custom_nodes.mcf"
     assert mcf_file.exists()
     assert "Node: dcid:vX" in mcf_file.read_text()
+
+
+def test_export_data_creates_missing_subdirectory(tmp_path):
+    """export_data creates the parent directory for a nested file_name."""
+    manager = CustomDataManager()
+    manager.add_source(name="S", url="http://s")
+    manager.add_provenance(name="P", url="http://p", source="S")
+    manager.set_includeInputSubdirs(True)
+    manager.add_input_file(
+        file_name="sub/gdp.csv",
+        provenance="P",
+        data=pd.DataFrame({"a": [1]}),
+        columnMappings={"value": "a"},
+    )
+
+    manager.export_data(tmp_path)
+
+    assert (tmp_path / "sub" / "gdp.csv").exists()
+
+
+def test_export_mcf_file_creates_missing_subdirectory(tmp_path):
+    """export_mcf_file creates the parent directory for a nested mcf_file_name."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(
+        Node="dcid:vX", name="VX", mcf_file_name="sub/custom_nodes.mcf"
+    )
+
+    manager.export_mcf_file(tmp_path, mcf_file_name="sub/custom_nodes.mcf")
+
+    assert (tmp_path / "sub" / "custom_nodes.mcf").exists()
+
+
+def test_export_vertical_specs_creates_missing_subdirectory(tmp_path):
+    """export_vertical_specs creates the parent directory for a nested verticalSpecsFile."""
+    manager = CustomDataManager()
+    manager.add_vertical_spec(
+        verticals=["PersonCountVertical"], file_name="sub/vertical_specs.json"
+    )
+
+    manager.export_vertical_specs(tmp_path)
+
+    assert (tmp_path / "sub" / "vertical_specs.json").exists()
+
+
+def test_export_all_writes_full_bundle_for_subdirectory_input_file(tmp_path):
+    """export_all writes the complete bundle when a file_name nests in a subdirectory."""
+    manager = CustomDataManager()
+    manager.set_includeInputSubdirs(True)
+    manager.add_source(name="S", url="http://s")
+    manager.add_provenance(name="P", url="http://p", source="S")
+    manager.add_input_file(
+        file_name="sub/gdp.csv",
+        provenance="P",
+        data=pd.DataFrame({"a": [1]}),
+        columnMappings={"value": "a"},
+    )
+
+    manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
+
+    assert (tmp_path / "sub" / "gdp.csv").exists()
+    assert (tmp_path / "config.json").exists()
+    assert (tmp_path / "provenance.mcf").exists()
 
 
 def test_add_variable_group_to_mcf_and_override():
@@ -874,6 +937,47 @@ def test_column_mappings_rejects_malformed_custom_dimension_names(dimension_name
 
 
 # --- Schema node builder tests ---
+
+
+def test_add_variable_to_mcf_normalizes_bare_node():
+    """add_variable_to_mcf normalizes a bare Node to dcid:, matching the other builders."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(Node="StatVar", name="Variable Name")
+    node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
+    assert node.Node == "dcid:StatVar"
+
+
+def test_add_variable_to_mcf_normalizes_bare_reference_fields():
+    """The Dcid-typed reference kwargs accept bare tokens too, like Node."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(
+        Node="StatVar",
+        name="Variable Name",
+        populationType="Person",
+        measuredProperty="count",
+        measurementQualifier="Commitment",
+        measurementDenominator="Area",
+    )
+    node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
+    assert node.populationType == "dcid:Person"
+    assert node.measuredProperty == "dcid:count"
+    assert node.measurementQualifier == "dcid:Commitment"
+    assert node.measurementDenominator == "dcid:Area"
+
+
+def test_add_variable_to_mcf_passes_prefixed_reference_fields_through():
+    """Already dcid:-prefixed values are not double-prefixed."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(
+        Node="dcid:StatVar",
+        name="Variable Name",
+        populationType="dcid:Person",
+        measuredProperty="dcid:count",
+    )
+    node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
+    assert node.Node == "dcid:StatVar"
+    assert node.populationType == "dcid:Person"
+    assert node.measuredProperty == "dcid:count"
 
 
 def test_add_entity_type_lands_node():


### PR DESCRIPTION
Closes #127. Closes #128.

## #127 — partial bundle on a subdirectory file name

`export_data` never created the parent directory, so any input file name containing a slash raised `OSError`. By then `export_config` had already run, leaving a directory holding a `config.json` that declares input files which are not on disk. That is the dangerous half of the bug: a stale but plausible-looking bundle is exactly what someone uploads.

`export_mcf_file` and `export_vertical_specs` had the same gap. Both are reachable from public API, so both are fixed here:

- `add_variable_to_mcf(mcf_file_name="sub/x.mcf")` — `MCFFileName`'s pattern is `.*\.mcf$`, unanchored, so a nested name validates.
- `add_vertical_spec(file_name="sub/vs.json")` — `verticalSpecsFile` has no format constraint at all.

`export_config` is deliberately not changed. It writes a fixed `config.json` name that no user input reaches.

The issue's separate question — whether `export_all` should validate the whole layout up front to honour its documented all-or-nothing contract — is **not** addressed here, as the issue asked.

## #128 — dcid: minting on add_variable_to_mcf

`add_variable_to_mcf` was the only builder that did not mint `dcid:` on `Node`, so a bare token worked in the five schema-node builders and raised here.

The issue proposed fixing `Node`. This also mints `populationType`, `measuredProperty`, `measurementQualifier` and `measurementDenominator`, which are plain `Dcid`-typed and had the identical gap. Fixing only `Node` would have left `add_variable_to_mcf(Node="v", populationType="Person")` still crashing immediately after a change whose whole point is that builder's inconsistency.

Two exclusions, both deliberate:

- `statType` is a `StrEnum` whose members are already `dcid:`-prefixed. A bare value failing is correct enum validation, not this bug.
- `memberOf` is `GroupDcidOrListGroupDcid`, the validator bypass tracked in #126. Fixing it here would collide with that work.

The `CustomDataManager` class docstring claimed `Node` had to be `dcid:`-prefixed here. This change makes that false, so it and its example are corrected.

## Behaviour change worth knowing

The minting is additive for every input shape but one. A bare token previously raised on all five kwargs, so no working call changes; an already-prefixed token is unaffected. The exception is a **whitespace-padded** prefixed value such as `" dcid:Foo "`, which the model's `strip_whitespace` used to accept and `ensure_dcid` now rejects with `ValueError`.

This is not new behaviour, it is the existing `ensure_dcid` contract that the five sibling builders have always applied — `add_entity_type(Node=" dcid:MyClass ")` rejects it today on `main`. This PR makes `add_variable_to_mcf` consistent with them. The argument docstring states the whitespace rule rather than claiming values pass through verbatim.

Relatedly, passing a non-`str` to these kwargs now surfaces a `TypeError` from inside `ensure_dcid` instead of a pydantic `ValidationError`. That is a pre-existing wart shared by all five sibling builders, not introduced here, and it only triggers when the caller has already violated the `str` signature.

## Typo fix

`csv_metadata_to_mfc_file` → `csv_metadata_to_mcf_file`. "mfc" is a transposition, and the name is exported from the package root. This completes the `export_mfc_file` rename from the previous release, which missed this one. Three single-word spelling fixes in prose are included; no other documentation is touched, since a separate docs rewrite owns those pages.

## Testing

184 pass, up from 177. `ruff check` and `ruff format --check` clean.

Every new regression test was confirmed to fail against the unfixed source and pass after — the export tests raise `OSError`, the minting tests raise `ValidationError`. One exception, stated plainly: `test_add_variable_to_mcf_passes_prefixed_reference_fields_through` passes against the old code too. It is a guard against a future double-prefixing bug, not evidence the fix works; the two tests above it carry that.

Co-authored-by: Claude <noreply@anthropic.com>