### PR TITLE
fix(custom_data): enforce the dcid: pattern on DcidOrListDcid fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,23 @@
   everywhere else. It now goes through the same `ensure_dcid` normalization, as do its
   `populationType`, `measuredProperty`, `measurementQualifier` and
   `measurementDenominator` arguments, which had the same gap.
+- `DcidOrListDcid` used a `PlainValidator`, which replaces the wrapped `Dcid` schema
+  instead of running before it, so the `dcid:` prefix check never executed. Any string,
+  including one with no `dcid:` prefix at all, passed through unvalidated and landed in
+  the MCF verbatim. This affected `typeOf` on every MCF node, `relevantVariable`,
+  `observationProperties` and `member` on StatVar nodes, and `includedIn`, `subClassOf`,
+  `domainIncludes`, `rangeIncludes` and `subPropertyOf` on the schema-node builders.
+  These fields now normalize a bare token to `dcid:<token>` (the same rule `ensure_dcid`
+  already applied at the builder level) and reject anything empty or whitespace-bearing.
+  A non-string value now raises `ValidationError` rather than being accepted silently.
+  This is a behaviour change for anyone passing a bare token to one of these fields today
+  and relying on it staying bare. The group/peer-group/topic variants
+  (`GroupDcidOrListGroupDcid` and friends) have the same gap and are not fixed here.
+  `memberOf`'s use as a scratch field in `build_stat_var_groups_from_strings` needs sorting
+  out first, and it is tracked separately. Two fields therefore stay unguarded:
+  `StatVarMCFNode.memberOf`, and `TopicMCFNode.relevantVariable`, whose type is a union of
+  the fixed and unfixed variants, so a value the fixed branch rejects still validates
+  through an unfixed one. `StatVarMCFNode.relevantVariable` is unaffected and is fixed.
 
 ### Removed
 - `add_implicit_schema_file` method on `CustomDataManager`.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -25,6 +25,20 @@
   while working everywhere else. Its `populationType`, `measuredProperty`,
   `measurementQualifier` and `measurementDenominator` arguments had the same gap and
   now accept bare tokens too.
