### PR TITLE
fix(custom_data)!: enforce dcid patterns on assignment and group refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,10 @@
 - `add_variables_to_mcf_from_csv(parse_groups=True)` raised `AttributeError` when the CSV had
   no `memberOf` column, or when a row left it blank. The missing column now raises a
   `ValueError` naming it, and a blank value leaves that node's `memberOf` unset.
+- A group path with a whitespace-only segment, such as `"Economic/\t/Health"`, minted a group
+  whose dcid ended in a bare `g/` with no slug. Only `/` and spaces were stripped, so a tab or
+  line break survived the split and `to_camelCase` reduced it to an empty slug. Such segments
+  are now dropped.
 
 ### Removed
 - `add_implicit_schema_file` method on `CustomDataManager`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@
   removed implicit (`variablePerColumn`) schema. Signatures, field names, and the serialized
   `config.json` are unchanged.
 - Single-entity StatVars don't emit `observationProperties` by default.
+- **Replaced `build_stat_var_groups_from_strings` with `resolve_group_paths`.** The old
+  function took an `MCFNodes` container and used `StatVarMCFNode.memberOf` as a scratch
+  field, holding a raw path such as `"Economic/Employment"` until it was overwritten with
+  the resolved group dcid. That is why `memberOf` could not be validated. `resolve_group_paths`
+  works on the path strings alone and returns the resolved dcid per path plus the
+  `StatVarGroupMCFNode` objects, so a node is never constructed with an invalid `memberOf`.
+  `csv_metadata_to_nodes` gained `parse_groups` and `group_namespace` and does the resolution
+  between reading the CSV and building the nodes. `CustomDataManager.add_variables_to_mcf_from_csv`
+  is unchanged.
+- `rename_variable` normalizes a bare `old_name`/`new_name` to `dcid:<token>`, the same rule
+  `add_variable_to_mcf` applies to `Node`.
 
 ### Fixed
 - `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
@@ -61,13 +72,26 @@
   already applied at the builder level) and reject anything empty or whitespace-bearing.
   A non-string value now raises `ValidationError` rather than being accepted silently.
   This is a behaviour change for anyone passing a bare token to one of these fields today
-  and relying on it staying bare. The group/peer-group/topic variants
-  (`GroupDcidOrListGroupDcid` and friends) have the same gap and are not fixed here.
-  `memberOf`'s use as a scratch field in `build_stat_var_groups_from_strings` needs sorting
-  out first, and it is tracked separately. Two fields therefore stay unguarded:
-  `StatVarMCFNode.memberOf`, and `TopicMCFNode.relevantVariable`, whose type is a union of
-  the fixed and unfixed variants, so a value the fixed branch rejects still validates
-  through an unfixed one. `StatVarMCFNode.relevantVariable` is unaffected and is fixed.
+  and relying on it staying bare.
+- `GroupDcidOrListGroupDcid` had the same `PlainValidator` bypass, so `StatVarMCFNode.memberOf`
+  accepted any string and wrote it to the MCF verbatim. It now enforces the `GroupDcid`
+  pattern, which requires a `g/` segment, so `memberOf="dcid:myGroup"` now raises and
+  `memberOf="one/g/economy"` is minted to `dcid:one/g/economy`. `TopicMCFNode.relevantVariable`
+  was a union of the fixed type with two unfixed ones, so a value the fixed branch rejected
+  still validated through a permissive branch. Its type is now plain `DcidOrListDcid`, which
+  accepts exactly the same values the union was meant to allow, group and topic dcids included.
+- `MCFNode` now validates on assignment (`validate_assignment=True`). Restoring the patterns
+  above would otherwise guard construction only, and the value that reaches the MCF file is
+  often written by assignment, so `node.memberOf = "garbage"` and `MCFNodes.rename` could
+  still put an invalid dcid in the output. Both now raise. Assigned values are also cleaned
+  of line breaks and trailing spaces the way constructed ones are, for declared fields and
+  for the extra keys that carry arbitrary MCF properties.
+- `csv_metadata_to_nodes` returned an `MCFNodes` whose lookup index did not include the
+  StatVarGroup nodes it appended, so a later `remove` or `rename` of a group node on the
+  returned container raised "not found".
+- `add_variables_to_mcf_from_csv(parse_groups=True)` raised `AttributeError` when the CSV had
+  no `memberOf` column, or when a row left it blank. The missing column now raises a
+  `ValueError` naming it, and a blank value leaves that node's `memberOf` unset.
 
 ### Removed
 - `add_implicit_schema_file` method on `CustomDataManager`.
@@ -83,6 +107,11 @@
   `CLOUD_SERVICE_REGION`, `CLOUD_RUN_SERVICE_NAME`, and `DATACOMMONS_SERVICE_IMAGE`.
 - **BREAKING**: `entity` key on `ColumnMappings`. Use `observationAbout` for single-entity data or
   `custom:<name>` for multi-entity dimensions.
+- The `PeerGroupDcidOrListPeerGroupDcid` and `TopicDcidOrListTopicDcid` type aliases, and the
+  `TopicDcid` they wrapped. `PeerGroupDcidOrListPeerGroupDcid` and `TopicDcid` were never
+  referenced by any field, which is how the bypass in them went unnoticed.
+  `TopicDcidOrListTopicDcid` was the permissive member of `TopicMCFNode.relevantVariable`'s
+  union, and nothing references it now that the union has collapsed.
 
 **Migration:**
 - Replace `add_implicit_schema_file` calls with `add_input_file` and supply a
@@ -95,6 +124,12 @@
 - Rename `ExplicitSchemaFile` → `InputFile` and `add_explicit_schema_file` → `add_input_file`.
   Names only; arguments and behaviour are unchanged.
 - Rename `export_mfc_file` → `export_mcf_file`.
+- Check any `memberOf` value you pass to `add_variable_to_mcf` or supply in a StatVar CSV. It
+  must now resolve to a group dcid containing `g/`, for example `one/g/economy` or
+  `dcid:one/g/economy`. A value such as `dcid:economy` is rejected instead of being written to
+  the MCF as-is.
+- Replace direct calls to `build_stat_var_groups_from_strings` with either
+  `csv_metadata_to_nodes(..., parse_groups=True, group_namespace=...)` or `resolve_group_paths`.
 
 ## [0.1.1] - 2026-02-19
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -33,12 +33,27 @@
   `subPropertyOf` on the schema-node builders. These fields now normalize a bare token to
   `dcid:<token>` and reject anything empty or whitespace-bearing, and a non-string value
   now raises rather than being accepted silently. Breaking for anyone
-  passing a bare token to one of these fields today and relying on it staying bare. The
-  group/peer-group/topic variants have the same gap and are not fixed here, since
-  `memberOf`'s use as a scratch field in `build_stat_var_groups_from_strings` needs
-  sorting out first. That leaves `StatVarMCFNode.memberOf` and
-  `TopicMCFNode.relevantVariable` unguarded, the latter because its type unions the fixed
-  and unfixed variants. `StatVarMCFNode.relevantVariable` is fixed. Tracked separately.
+  passing a bare token to one of these fields today and relying on it staying bare.
+- **Breaking:** `memberOf` on a StatVar now has to be a real group dcid. It had the same
+  bypass, so any string reached the MCF verbatim; it now requires a `g/` segment, so
+  `one/g/economy` is minted to `dcid:one/g/economy` and `dcid:economy` is rejected. Check the
+  `memberOf` values in your StatVar CSVs and `add_variable_to_mcf` calls.
+- **Breaking:** `relevantVariable` on a Topic node is now plain `DcidOrListDcid`. Its type used
+  to combine the fixed variant with two unfixed ones, so a value the fixed one rejected still
+  got through the others. It accepts the same StatVar, group and topic dcids as before, and
+  now rejects the malformed values that used to slip past.
+- **Breaking:** MCF nodes now validate on assignment, not only on construction. Setting a
+  field to an invalid value, for example `node.memberOf = "garbage"` or renaming a node to a
+  token with no `dcid:` prefix, raises instead of quietly writing it to the MCF file.
+- **Breaking:** `build_stat_var_groups_from_strings` is replaced by `resolve_group_paths`. It
+  used `memberOf` to hold an unresolved group path such as `"Economic/Employment"` until it
+  was overwritten, which is what blocked validating the field. Group paths are now resolved
+  before the nodes are built. If you call it directly, use
+  `csv_metadata_to_nodes(..., parse_groups=True, group_namespace=...)` instead.
+  `add_variables_to_mcf_from_csv` is unchanged.
+- Fixed `add_variables_to_mcf_from_csv(parse_groups=True)` raising `AttributeError` when the
+  CSV had no `memberOf` column or a row left it blank. The missing column now raises a clear
+  `ValueError`, and a blank value leaves that node's `memberOf` unset.
 - **Breaking:** re-pointed the data load flow at the DCP v1.1.0 prep job. `run_data_load`
   now triggers the preprocessing job. The `redeploy` command and `redeploy_service` are removed.
   Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME`,

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -53,7 +53,9 @@
   `add_variables_to_mcf_from_csv` is unchanged.
 - Fixed `add_variables_to_mcf_from_csv(parse_groups=True)` raising `AttributeError` when the
   CSV had no `memberOf` column or a row left it blank. The missing column now raises a clear