+- Fixed `DcidOrListDcid`, which used a `PlainValidator` that replaced the wrapped `Dcid`
+  schema rather than running before it, so the `dcid:` prefix check never ran. Any
+  string, prefixed or not, passed through and landed in the MCF verbatim. This affected
+  `typeOf` on every MCF node, `relevantVariable`, `observationProperties` and `member` on
+  StatVar nodes, and `includedIn`, `subClassOf`, `domainIncludes`, `rangeIncludes` and
+  `subPropertyOf` on the schema-node builders. These fields now normalize a bare token to
+  `dcid:<token>` and reject anything empty or whitespace-bearing, and a non-string value
+  now raises rather than being accepted silently. Breaking for anyone
+  passing a bare token to one of these fields today and relying on it staying bare. The
+  group/peer-group/topic variants have the same gap and are not fixed here, since
+  `memberOf`'s use as a scratch field in `build_stat_var_groups_from_strings` needs
+  sorting out first. That leaves `StatVarMCFNode.memberOf` and
+  `TopicMCFNode.relevantVariable` unguarded, the latter because its type unions the fixed
+  and unfixed variants. `StatVarMCFNode.relevantVariable` is fixed. Tracked separately.
 - **Breaking:** re-pointed the data load flow at the DCP v1.1.0 prep job. `run_data_load`
   now triggers the preprocessing job. The `redeploy` command and `redeploy_service` are removed.
   Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME`,

--- a/src/dcp_tools/custom_data/models/common.py
+++ b/src/dcp_tools/custom_data/models/common.py
@@ -79,6 +79,40 @@ def parse_str_or_list(value: str | list[str]) -> str | list[str]:
     return value
 
 
+def _prepare_dcid_or_list(value: Any) -> str | list[str]:
+    """Normalize dcid-or-list input ahead of the inner Dcid-family schema.
+
+    Used as a ``BeforeValidator`` (not ``PlainValidator``, which would replace the inner
+    schema rather than run before it) so the ``dcid:``/slug pattern check on the wrapped
+    ``Dcid``/``GroupDcid``/``PeerGroupDcid``/``TopicDcid`` type still runs afterwards.
+
+    Splits a comma-delimited string into a list (``parse_str_or_list``), repairs
+    ``"dcid: <token>"`` spacing per element the same way ``Dcid``'s own
+    ``BeforeValidator`` does, and mints bare tokens to ``dcid:<token>`` via
+    ``ensure_dcid``. Repairing the spacing before minting means a value like
+    ``"dcid: Foo"`` is fixed up rather than rejected by ``ensure_dcid``'s
+    no-whitespace rule, matching what a plain ``Dcid`` field already does.
+
+    Raises:
+        ValueError: If the value is not a string or a list of strings. Raising
+            ``ValueError`` (rather than letting ``ensure_dcid`` fail on a non-iterable)
+            keeps the failure a ``pydantic.ValidationError`` for the caller.
+    """
+    if not isinstance(value, (str, list)):
+        raise ValueError(
+            f"expected a string or list of strings, got {type(value).__name__}"
+        )
+    if isinstance(value, list) and not all(isinstance(v, str) for v in value):
+        raise ValueError("expected every element to be a string")
+
+    value = parse_str_or_list(value)
+    if isinstance(value, list):
+        value = [_strip_space_after_dcid(v) for v in value]
+    else:
+        value = _strip_space_after_dcid(value)
+    return ensure_dcid(value)
+
+
 QuotedStr = Annotated[
     str, PlainSerializer(_ensure_quoted, return_type=str | None, when_used="always")
 ]
@@ -118,10 +152,11 @@ TopicDcid = Annotated[
 
 DcidOrListDcid = Annotated[
     Dcid | list[Dcid],
-    PlainValidator(parse_str_or_list),
+    BeforeValidator(_prepare_dcid_or_list),
     PlainSerializer(mcf_str, return_type=Dcid | None, when_used="always"),
 ]
-"""Accepts a string or list and serialises to a comma-separated string."""
+"""Accepts a bare or dcid:-prefixed string/list (bare tokens are minted via
+ensure_dcid) and serialises to a comma-separated string."""
 
 
 GroupDcidOrListGroupDcid = Annotated[
@@ -129,21 +164,32 @@ GroupDcidOrListGroupDcid = Annotated[
     PlainValidator(parse_str_or_list),
     PlainSerializer(mcf_str, return_type=GroupDcid | None, when_used="always"),
 ]
-"""Accepts a string or list and serialises to a comma-separated string."""
+"""Accepts a string or list and serialises to a comma-separated string.
+
+Still uses PlainValidator, unlike DcidOrListDcid: `memberOf` on StatVarMCFNode is used
+by build_stat_var_groups_from_strings as a scratch field for an unresolved raw group
+path before it is reassigned to a real group dcid, and MCFNode has no
+validate_assignment, so enforcing the pattern here would block that legitimate
+intermediate value without actually guarding the value that reaches the MCF file.
+Tracked separately from #126 (see follow-up issue)."""
 
 PeerGroupDcidOrListPeerGroupDcid = Annotated[
     PeerGroupDcid | list[PeerGroupDcid],
     PlainValidator(parse_str_or_list),
     PlainSerializer(mcf_str, return_type=PeerGroupDcid | None, when_used="always"),
 ]
-"""Accepts a string or list and serialises to a comma-separated string."""
+"""Accepts a string or list and serialises to a comma-separated string.
+
+See GroupDcidOrListGroupDcid docstring: same PlainValidator, same follow-up."""
 
 TopicDcidOrListTopicDcid = Annotated[
     TopicDcid | list[TopicDcid],
     PlainValidator(parse_str_or_list),
     PlainSerializer(mcf_str, return_type=TopicDcid | None, when_used="always"),
 ]
-"""Accepts a string or list and serialises to a comma-separated string."""
+"""Accepts a string or list and serialises to a comma-separated string.
+
+See GroupDcidOrListGroupDcid docstring: same PlainValidator, same follow-up."""
 
 CustomDimensionName = Annotated[str, StringConstraints(pattern=r"^\S+$")]
 """A custom dimension key, becomes `custom:<name>` and `dcid:<name>` downstream."""

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -1,7 +1,8 @@
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from dcp_tools.custom_data.models.common import (
+    DcidOrListDcid,
     StrOrListStr,
     _ensure_quoted,
     ensure_dcid,
@@ -118,3 +119,68 @@ def test_mint_dcid_rejects_empty_or_whitespace_names():
         mint_dcid(prefix="source", name="  leading")
     with pytest.raises(ValueError):
         mint_dcid(prefix="source", name="trailing\t")
+
+
+# --- DcidOrListDcid and friends (regression test for #126) ---
+#
+# PlainValidator used to replace the inner Dcid/GroupDcid/PeerGroupDcid/TopicDcid schema
+# outright, so its dcid:/slug pattern never ran and any string passed through unvalidated.
+# These exercise the BeforeValidator fix directly against the type aliases (not just a
+# specific model field), matching the Dummy(BaseModel) pattern used for StrOrListStr above.
+
+
+def test_dcid_or_list_dcid_mints_bare_scalar_and_list():
+    class Dummy(BaseModel):
+        field: DcidOrListDcid
+
+    assert Dummy(field="MyClass").field == "dcid:MyClass"
+    assert Dummy(field=["One", "Two"]).field == ["dcid:One", "dcid:Two"]
+    # comma-delimited string is split first, then each element minted
+    assert Dummy(field="One, Two").field == ["dcid:One", "dcid:Two"]
+    # already dcid:-prefixed values pass through verbatim
+    assert Dummy(field="dcid:bio/Foo").field == "dcid:bio/Foo"
+
+
+def test_dcid_or_list_dcid_rejects_whitespace_bearing_token():
+    class Dummy(BaseModel):
+        field: DcidOrListDcid
+
+    with pytest.raises(ValidationError):
+        Dummy(field="has space")
+    with pytest.raises(ValidationError):
+        Dummy(field=["ok", "has space"])
+
+
+def test_dcid_or_list_dcid_repairs_space_after_dcid_prefix():
+    """ "dcid: Foo" is repaired to "dcid:Foo", the same as a plain Dcid field, rather
+    than rejected by ensure_dcid's own no-whitespace rule. Preserves the one case where
+    the old, unvalidated PlainValidator didn't raise on this input either (see #126)."""
+
+    class Dummy(BaseModel):
+        field: DcidOrListDcid
+
+    assert Dummy(field="dcid: Foo").field == "dcid:Foo"
+
+
+def test_dcid_or_list_dcid_rejects_non_string_input():
+    """A non-string value raises ValidationError, not a raw TypeError out of ensure_dcid.
+
+    Before #126 a value like 123 was silently accepted, because PlainValidator never
+    reached ensure_dcid. The guard keeps the failure a pydantic error for the caller.
+    """
+
+    class Dummy(BaseModel):
+        field: DcidOrListDcid
+
+    with pytest.raises(ValidationError):
+        Dummy(field=123)
+    with pytest.raises(ValidationError):
+        Dummy(field=["dcid:ok", 5])
+    with pytest.raises(ValidationError):
+        Dummy(field={"a": "b"})
+
+
+# GroupDcidOrListGroupDcid, PeerGroupDcidOrListPeerGroupDcid and TopicDcidOrListTopicDcid
+# still use PlainValidator (their slug pattern still bypassed) — see the docstring on
+# GroupDcidOrListGroupDcid in models/common.py for why, and the follow-up issue tracking
+# it separately from #126.

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 
 from dcp_tools.custom_data.models.mcf import MCFNode, MCFNodes
 
@@ -92,6 +93,17 @@ def test_mcfnodes_load_from_file_without_name(tmp_path):
     assert first.Node == "dcid:NoName"
     assert getattr(first, "name", None) is None
     assert first.typeOf == "dcid:TypeA"
+
+
+def test_mcfnode_typeof_normalizes_bare_token():
+    """typeOf is DcidOrListDcid; a bare token is minted to dcid:<token> (regression for #126)."""
+    node = MCFNode(Node="dcid:TestNode", typeOf="TypeA")
+    assert node.typeOf == "dcid:TypeA"
+
+
+def test_mcfnode_typeof_rejects_whitespace_bearing_token():
+    with pytest.raises(ValidationError):
+        MCFNode(Node="dcid:TestNode", typeOf="has space")
 
 
 def test_mcfnodes_add_override_and_remove():

--- a/tests/test_models_schema_nodes.py
+++ b/tests/test_models_schema_nodes.py
@@ -33,6 +33,12 @@ def test_entity_type_rejects_malformed_node():
         EntityTypeMCFNode(Node="MyClass", name="My Class")
 
 
+def test_entity_type_included_in_normalizes_bare_token():
+    """includedIn is DcidOrListDcid; a bare token is minted (regression for #126)."""
+    node = EntityTypeMCFNode(Node="dcid:MyClass", name="My Class", includedIn="p")
+    assert node.includedIn == "dcid:p"
+
+
 # --- EventTypeMCFNode ---
 
 
@@ -48,6 +54,14 @@ def test_event_type_subclassof_override():
     )
     assert node.subClassOf == "dcid:DisasterEvent"
     assert "subClassOf: dcid:DisasterEvent" in node.mcf
+
+
+def test_event_type_subclassof_normalizes_bare_token():
+    """subClassOf is DcidOrListDcid; a bare token is minted (regression for #126)."""
+    node = EventTypeMCFNode(
+        Node="dcid:MyEvent", name="My Event", subClassOf="DisasterEvent"
+    )
+    assert node.subClassOf == "dcid:DisasterEvent"
 
 
 # --- PropertyMCFNode ---
@@ -71,15 +85,29 @@ def test_property_optional_refs_serialize():
     assert "subPropertyOf: dcid:baseProp" in node.mcf
 
 
-def test_property_model_accepts_bare_ref_unvalidated():
-    """DcidOrListDcid uses PlainValidator; the dcid: pattern is NOT enforced on ref fields.
-
-    This documents that the builder (add_property, via ensure_dcid) — not the model — is
-    what guarantees the dcid: prefix on domainIncludes/rangeIncludes/subPropertyOf. Contrast
-    with test_entity_type_rejects_malformed_node: Node is a bare Dcid field and DOES enforce.
-    """
+def test_property_model_normalizes_bare_ref():
+    """DcidOrListDcid now runs ensure_dcid via a BeforeValidator (regression for #126), so
+    domainIncludes/rangeIncludes/subPropertyOf are normalized at the model layer too, not
+    just by the builder (add_property). A bare token is minted to dcid:<token>."""
     node = PropertyMCFNode(Node="dcid:myProp", domainIncludes="Person")
-    assert node.domainIncludes == "Person"
+    assert node.domainIncludes == "dcid:Person"
+
+
+def test_property_model_rejects_whitespace_bearing_ref():
+    with pytest.raises(ValidationError):
+        PropertyMCFNode(Node="dcid:myProp", domainIncludes="has space")
+
+
+def test_property_model_normalizes_bare_ref_list():
+    node = PropertyMCFNode(
+        Node="dcid:myProp",
+        domainIncludes=["Person", "Household"],
+        rangeIncludes=["Number"],
+        subPropertyOf=["baseProp"],
+    )
+    assert node.domainIncludes == ["dcid:Person", "dcid:Household"]
+    assert node.rangeIncludes == ["dcid:Number"]
+    assert node.subPropertyOf == ["dcid:baseProp"]
 
 
 # --- UnitOfMeasureMCFNode ---

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -1,6 +1,11 @@
 import pandas as pd
+import pytest
+from pydantic import ValidationError
 
-from dcp_tools.custom_data.models.stat_vars import StatVarMCFNode
+from dcp_tools.custom_data.models.stat_vars import (
+    StatVarMCFNode,
+    StatVarPeerGroupMCFNode,
+)
 from dcp_tools.custom_data.schema_tools import _rows_to_stat_var_nodes
 
 
@@ -80,3 +85,66 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
     assert "memberOf: dcid:oneId, dcid:twoId" in mcf
+
+
+# --- observationProperties / relevantVariable normalize bare tokens (regression for #126) ---
+#
+# Both are DcidOrListDcid. Before the fix, PlainValidator bypassed the dcid: pattern
+# entirely, so a bare token like "originCountry" landed in the MCF unprefixed.
+
+
+def test_observation_properties_normalizes_bare_scalar_and_list():
+    sv = StatVarMCFNode(
+        Node="dcid:n1", name="Var", observationProperties="originCountry"
+    )
+    assert sv.observationProperties == "dcid:originCountry"
+
+    sv_list = StatVarMCFNode(
+        Node="dcid:n1",
+        name="Var",
+        observationProperties=["originCountry", "destinationCountry"],
+    )
+    assert sv_list.observationProperties == [
+        "dcid:originCountry",
+        "dcid:destinationCountry",
+    ]
+    assert (
+        "observationProperties: dcid:originCountry, dcid:destinationCountry"
+        in sv_list.mcf
+    )
+
+
+def test_observation_properties_rejects_whitespace_bearing_token():
+    with pytest.raises(ValidationError):
+        StatVarMCFNode(Node="dcid:n1", name="Var", observationProperties="has space")
+
+
+def test_relevant_variable_normalizes_bare_scalar_and_list():
+    sv = StatVarMCFNode(Node="dcid:n1", name="Var", relevantVariable="otherVar")
+    assert sv.relevantVariable == "dcid:otherVar"
+
+    sv_list = StatVarMCFNode(
+        Node="dcid:n1", name="Var", relevantVariable=["one", "two"]
+    )
+    assert sv_list.relevantVariable == ["dcid:one", "dcid:two"]
+
+
+def test_relevant_variable_rejects_whitespace_bearing_token():
+    with pytest.raises(ValidationError):
+        StatVarMCFNode(Node="dcid:n1", name="Var", relevantVariable="has space")
+
+
+# --- member on StatVarPeerGroupMCFNode is DcidOrListDcid, same normalization ---
+
+
+def test_peer_group_member_normalizes_bare_scalar_and_list():
+    node = StatVarPeerGroupMCFNode(
+        Node="dcid:svpg/x", name="Peers", member=["varOne", "varTwo"]
+    )
+    assert node.member == ["dcid:varOne", "dcid:varTwo"]
+    assert "member: dcid:varOne, dcid:varTwo" in node.mcf
+
+
+def test_peer_group_member_rejects_whitespace_bearing_token():
+    with pytest.raises(ValidationError):
+        StatVarPeerGroupMCFNode(Node="dcid:svpg/x", name="Peers", member="has space")

--- a/tests/test_models_topics.py
+++ b/tests/test_models_topics.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import ValidationError
+
+from dcp_tools.custom_data.models.topics import TopicMCFNode
+
+# relevantVariable is DcidOrListDcid | GroupDcidOrListGroupDcid | TopicDcidOrListTopicDcid.
+# Only DcidOrListDcid was fixed for #126 (see models/common.py); the other two still use
+# PlainValidator, so there is no whitespace-rejection test here — a value the DcidOrListDcid
+# branch would reject can still validate via the still-permissive Group/Topic branches.
+
+
+def test_topic_relevant_variable_accepts_bare_statvar_dcid():
+    """A bare token matches the plain-Dcid branch and is minted to a plain dcid
+    (regression for #126: this used to pass through unvalidated)."""
+    node = TopicMCFNode(
+        Node="dcid:topic/T", name="Topic", relevantVariable="myVariable"
+    )
+    assert node.relevantVariable == "dcid:myVariable"
+
+
+def test_topic_relevant_variable_accepts_group_dcid():
+    node = TopicMCFNode(Node="dcid:topic/T", name="Topic", relevantVariable="g/MyGroup")
+    assert node.relevantVariable == "dcid:g/MyGroup"
+
+
+def test_topic_relevant_variable_accepts_topic_dcid():
+    node = TopicMCFNode(
+        Node="dcid:topic/T", name="Topic", relevantVariable="topic/OtherTopic"
+    )
+    assert node.relevantVariable == "dcid:topic/OtherTopic"
+
+
+def test_topic_relevant_variable_accepts_list():
+    node = TopicMCFNode(
+        Node="dcid:topic/T",
+        name="Topic",
+        relevantVariable=["varOne", "varTwo"],
+    )
+    assert node.relevantVariable == ["dcid:varOne", "dcid:varTwo"]
+    assert "relevantVariable: dcid:varOne, dcid:varTwo" in node.mcf
+
+
+def test_topic_node_rejects_missing_slug():
+    with pytest.raises(ValidationError):
+        TopicMCFNode(Node="dcid:NotATopic", name="Topic", relevantVariable="var")


### PR DESCRIPTION
Closes #126.

`DcidOrListDcid` wrapped `Dcid | list[Dcid]` in a `PlainValidator`, which **replaces** the inner schema instead of running before it, so the `^dcid:\S+$` pattern never executed. Any string survived validation and reached the MCF file verbatim.

```python
sv = StatVarMCFNode(Node="dcid:n1", name="Var", observationProperties=["originCountry"])
# before: observationProperties: originCountry
# after:  observationProperties: dcid:originCountry
```

The wrapper is now a `BeforeValidator`, so the pattern runs. It comma-splits, repairs `"dcid: Foo"` spacing per element the way `Dcid`'s own `BeforeValidator` does, then mints bare tokens via `ensure_dcid`. Repairing *before* minting matters: `ensure_dcid` rejects any whitespace, so the other order would have turned a silently-repaired input into a hard error.

Covers `typeOf` on every MCF node, `relevantVariable`, `observationProperties` and `member` on StatVar nodes, and `includedIn`, `subClassOf`, `domainIncludes`, `rangeIncludes` and `subPropertyOf` on the schema nodes.

## Behaviour changes

- A bare token is rewritten to `dcid:<token>` instead of staying bare.
- An empty or whitespace-bearing value now raises.
- A non-string value now raises `ValidationError`. It was accepted silently before, and once `ensure_dcid` was in the path a non-iterable would have leaked a raw `TypeError`, so `_prepare_dcid_or_list` guards the type explicitly.

## Scope: the slug-patterned variants are deliberately not fixed

The issue also names `GroupDcidOrListGroupDcid`, `PeerGroupDcidOrListPeerGroupDcid` and `TopicDcidOrListTopicDcid`. Fixing them here would have been wrong, for a reason that only shows up on inspection.

`memberOf` is `GroupDcidOrListGroupDcid`, and `build_stat_var_groups_from_strings` deliberately parks an unresolved slash path there (`"Economic/Employment"`) before resolving it. Its docstring documents that. Enforcing the group pattern at construction breaks `add_variables_to_mcf_from_csv(parse_groups=True)` and four existing tests.

That alone would only argue for staging the path elsewhere. The deciding point is that `MCFNode` does not set `validate_assignment`, so assignment is never validated:

```python
sv.memberOf = "total/garbage no slug"   # accepted silently
```

`build_stat_var_groups_from_strings` writes the value that actually reaches the MCF through exactly that unvalidated assignment. So construction-time enforcement would reject a legitimate intermediate value while leaving the real output unguarded — it buys nothing and breaks a working feature.

Filed as #131, which captures the variants, the `memberOf` staging design and the `validate_assignment` gap together, because a fix to any one of them alone is incomplete.

**What stays exposed, stated plainly:** `StatVarMCFNode.memberOf`, and `TopicMCFNode.relevantVariable` — the latter because its type unions the fixed variant with two unfixed ones, so a value the fixed branch rejects still validates through an unfixed branch. It is the only such union in the codebase. `StatVarMCFNode.relevantVariable` is plain `DcidOrListDcid` and is fixed. Both changelogs say this rather than implying a blanket fix.

## Testing

205 pass, up from 184. `ruff check`, `ruff format --check` and `ty check` clean.

All 20 new and changed tests were confirmed to fail against the unfixed `common.py`; none are hollow. `tests/test_schema_tools.py` and `tests/goldens/` have **zero diff**, which is the check that the serialized output for valid input is unchanged.

One pre-existing test was modified: `test_property_model_accepts_bare_ref_unvalidated` → `test_property_model_normalizes_bare_ref`. It documented the bug, so its assertion is inverted and its name no longer advertises the old behaviour.

`tests/test_models_topics.py` deliberately omits a rejection test for `relevantVariable`, with a comment saying why, rather than asserting behaviour that does not hold.

## Known, pre-existing, not addressed

Field defaults (`subClassOf = "dcid:Event"`, and the two `typeOf` defaults) are never validated, because `validate_default` is off. They are correct by inspection, but they do not exercise this code path.

Co-authored-by: Claude <noreply@anthropic.com>