-  `ValueError`, and a blank value leaves that node's `memberOf` unset.
+  `ValueError`, and a blank value leaves that node's `memberOf` unset. A group path holding a
+  whitespace-only segment, such as a stray tab between two slashes, also used to mint a group
+  with an empty name; those segments are now dropped.
 - **Breaking:** re-pointed the data load flow at the DCP v1.1.0 prep job. `run_data_load`
   now triggers the preprocessing job. The `redeploy` command and `redeploy_service` are removed.
   Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME`,

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -39,7 +39,6 @@ from dcp_tools.custom_data.models.stat_vars import (
 )
 from dcp_tools.custom_data.models.vertical_specs import VerticalSpec
 from dcp_tools.custom_data.schema_tools import (
-    build_stat_var_groups_from_strings,
     csv_metadata_to_nodes,
     validate_mcf_file_name,
 )
@@ -927,21 +926,21 @@ class CustomDataManager:
                 ``pandas.read_csv``.
             ignore_columns: List of columns to ignore in the CSV file.
             override: If True, overwrite the existing nodes if they exist. Defaults to False.
+
+        Raises:
+            ValueError: If ``group_namespace`` is set while ``parse_groups`` is False, or
+                if ``parse_groups`` is True and the CSV has no ``memberOf`` column.
         """
         stat_vars = csv_metadata_to_nodes(
             file_path=csv_file_path,
             column_to_property_mapping=column_to_property_mapping,
             csv_options=csv_options,
             ignore_columns=ignore_columns,
+            parse_groups=parse_groups,
+            group_namespace=group_namespace,
         )
 
-        if parse_groups:
-            if not group_namespace:
-                group_namespace = ""
-            stat_vars = build_stat_var_groups_from_strings(
-                stat_vars, groups_namespace=group_namespace
-            )
-        elif group_namespace:
+        if not parse_groups and group_namespace:
             raise ValueError(
                 "group_namespace should not be set if parse_groups is False"
             )
@@ -1092,8 +1091,11 @@ class CustomDataManager:
         """Rename a variable across any loaded MCF files.
 
         Args:
-            old_name: The name of the variable to rename.
-            new_name: The new name for the variable.
+            old_name: The name of the variable to rename. A bare token is normalized
+                to ``dcid:<token>``, the same rule ``add_variable_to_mcf`` applies to
+                ``Node``.
+            new_name: The new name for the variable. Same normalization as
+                ``old_name``.
             mcf_file_name: Optional name of the MCF file from which to rename the variable.
                 If omitted, all managed MCF files are searched.
         Raises:
@@ -1101,6 +1103,9 @@ class CustomDataManager:
                 new name already exists in any searched MCF file.
 
         """
+
+        old_name = ensure_dcid(old_name)
+        new_name = ensure_dcid(new_name)
 
         file_names = (
             [validate_mcf_file_name(mcf_file_name)]

--- a/src/dcp_tools/custom_data/models/common.py
+++ b/src/dcp_tools/custom_data/models/common.py
@@ -84,7 +84,7 @@ def _prepare_dcid_or_list(value: Any) -> str | list[str]:
 
     Used as a ``BeforeValidator`` (not ``PlainValidator``, which would replace the inner
     schema rather than run before it) so the ``dcid:``/slug pattern check on the wrapped
-    ``Dcid``/``GroupDcid``/``PeerGroupDcid``/``TopicDcid`` type still runs afterwards.
+    ``Dcid``/``GroupDcid`` type still runs afterwards.
 
     Splits a comma-delimited string into a list (``parse_str_or_list``), repairs
     ``"dcid: <token>"`` spacing per element the same way ``Dcid``'s own
@@ -146,10 +146,6 @@ PeerGroupDcid = Annotated[
     Dcid, StringConstraints(strip_whitespace=True, pattern=r"^dcid:.*svpg/.*")
 ]
 
-TopicDcid = Annotated[
-    Dcid, StringConstraints(strip_whitespace=True, pattern=r"^dcid:.*topic/.*")
-]
-
 DcidOrListDcid = Annotated[
     Dcid | list[Dcid],
     BeforeValidator(_prepare_dcid_or_list),
@@ -161,35 +157,11 @@ ensure_dcid) and serialises to a comma-separated string."""
 
 GroupDcidOrListGroupDcid = Annotated[
     GroupDcid | list[GroupDcid],
-    PlainValidator(parse_str_or_list),
+    BeforeValidator(_prepare_dcid_or_list),
     PlainSerializer(mcf_str, return_type=GroupDcid | None, when_used="always"),
 ]
-"""Accepts a string or list and serialises to a comma-separated string.
-
-Still uses PlainValidator, unlike DcidOrListDcid: `memberOf` on StatVarMCFNode is used
-by build_stat_var_groups_from_strings as a scratch field for an unresolved raw group
-path before it is reassigned to a real group dcid, and MCFNode has no
-validate_assignment, so enforcing the pattern here would block that legitimate
-intermediate value without actually guarding the value that reaches the MCF file.
-Tracked separately from #126 (see follow-up issue)."""
-
-PeerGroupDcidOrListPeerGroupDcid = Annotated[
-    PeerGroupDcid | list[PeerGroupDcid],
-    PlainValidator(parse_str_or_list),
-    PlainSerializer(mcf_str, return_type=PeerGroupDcid | None, when_used="always"),
-]
-"""Accepts a string or list and serialises to a comma-separated string.
-
-See GroupDcidOrListGroupDcid docstring: same PlainValidator, same follow-up."""
-
-TopicDcidOrListTopicDcid = Annotated[
-    TopicDcid | list[TopicDcid],
-    PlainValidator(parse_str_or_list),
-    PlainSerializer(mcf_str, return_type=TopicDcid | None, when_used="always"),
-]
-"""Accepts a string or list and serialises to a comma-separated string.
-
-See GroupDcidOrListGroupDcid docstring: same PlainValidator, same follow-up."""
+"""Accepts a bare or dcid:-prefixed string/list (bare tokens are minted via
+ensure_dcid) and serialises to a comma-separated string."""
 
 CustomDimensionName = Annotated[str, StringConstraints(pattern=r"^\S+$")]
 """A custom dimension key, becomes `custom:<name>` and `dcid:<name>` downstream."""

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -45,21 +45,29 @@ class MCFNode(BaseModel):
     # (which assigns `.Node`), not just on construction.
     model_config = ConfigDict(extra="allow", validate_assignment=True)
 
+    @staticmethod
+    def _clean_str(value: str) -> str:
+        return value.replace("\n", "").replace("\r", "").rstrip()
+
     @classmethod
     def _clean_value(cls, value: Any) -> Any:
         """Recursively remove line breaks and trailing spaces from strings.
 
-        Enum members (e.g. StatType) are returned untouched. They are not plain
-        strings even when their base class is str: `value.replace(...)` on a
-        StrEnum member returns a plain `str`, which would silently degrade the
-        enum to its value. That only matters under validate_assignment, where this
-        also runs on assignment (see `__setattr__` below) over an
-        already-constructed value.
+        An Enum member survives cleaning that would not change it. A StrEnum member
+        is a `str`, so `value.replace(...)` returns a plain `str` and silently
+        degrades the member to its value. That matters under validate_assignment,
+        where this also runs on assignment (see `__setattr__` below) over
+        already-constructed values, and it would demote a `StatType` on any
+        unrelated assignment. A member whose value does carry a line break is still
+        cleaned, since keeping it would put a line break mid-node in the MCF file.
         """
         if isinstance(value, Enum):
+            if isinstance(value, str):
+                cleaned = cls._clean_str(value)
+                return value if cleaned == str(value) else cleaned
             return value
         if isinstance(value, str):
-            return value.replace("\n", "").replace("\r", "").rstrip()
+            return cls._clean_str(value)
         if isinstance(value, list):
             return [cls._clean_value(v) for v in value]
         if isinstance(value, dict):

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from os import PathLike
 from pathlib import Path
 from typing import Any
@@ -39,12 +40,24 @@ class MCFNode(BaseModel):
     subClassOf: StrOrListStr | None = None
 
     # Allow extra fields since MCF can have arbitrary properties and this
-    # class is not comprehensive of all possible MCF properties.
-    model_config = ConfigDict(extra="allow")
+    # class is not comprehensive of all possible MCF properties. Assignments are
+    # validated too, so patterns like Dcid/GroupDcid are enforced on `MCFNodes.rename`
+    # (which assigns `.Node`), not just on construction.
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
 
     @classmethod
     def _clean_value(cls, value: Any) -> Any:
-        """Recursively remove line breaks and trailing spaces from strings."""
+        """Recursively remove line breaks and trailing spaces from strings.
+
+        Enum members (e.g. StatType) are returned untouched. They are not plain
+        strings even when their base class is str: `value.replace(...)` on a
+        StrEnum member returns a plain `str`, which would silently degrade the
+        enum to its value. That only matters under validate_assignment, where this
+        also runs on assignment (see `__setattr__` below) over an
+        already-constructed value.
+        """
+        if isinstance(value, Enum):
+            return value
         if isinstance(value, str):
             return value.replace("\n", "").replace("\r", "").rstrip()
         if isinstance(value, list):
@@ -59,6 +72,18 @@ class MCFNode(BaseModel):
         if isinstance(data, dict):
             return {k: cls._clean_value(v) for k, v in data.items()}
         return data
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Clean the value before it is assigned, as construction cleans it.
+
+        Under `validate_assignment`, `_strip_whitespace` reruns on every assignment,
+        but its cleaned output is applied only to the *other*, already-set fields and
+        is discarded for the field actually being assigned. Cleaning here instead
+        covers both declared fields and the `extra="allow"` keys that carry arbitrary
+        MCF properties, neither of which a wildcard field validator would reach in
+        full.
+        """
+        super().__setattr__(name, self._clean_value(value))
 
     @property
     def mcf(self) -> str:

--- a/src/dcp_tools/custom_data/models/topics.py
+++ b/src/dcp_tools/custom_data/models/topics.py
@@ -2,11 +2,7 @@ from typing import Annotated, Literal
 
 from pydantic import StringConstraints
 
-from dcp_tools.custom_data.models.common import (
-    DcidOrListDcid,
-    GroupDcidOrListGroupDcid,
-    TopicDcidOrListTopicDcid,
-)
+from dcp_tools.custom_data.models.common import DcidOrListDcid
 from dcp_tools.custom_data.models.mcf import MCFNode
 
 
@@ -20,7 +16,10 @@ class TopicMCFNode(MCFNode):
         Node: Node identifier, must contain '/topic'.
         typeOf: Fixed type indicating this is a Topic.
         relevantVariable: Variable or list of variables relevant to a topic.
-            Contains a list of ordered values. Must start with 'dcid:'
+            Contains a list of ordered values. Must start with 'dcid:'. Accepts
+            plain StatVar dcids as well as group (``.../g/...``) and topic
+            (``.../topic/...``) dcids: both are already valid ``dcid:\\S+`` tokens,
+            so DcidOrListDcid covers them without a separate union member.
 
         Inherits from MCFNode:
             name: The human-readable name for the Node.
@@ -35,6 +34,4 @@ class TopicMCFNode(MCFNode):
         str, StringConstraints(strip_whitespace=True, pattern=r".*topic/.*")
     ]
     typeOf: Literal["dcid:Topic"] = "dcid:Topic"
-    relevantVariable: (
-        DcidOrListDcid | GroupDcidOrListGroupDcid | TopicDcidOrListTopicDcid
-    )
+    relevantVariable: DcidOrListDcid

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -121,8 +121,9 @@ def resolve_group_paths(
 
     Args:
         paths: Raw slash-separated group path strings, one per StatVar. Each path
-            has a leading '-' stripped and '/' and whitespace stripped from both
-            ends before being split; empty segments are dropped.
+            has line breaks removed, a leading '-' stripped, and '/' and whitespace
+            stripped from both ends before being split; empty and whitespace-only
+            segments are dropped.
         group_namespace: The namespace under which group dcids are minted (e.g.,
             "one"). The resulting dcids have the form
             "dcid:{group_namespace}/g/{groupSlug}".
@@ -145,8 +146,13 @@ def resolve_group_paths(
         if raw in resolved:
             continue
 
-        cleaned = raw.lstrip("-").strip("/ ")
-        parts = [p for p in cleaned.split("/") if p]
+        # Strip line breaks and trailing spaces first. Group paths used to reach the
+        # resolver through `StatVarMCFNode(memberOf=...)`, which cleaned them on the
+        # way in; resolving before construction skips that. Segments that are only
+        # whitespace are dropped too, or `to_camelCase` yields an empty slug and the
+        # path mints a group whose dcid ends in a bare "g/".
+        cleaned = MCFNode._clean_value(raw).lstrip("-").strip("/ ")
+        parts = [p for p in cleaned.split("/") if p.strip()]
         if not parts:
             continue
         slug_parts = [to_camelCase(part) for part in parts]

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import re
+from collections.abc import Iterable
 from enum import StrEnum
 from os import PathLike
 from pathlib import Path
@@ -108,60 +109,63 @@ def to_camelCase(segment: str) -> str:
     return words[0].lower() + "".join(w.title() for w in words[1:])
 
 
-def build_stat_var_groups_from_strings(
-    stat_vars: MCFNodes[StatVarMCFNode], *, groups_namespace: str
-) -> MCFNodes[StatVarMCFNode]:
-    """
-    Build hierarchical StatVarGroup nodes from string-encoded group paths and attach them to StatVar nodes.
+def resolve_group_paths(
+    paths: Iterable[str], *, group_namespace: str
+) -> tuple[dict[str, str], list[StatVarGroupMCFNode]]:
+    """Resolve slash-separated group path strings into StatVarGroup dcids.
 
-    This function reads the `memberOf` attribute of each StatVar node in `stat_vars`, which is
-    expected to be a slash-separated string path describing its group hierarchy (e.g.,
-    "Economic/Employment/Unemployment"). It generates StatVarGroupMCFNode objects for each
-    group level, sets up their parent-child relationships, and updates the original StatVar
-    nodes to reference the deepest group DCID.
+    Each path (e.g. "Economic/Employment/Unemployment") is split into segments,
+    each segment is camelCased and minted into a chain of StatVarGroupMCFNode
+    objects rooted at "dcid:dc/g/Root". A segment shared by two paths (a common
+    prefix, or the same path repeated) mints only one node.
 
     Args:
-        stat_vars: An MCFNodes container holding StatVarMCFNode objects. Each node must have a
-            `memberOf` attribute set to a path string indicating its group hierarchy.
-        groups_namespace: The namespace under which group DCIDs will be created (e.g.,
-            "one"). The resulting group DCIDs will have the form
-            "dcid: {groups_namespace}/g/{{groupSlug}}".
+        paths: Raw slash-separated group path strings, one per StatVar. Each path
+            has a leading '-' stripped and '/' and whitespace stripped from both
+            ends before being split; empty segments are dropped.
+        group_namespace: The namespace under which group dcids are minted (e.g.,
+            "one"). The resulting dcids have the form
+            "dcid:{group_namespace}/g/{groupSlug}".
 
     Returns:
-        The same MCFNodes container provided as `stat_vars`, extended in-place with newly
-        created StatVarGroupMCFNode objects representing each unique group. Each StatVarMCFNode's
-        `memberOf` will be updated to the DCID of its deepest group.
+        A tuple of:
+            - A mapping from each input path (as given) to the dcid of its
+              deepest group. A path with no non-empty segments once cleaned
+              (e.g. "-", "/") is omitted.
+            - The StatVarGroupMCFNode objects for every unique group, in
+              first-seen order.
     """
 
-    group_nodes, seen = [], set()
-    root = f"dcid:{groups_namespace}/g/"
+    resolved: dict[str, str] = {}
+    group_nodes: list[StatVarGroupMCFNode] = []
+    seen: set[str] = set()
+    root = f"dcid:{group_namespace}/g/"
 
-    for node_idx, node in enumerate(stat_vars.nodes):
-        # clean
-        raw = node.memberOf
-        raw = raw.lstrip("-").strip("/ ")
-        parts = [p for p in raw.split("/") if p]
+    for raw in paths:
+        if raw in resolved:
+            continue
+
+        cleaned = raw.lstrip("-").strip("/ ")
+        parts = [p for p in cleaned.split("/") if p]
+        if not parts:
+            continue
         slug_parts = [to_camelCase(part) for part in parts]
 
         for idx, part in enumerate(parts):
-            group_node = root + f"{slug_parts[idx]}"
+            group_dcid = root + slug_parts[idx]
 
-            if idx == len(parts) - 1:
-                stat_vars.nodes[node_idx].memberOf = group_node
+            if group_dcid not in seen:
+                seen.add(group_dcid)
+                parent = "dcid:dc/g/Root" if idx == 0 else root + slug_parts[idx - 1]
+                group_nodes.append(
+                    StatVarGroupMCFNode(
+                        Node=group_dcid, name=part, specializationOf=parent
+                    )
+                )
 
-            if group_node in seen:
-                continue
-            seen.add(group_node)
+        resolved[raw] = group_dcid
 
-            parent = "dcid:dc/g/Root" if idx == 0 else root + f"{slug_parts[idx - 1]}"
-
-            group_nodes.append(
-                StatVarGroupMCFNode(Node=group_node, name=part, specializationOf=parent)
-            )
-
-    stat_vars.nodes.extend(group_nodes)
-
-    return stat_vars
+    return resolved, group_nodes
 
 
 def csv_metadata_to_nodes(
@@ -171,6 +175,8 @@ def csv_metadata_to_nodes(
     column_to_property_mapping: dict[str, str] | None = None,
     csv_options: dict[str, Any] | None = None,
     ignore_columns: list[str] | None = None,
+    parse_groups: bool = False,
+    group_namespace: str | None = None,
 ) -> MCFNodes[StatVarMCFNode]:
     """Read a CSV of StatVar metadata and return the corresponding MCF StatVar nodes.
 
@@ -182,9 +188,24 @@ def csv_metadata_to_nodes(
         csv_options: Extra keyword arguments forwarded verbatim to
             ``pandas.read_csv``.
         ignore_columns: Optional list of columns to ignore when reading the CSV.
+        parse_groups: If True, the ``memberOf`` column is treated as a
+            slash-separated group path (e.g. "Economic/Employment/Unemployment"),
+            resolved via ``resolve_group_paths``, and the minted
+            ``StatVarGroupMCFNode`` objects are appended to the returned
+            container. A row whose ``memberOf`` carries no group path, whether
+            missing, empty, or cleaning to no segments at all (e.g. "-", "/"), is
+            left unset rather than raising. Defaults to False.
+        group_namespace: Namespace under which group dcids are minted (e.g.,
+            "one"). Only used if ``parse_groups`` is True; an empty string is
+            used if not provided.
 
     Returns:
-        A ``Nodes`` container populated with ``StatVarMCFNode`` objects.
+        A ``Nodes`` container populated with ``StatVarMCFNode`` objects, followed
+        by any ``StatVarGroupMCFNode`` objects minted from ``memberOf`` paths.
+
+    Raises:
+        ValueError: If ``parse_groups`` is True and the CSV has no ``memberOf``
+            column.
     """
 
     if column_to_property_mapping is None:
@@ -196,12 +217,33 @@ def csv_metadata_to_nodes(
     if ignore_columns is None:
         ignore_columns = []
 
-    return (
+    data = (
         pd.read_csv(file_path, **csv_options)
         .drop(columns=ignore_columns)
         .rename(columns=column_to_property_mapping)
-        .pipe(_rows_to_stat_var_nodes, node_type=node_type)
     )
+
+    group_nodes: list[StatVarGroupMCFNode] = []
+    if parse_groups:
+        if "memberOf" not in data.columns:
+            raise ValueError(
+                "parse_groups=True requires a 'memberOf' column in the CSV."
+            )
+
+        present = data["memberOf"].map(lambda v: not pd.isna(v) and v != "")
+        resolved, group_nodes = resolve_group_paths(
+            data.loc[present, "memberOf"], group_namespace=group_namespace or ""
+        )
+        # A path that cleans to no segments at all (e.g. "-", "/") is absent from
+        # `resolved` and leaves the node ungrouped, the same as a blank cell. Keeping
+        # the raw value would send it to a `memberOf` that now enforces the group
+        # pattern, turning a row that carries no group into a hard failure.
+        data["memberOf"] = data.loc[present, "memberOf"].map(resolved.get)
+
+    nodes = _rows_to_stat_var_nodes(data, node_type=node_type)
+    for group_node in group_nodes:
+        nodes.add(group_node)
+    return nodes
 
 
 def validate_mcf_file_name(file_name: str | MCFFileName) -> str:

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -350,6 +350,44 @@ def test_add_variable_group_to_mcf_and_override():
     assert any(n.name == "Group2" for n in updated if n.Node == "dcid:test/g/1")
 
 
+def test_add_variables_to_mcf_from_csv_parse_groups(tmp_path):
+    """
+    Checks that parse_groups/group_namespace are forwarded correctly: StatVars
+    and the minted StatVarGroup nodes both land in the target MCF file.
+    """
+    csv_path = tmp_path / "vars.csv"
+    csv_path.write_text(
+        "Node,name,typeOf,memberOf\n"
+        "dcid:n1,Name1,dcid:StatisticalVariable,Economic/Employment\n"
+    )
+
+    manager = CustomDataManager()
+    manager.add_variables_to_mcf_from_csv(
+        str(csv_path), parse_groups=True, group_namespace="ns"
+    )
+
+    nodes = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes
+    node_ids = [n.Node for n in nodes]
+    assert node_ids == ["dcid:n1", "dcid:ns/g/economic", "dcid:ns/g/employment"]
+
+    statvar = next(n for n in nodes if n.Node == "dcid:n1")
+    assert statvar.memberOf == "dcid:ns/g/employment"
+
+
+def test_add_variables_to_mcf_from_csv_rejects_namespace_without_parse_groups(
+    tmp_path,
+):
+    """group_namespace without parse_groups=True stays a ValueError."""
+    csv_path = tmp_path / "vars.csv"
+    csv_path.write_text("Node,name,typeOf\ndcid:n1,Name1,dcid:StatisticalVariable\n")
+
+    manager = CustomDataManager()
+    with pytest.raises(
+        ValueError, match="group_namespace should not be set if parse_groups is False"
+    ):
+        manager.add_variables_to_mcf_from_csv(str(csv_path), group_namespace="ns")
+
+
 def test_config_round_trip(tmp_path):
     """
     Ensures a Config can be dumped to JSON and loaded back identically.
@@ -714,6 +752,21 @@ def test_rename_variable_mcf_only():
     manager.add_variable_to_mcf(Node="dcid:v3", name="Var3")
     with pytest.raises(ValueError):
         manager.rename_variable("dcid:v2", "dcid:v3")
+
+
+def test_rename_variable_mints_bare_tokens():
+    """Both old_name and new_name are run through ensure_dcid (#131), consistent
+    with add_variable_to_mcf (#130). A bare old_name used to fail the lookup (it
+    never matched the stored dcid:-prefixed Node), so minting both is strictly an
+    improvement, not a behaviour change any test pinned."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+
+    manager.rename_variable("v1", "v2")
+
+    for nodes in manager._mcf_nodes.values():
+        assert any(n.Node == "dcid:v2" for n in nodes.nodes)
+        assert all(n.Node != "dcid:v1" for n in nodes.nodes)
 
 
 def test_rename_variable_keeps_lookup_index_consistent():

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel, ValidationError
 
 from dcp_tools.custom_data.models.common import (
     DcidOrListDcid,
+    GroupDcidOrListGroupDcid,
     StrOrListStr,
     _ensure_quoted,
     ensure_dcid,
@@ -180,7 +181,36 @@ def test_dcid_or_list_dcid_rejects_non_string_input():
         Dummy(field={"a": "b"})
 
 
+# --- GroupDcidOrListGroupDcid (regression test for #131) ---
+#
 # GroupDcidOrListGroupDcid, PeerGroupDcidOrListPeerGroupDcid and TopicDcidOrListTopicDcid
-# still use PlainValidator (their slug pattern still bypassed) — see the docstring on
-# GroupDcidOrListGroupDcid in models/common.py for why, and the follow-up issue tracking
-# it separately from #126.
+# used to still use PlainValidator (their slug pattern bypassed), tracked separately from
+# #126. #131 switched all three to the same BeforeValidator as DcidOrListDcid, once
+# StatVarMCFNode.memberOf no longer used the field as a scratch value for an unresolved
+# raw group path (see resolve_group_paths in schema_tools.py). PeerGroupDcidOrListPeerGroupDcid
+# and TopicDcidOrListTopicDcid were then deleted, along with the TopicDcid they wrapped: no
+# field references them (TopicMCFNode.relevantVariable collapsed to plain DcidOrListDcid — see
+# test_models_topics.py).
+
+
+def test_group_dcid_or_list_group_dcid_mints_and_enforces_slug_pattern():
+    """Same BeforeValidator as DcidOrListDcid, plus the GroupDcid slug pattern
+    (the resolved dcid must contain 'g/')."""
+
+    class Dummy(BaseModel):
+        field: GroupDcidOrListGroupDcid
+
+    assert Dummy(field="g/MyGroup").field == "dcid:g/MyGroup"
+    assert Dummy(field=["g/One", "g/Two"]).field == ["dcid:g/One", "dcid:g/Two"]
+    # already dcid:-prefixed values pass through verbatim
+    assert Dummy(field="dcid:ns/g/Foo").field == "dcid:ns/g/Foo"
+
+
+def test_group_dcid_or_list_group_dcid_rejects_non_group_token():
+    """A minted dcid with no 'g/' segment fails the GroupDcid pattern."""
+
+    class Dummy(BaseModel):
+        field: GroupDcidOrListGroupDcid
+
+    with pytest.raises(ValidationError):
+        Dummy(field="NotAGroup")

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -2,6 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from dcp_tools.custom_data.models.mcf import MCFNode, MCFNodes
+from dcp_tools.custom_data.models.stat_vars import StatType, StatVarMCFNode
 
 
 def test_mcfnode_mcf_output_order_and_formatting():
@@ -128,3 +129,63 @@ def test_mcfnodes_add_override_and_remove():
     nodes.remove("dcid:n1")
     with pytest.raises(ValueError):
         nodes._expect_present("n1")
+
+
+# --- validate_assignment (regression tests for #131) ---
+#
+# MCFNode.model_config gained validate_assignment=True so that the patterns restored on
+# the slug-variant types (GroupDcidOrListGroupDcid and friends, see models/common.py) are
+# enforced on assignment too, not just on construction.
+
+
+def test_mcfnode_assignment_is_validated():
+    """An invalid value assigned to a pattern-constrained field raises, the same as
+    construction would."""
+    node = MCFNode(Node="dcid:n1", typeOf="dcid:T1")
+    with pytest.raises(ValidationError):
+        node.typeOf = "has space"
+
+
+def test_mcfnode_assignment_cleans_the_assigned_value():
+    """A newly-assigned value is cleaned (newlines/trailing spaces stripped) the same
+    way construction cleans it, for declared fields and for the extra keys that carry
+    arbitrary MCF properties. An uncleaned value would emit a line break mid-node and
+    break the MCF file (the bug fixed in v0.0.7, for construction only)."""
+    node = MCFNode(Node="dcid:n1", typeOf="dcid:T1")
+
+    node.name = "text\nwith newline  "
+    assert node.name == "textwith newline"
+
+    node.customProperty = "extra\nvalue  "
+    assert node.customProperty == "extravalue"
+    assert "customProperty: extravalue\n" in node.mcf
+
+
+def test_stat_type_survives_assignment():
+    """Regression: with validate_assignment=True, `_strip_whitespace` (a mode="before"
+    model validator) reran over the whole field dict on every assignment, including
+    fields the assignment did not touch. Because StatType is a StrEnum, the old
+    `_clean_value` matched its `isinstance(value, str)` branch and `value.replace(...)`
+    returned a plain str, silently degrading the enum member on any unrelated
+    assignment. `_clean_value` now leaves Enum members untouched."""
+    sv = StatVarMCFNode(Node="dcid:v1")
+    assert isinstance(sv.statType, StatType)
+
+    sv.name = "Var"
+
+    assert isinstance(sv.statType, StatType)
+    assert sv.statType == StatType.MEASURED_VALUE
+
+
+def test_mcfnodes_rename_rejected_leaves_index_intact():
+    """A rename to a value that fails Node's dcid pattern raises, and leaves the
+    node and the lookup index exactly as they were (assignment happens before
+    `_pos` is mutated)."""
+    nodes = MCFNodes()
+    nodes.add(MCFNode(Node="dcid:n1", typeOf="dcid:T1"))
+
+    with pytest.raises(ValidationError):
+        nodes.rename("dcid:n1", "not-a-dcid")
+
+    assert nodes.nodes[0].Node == "dcid:n1"
+    assert nodes._pos == {"dcid:n1": 0}

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -1,3 +1,5 @@
+from enum import StrEnum
+
 import pytest
 from pydantic import ValidationError
 
@@ -167,7 +169,8 @@ def test_stat_type_survives_assignment():
     fields the assignment did not touch. Because StatType is a StrEnum, the old
     `_clean_value` matched its `isinstance(value, str)` branch and `value.replace(...)`
     returned a plain str, silently degrading the enum member on any unrelated
-    assignment. `_clean_value` now leaves Enum members untouched."""
+    assignment. `_clean_value` now keeps an Enum member that cleaning would not
+    change."""
     sv = StatVarMCFNode(Node="dcid:v1")
     assert isinstance(sv.statType, StatType)
 
@@ -175,6 +178,21 @@ def test_stat_type_survives_assignment():
 
     assert isinstance(sv.statType, StatType)
     assert sv.statType == StatType.MEASURED_VALUE
+
+
+def test_enum_carrying_a_line_break_is_still_cleaned():
+    """The Enum carve-out above must not become a way to smuggle a line break into
+    the MCF. A StrEnum member whose value would change under cleaning is cleaned to
+    a plain string, since keeping it would split one property across two lines and
+    corrupt the file."""
+
+    class Dirty(StrEnum):
+        BAD = "line\nbreak  "
+
+    node = MCFNode(Node="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
+
+    assert node.custom == "linebreak"
+    assert "custom: linebreak\n" in node.mcf
 
 
 def test_mcfnodes_rename_rejected_leaves_index_intact():

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -79,12 +79,12 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
         {
             "Node": ["dcid:n3"],
             "name": ["Var"],
-            "memberOf": ['["dcid:oneId", "dcid:twoId"]'],
+            "memberOf": ['["dcid:g/oneId", "dcid:g/twoId"]'],
         }
     )
     nodes = _rows_to_stat_var_nodes(df)
     mcf = nodes.nodes[0].mcf
-    assert "memberOf: dcid:oneId, dcid:twoId" in mcf
+    assert "memberOf: dcid:g/oneId, dcid:g/twoId" in mcf
 
 
 # --- observationProperties / relevantVariable normalize bare tokens (regression for #126) ---

--- a/tests/test_models_topics.py
+++ b/tests/test_models_topics.py
@@ -3,10 +3,12 @@ from pydantic import ValidationError
 
 from dcp_tools.custom_data.models.topics import TopicMCFNode
 
-# relevantVariable is DcidOrListDcid | GroupDcidOrListGroupDcid | TopicDcidOrListTopicDcid.
-# Only DcidOrListDcid was fixed for #126 (see models/common.py); the other two still use
-# PlainValidator, so there is no whitespace-rejection test here — a value the DcidOrListDcid
-# branch would reject can still validate via the still-permissive Group/Topic branches.
+# relevantVariable collapsed to plain DcidOrListDcid in #131. The group and topic members of
+# the old union each layered an extra pattern on top of Dcid, so every value they accept, Dcid
+# accepts too, and the three-member union was exactly DcidOrListDcid once all three enforced
+# their patterns.
+# Unlike before #131, a value DcidOrListDcid rejects is now rejected outright (there is no
+# more-permissive Group/Topic branch left to fall back on).
 
 
 def test_topic_relevant_variable_accepts_bare_statvar_dcid():
@@ -43,3 +45,11 @@ def test_topic_relevant_variable_accepts_list():
 def test_topic_node_rejects_missing_slug():
     with pytest.raises(ValidationError):
         TopicMCFNode(Node="dcid:NotATopic", name="Topic", relevantVariable="var")
+
+
+def test_topic_relevant_variable_rejects_whitespace_bearing_token():
+    """Regression for #131: before the union collapsed to plain DcidOrListDcid, a
+    value DcidOrListDcid rejected could still validate via the more-permissive
+    Group/Topic branches (which used PlainValidator and never enforced a pattern)."""
+    with pytest.raises(ValidationError):
+        TopicMCFNode(Node="dcid:topic/T", name="Topic", relevantVariable="has space")

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -135,6 +135,30 @@ def test_resolve_group_paths_cleans_raw_path():
     assert resolved["-Economic// Employment / "] == "dcid:ns/g/employment"
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Economic/\t", ["dcid:ns/g/economic"]),
+        ("Economic/\t/Health", ["dcid:ns/g/economic", "dcid:ns/g/health"]),
+        ("Economic/Health\n", ["dcid:ns/g/economic", "dcid:ns/g/health"]),
+        ("Eco\nnomic", ["dcid:ns/g/economic"]),
+    ],
+)
+def test_resolve_group_paths_drops_whitespace_only_segments(raw, expected):
+    """A segment that is only whitespace mints no group.
+
+    `.strip("/ ")` does not remove a tab or newline, so such a segment used to
+    survive and `to_camelCase` reduced it to an empty slug, minting a group whose
+    dcid ends in a bare "g/". These paths reached the resolver through
+    `StatVarMCFNode(memberOf=...)` before groups were resolved ahead of node
+    construction, and were cleaned on the way in.
+    """
+    resolved, groups = resolve_group_paths([raw], group_namespace="ns")
+
+    assert [g.Node for g in groups] == expected
+    assert resolved[raw] == expected[-1]
+
+
 def test_resolve_group_paths_omits_path_with_no_segments():
     """A path that cleans down to nothing (e.g. just '-' or '/') mints no group
     and is omitted from the resolved mapping."""

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -1,11 +1,13 @@
+import pytest
+
 from dcp_tools.custom_data.models.mcf import MCFNodes
 from dcp_tools.custom_data.models.stat_vars import (
     StatVarGroupMCFNode,
     StatVarMCFNode,
 )
 from dcp_tools.custom_data.schema_tools import (
-    build_stat_var_groups_from_strings,
     csv_metadata_to_nodes,
+    resolve_group_paths,
     to_camelCase,
 )
 
@@ -35,13 +37,6 @@ def test_csv_metadata_to_nodes(tmp_path):
         assert hasattr(node, "searchDescription")
 
 
-def make_sv(member_of: str) -> StatVarMCFNode:
-    """Helper to create a StatVarMCFNode with a given memberOf path."""
-    return StatVarMCFNode(
-        Node="dcid:dummy", name="TestVar", description="", memberOf=member_of
-    )
-
-
 def get_group_nodes(nodes: MCFNodes) -> list[StatVarGroupMCFNode]:
     """Extract all StatVarGroupMCFNode instances from MCFNodes."""
     return [n for n in nodes.nodes if isinstance(n, StatVarGroupMCFNode)]
@@ -53,30 +48,21 @@ def get_statvar_nodes(nodes: MCFNodes) -> list[StatVarMCFNode]:
 
 
 def test_single_level_group():
-    sv = make_sv("Category")
-    nodes = MCFNodes(nodes=[sv])
+    resolved, groups = resolve_group_paths(["Category"], group_namespace="example.org")
 
-    result = build_stat_var_groups_from_strings(nodes, groups_namespace="example.org")
-    groups = get_group_nodes(result)
     assert len(groups) == 1, (
         "Should create exactly one group node for single-level path"
     )
-
     group = groups[0]
     assert group.Node == "dcid:example.org/g/category"
     assert group.name == "Category"
     assert group.specializationOf == "dcid:dc/g/Root"
 
-    statvars = get_statvar_nodes(result)
-    assert statvars[0].memberOf == group.Node
+    assert resolved["Category"] == group.Node
 
 
 def test_multi_level_group():
-    sv = make_sv("A/B/C")
-    nodes = MCFNodes(nodes=[sv])
-
-    result = build_stat_var_groups_from_strings(nodes, groups_namespace="ns")
-    groups = get_group_nodes(result)
+    resolved, groups = resolve_group_paths(["A/B/C"], group_namespace="ns")
 
     assert len(groups) == 3
     slug_map = {g.Node.split("/")[-1]: g for g in groups}
@@ -86,24 +72,153 @@ def test_multi_level_group():
     assert slug_map["B"].specializationOf == "dcid:ns/g/A"
     assert slug_map["C"].specializationOf == "dcid:ns/g/B"
 
-    # Check StatVar points to deepest
-    statvars = get_statvar_nodes(result)
-    assert statvars[0].memberOf == "dcid:ns/g/C"
+    # Check the path resolves to the deepest group
+    assert resolved["A/B/C"] == "dcid:ns/g/C"
 
 
 def test_duplicate_paths_do_not_create_duplicates():
-    sv1 = make_sv("X/Y")
-    sv2 = make_sv("X/Y/Z")
-    nodes = MCFNodes(nodes=[sv1, sv2])
+    resolved, groups = resolve_group_paths(["X/Y", "X/Y/Z"], group_namespace="ns2")
 
-    result = build_stat_var_groups_from_strings(nodes, groups_namespace="ns2")
-    groups = get_group_nodes(result)
     # Expect three unique group nodes: X, Y, Z
     assert len(groups) == 3
     slugs = sorted(g.Node for g in groups)
     assert "dcid:ns2/g/X" in slugs
     assert "dcid:ns2/g/Y" in slugs
     assert "dcid:ns2/g/Z" in slugs
+
+    assert resolved["X/Y"] == "dcid:ns2/g/Y"
+    assert resolved["X/Y/Z"] == "dcid:ns2/g/Z"
+
+
+def test_csv_metadata_to_nodes_parse_groups(tmp_path):
+    """
+    Full-pipeline check: StatVars keep CSV order, group nodes come after in
+    first-seen order, and each StatVar's memberOf is rewritten to the resolved
+    group dcid.
+    """
+    content = (
+        "Node,name,typeOf,memberOf\n"
+        "dcid:n1,Name1,dcid:StatisticalVariable,Economic/Employment\n"
+        "dcid:n2,Name2,dcid:StatisticalVariable,Economic/Health\n"
+    )
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(content)
+
+    nodes = csv_metadata_to_nodes(
+        str(csv_path), parse_groups=True, group_namespace="ns"
+    )
+
+    assert [n.Node for n in nodes.nodes] == [
+        "dcid:n1",
+        "dcid:n2",
+        "dcid:ns/g/economic",
+        "dcid:ns/g/employment",
+        "dcid:ns/g/health",
+    ]
+
+    statvars = get_statvar_nodes(nodes)
+    assert statvars[0].memberOf == "dcid:ns/g/employment"
+    assert statvars[1].memberOf == "dcid:ns/g/health"
+
+
+def test_resolve_group_paths_cleans_raw_path():
+    """Covers the path-cleaning contract in the docstring: a leading '-' is
+    stripped, '/' and whitespace are stripped from both ends, and empty segments
+    (from doubled or edge slashes) are dropped."""
+    resolved, groups = resolve_group_paths(
+        ["-Economic// Employment / "], group_namespace="ns"
+    )
+
+    assert len(groups) == 2
+    slugs = [g.Node for g in groups]
+    assert slugs == ["dcid:ns/g/economic", "dcid:ns/g/employment"]
+    assert resolved["-Economic// Employment / "] == "dcid:ns/g/employment"
+
+
+def test_resolve_group_paths_omits_path_with_no_segments():
+    """A path that cleans down to nothing (e.g. just '-' or '/') mints no group
+    and is omitted from the resolved mapping."""
+    resolved, groups = resolve_group_paths(["-", "/"], group_namespace="ns")
+
+    assert resolved == {}
+    assert groups == []
+
+
+def test_csv_metadata_to_nodes_parse_groups_without_memberof_column_raises(tmp_path):
+    """parse_groups=True with no `memberOf` column is a clear ValueError, not a crash."""
+    content = "Node,name,typeOf\ndcid:n1,Name1,dcid:StatisticalVariable\n"
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(content)
+
+    with pytest.raises(ValueError, match="memberOf"):
+        csv_metadata_to_nodes(str(csv_path), parse_groups=True, group_namespace="ns")
+
+
+def test_csv_metadata_to_nodes_parse_groups_leaves_missing_memberof_unset(tmp_path):
+    """A row with a missing memberOf is left unset rather than crashing."""
+    content = (
+        "Node,name,typeOf,memberOf\n"
+        "dcid:n1,Name1,dcid:StatisticalVariable,Economic/Employment\n"
+        "dcid:n2,Name2,dcid:StatisticalVariable,\n"
+    )
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(content)
+
+    nodes = csv_metadata_to_nodes(
+        str(csv_path), parse_groups=True, group_namespace="ns"
+    )
+    statvars = get_statvar_nodes(nodes)
+
+    assert statvars[0].memberOf == "dcid:ns/g/employment"
+    assert statvars[1].memberOf is None
+
+
+def test_csv_metadata_to_nodes_parse_groups_leaves_segmentless_memberof_unset(tmp_path):
+    """A memberOf that cleans down to nothing ('-', '/') leaves the node ungrouped,
+    the same as a blank cell.
+
+    Keeping the raw value instead would hand '-' to a memberOf that now enforces the
+    group pattern, aborting the whole call over a row that carries no group at all.
+    """
+    content = (
+        "Node,name,typeOf,memberOf\n"
+        "dcid:n1,Name1,dcid:StatisticalVariable,-\n"
+        "dcid:n2,Name2,dcid:StatisticalVariable,/\n"
+        "dcid:n3,Name3,dcid:StatisticalVariable,Economic/Employment\n"
+    )
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(content)
+
+    nodes = csv_metadata_to_nodes(
+        str(csv_path), parse_groups=True, group_namespace="ns"
+    )
+    statvars = get_statvar_nodes(nodes)
+
+    assert statvars[0].memberOf is None
+    assert statvars[1].memberOf is None
+    assert statvars[2].memberOf == "dcid:ns/g/employment"
+
+
+def test_csv_metadata_to_nodes_parse_groups_remove_works_on_group_node(tmp_path):
+    """Regression test: csv_metadata_to_nodes used to append group nodes directly to
+    `nodes.nodes`, bypassing `MCFNodes.add` and leaving `_pos` stale. `.remove()` (which
+    looks the node up via `_pos`) on a group node from a parse_groups=True result must
+    work — the same class of index bug #126 fixed in `rename_variable`."""
+    content = (
+        "Node,name,typeOf,memberOf\n"
+        "dcid:n1,Name1,dcid:StatisticalVariable,Economic/Employment\n"
+    )
+    csv_path = tmp_path / "test.csv"
+    csv_path.write_text(content)
+
+    nodes = csv_metadata_to_nodes(
+        str(csv_path), parse_groups=True, group_namespace="ns"
+    )
+
+    nodes.remove("dcid:ns/g/employment")
+    assert [n.Node for n in nodes.nodes] == ["dcid:n1", "dcid:ns/g/economic"]
+    # The index was kept consistent, not merely the list.
+    assert nodes._expect_present("dcid:ns/g/economic") == 1
 
 
 def test_to_camelcase_multi_word():


### PR DESCRIPTION
Closes #131.

#132 fixed `DcidOrListDcid`, whose `PlainValidator` replaced the wrapped schema so the `dcid:` pattern never ran. It deliberately left the slug-patterned siblings alone, because two things blocked them.

`build_stat_var_groups_from_strings` used `StatVarMCFNode.memberOf` as a scratch field, holding a raw path such as `"Economic/Employment"` until it was overwritten with the resolved group dcid. And `MCFNode` never validated assignment, so the value that actually reaches the MCF file was written through an unchecked `setattr`. Enforcing the pattern at construction alone would have rejected a legitimate intermediate value while leaving the real output unguarded.

## What changed

**Group paths are resolved before nodes are built.** `resolve_group_paths` replaces `build_stat_var_groups_from_strings`. It works on the path strings and returns the resolved dcid per path plus the `StatVarGroupMCFNode` objects, so no node is ever constructed with an invalid `memberOf`. `csv_metadata_to_nodes` gained `parse_groups` and `group_namespace` and does the resolution between reading the CSV and building the nodes. `add_variables_to_mcf_from_csv` is unchanged.

**The patterns are enforced, on construction and on assignment.** `GroupDcidOrListGroupDcid` switched to `BeforeValidator`. `MCFNode` sets `validate_assignment=True`, so `node.memberOf = "garbage"` and `MCFNodes.rename` now raise instead of writing an invalid dcid. `TopicMCFNode.relevantVariable` collapses to plain `DcidOrListDcid`: the group and topic members each layered an extra pattern on top of `Dcid`, so the union accepted exactly what `Dcid` accepts once all three enforced their patterns. `rename_variable` mints bare names, consistent with #130.

**Three unused type aliases are gone**: `PeerGroupDcidOrListPeerGroupDcid`, `TopicDcidOrListTopicDcid`, and the `TopicDcid` they wrapped. Untested, unreferenced types are how the bypass went unnoticed.

## Two things worth a look

**A `StrEnum` trap that `validate_assignment` exposes.** Under `validate_assignment`, the `_strip_whitespace` model validator reruns over the whole field dict on every assignment and its output is written back to the untouched fields. `StatType` is a `StrEnum`, so `_clean_value`'s `isinstance(value, str)` branch matched and `value.replace(...)` returned a plain `str`, silently degrading the enum on any unrelated assignment. `_clean_value` now leaves `Enum` members alone. Pinned by `test_stat_type_survives_assignment`.

**A degenerate group path used to be tolerated.** A `memberOf` of `"-"` or `"/"` cleans to no segments. Previously it was written to the MCF verbatim as garbage; the first cut of this branch turned it into a hard `ValidationError` that aborted the whole call. It now leaves the node ungrouped, the same as a blank cell, which is the only reading of "a path with no segments" that keeps the row importable.

## Testing

222 tests pass, up from 221 on `main`. `ruff check`, `ruff format --check` and `ty check src` are clean, and `tests/goldens/` shows zero diff.

`resolve_group_paths` was differential-tested against the original implementation across 60 inputs covering ordering, minting, path cleaning, dedup, empty and segmentless paths, and unicode: zero drift. The `__setattr__` override was checked against `model_copy`, `deepcopy`, `pickle`, `model_validate`, the `MCFNodes` private index, and an MCF file round-trip. Each new regression test was confirmed to fail without its fix.

One existing fixture changed: `tests/test_models_stat_vars.py` used `dcid:oneId` as a `memberOf` placeholder, which was never a valid group dcid. It is now `dcid:g/oneId`. The test's subject, bracket-list parsing, is unaffected.

Co-authored-by: Claude <noreply@anthropic.com>