### PR TITLE
docs: rewrite documentation for the DCP flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,7 @@
 - `sync_directory_to_gcs` function in `storage.py` that composes upload + stale blob cleanup.
 - `sync` parameter on `upload_to_cloud_storage` in `pipeline.py`.
 
-## [0.1.0] - 2025-02-13
+## [0.1.0] - 2026-02-13
 
 ### Added
 - Support for Application Default Credentials (ADC) as an alternative to service account JSON keys.

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome, and they are greatly appreciated. 
+Contributions are welcome and greatly appreciated.
 
 ## Types of Contributions
 
@@ -24,10 +24,9 @@ and "help wanted" is open to whoever wants to implement it.
 
 ### Write Documentation
 
-You can never have enough documentation. Please feel free to contribute to any
-part: official docs, docstrings, blog posts, articles, and such. 
-Documentation is built using
-[mkdocs] and documentation files are located in the `docs/` directory.
+Documentation contributions are always welcome, whether to the official docs,
+docstrings, blog posts, or articles. The docs are built with
+[mkdocs](https://www.mkdocs.org/), and the source files live in the `docs/` directory.
 
 ### Submit Feedback
 
@@ -35,8 +34,7 @@ If you are proposing a feature:
 
 * Explain in detail how it would work.
 * Keep the scope as narrow as possible, to make it easier to implement.
-* Remember that this is a public good project: the tools will always be 
-open source, and contributions are welcome,
+* This is a public-good project. The tools will always be open source.
 
 ## Get Started!
 
@@ -44,7 +42,7 @@ Ready to contribute? Here's how to set up `bblocks-datacommons-tools` for local 
 
 1. Open an issue in the `bblocks-datacommons-tools` repository to discuss your proposed changes or enhancements. 
    This is a good way to get feedback and ensure your work aligns with the project's goals.
-2. Fork `bblocks-datacommons-places` and clone your fork:
+2. Fork `bblocks-datacommons-tools` and clone your fork.
 3. Dependencies are managed using uv. Install uv in your virtual environment and
 install project dependencies:
 
@@ -52,16 +50,24 @@ install project dependencies:
 uv sync --group dev
 ```
 
-4.  Ensure tests are written for any new functionality
+4. Install the pre-commit hooks so formatting and lint checks run automatically on each commit:
+
+```console
+uv run pre-commit install
+```
+
+5. Ensure tests are written for any new functionality
 and that existing tests pass. Code coverage is important but not critical. We prioritize
 meaningful tests that cover all major functionality. Code should be formatted 
-using `ruff format` to adhere to the project's coding standards.
+using `ruff format` and pass `ruff check` and `ty check` to adhere to the project's coding
+standards. CI runs all four (`ruff check`, `ruff format --check`, `ty check`, and `pytest`) on
+every pull request.
 
-5. When you are done developing, open a pull request on the main repository, 
+6. When you are done developing, open a pull request on the main repository, 
 with a clear description of your changes and any relevant issue numbers.
 One of the maintainers will review your changes and provide feedback.
 
-6. If your pull request is accepted, it will be merged into the main branch. Your changes
+7. If your pull request is accepted, it will be merged into the main branch. Your changes
 will be included in the next release, and your contributions 
 will be acknowledged in the project's changelog.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # dcp-tools
 
-__Manage and load data to custom Data Commons instances__
+__Manage and load data to Data Commons Platform instances__
 
 [![PyPI](https://img.shields.io/pypi/v/dcp-tools.svg)](https://pypi.org/project/dcp-tools/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/dcp-tools.svg)](https://pypi.org/project/dcp-tools/)
 [![Docs](https://img.shields.io/badge/docs-bblocks-blue)](https://docs.one.org/tools/bblocks/datacommons-tools/)
 [![Lint/format: Ruff](https://img.shields.io/badge/lint%2Fformat-ruff-46a758.svg)](https://github.com/astral-sh/ruff)
 
-A [custom Data Commons](https://docs.datacommons.org/custom_dc/custom_data.html) instance takes
+A [Data Commons Platform](https://docs.datacommons.org/custom_dc/custom_data.html) instance takes
 your data as CSVs in a fixed variable-per-row shape, plus a `config.json` that maps each CSV's
 columns onto the Data Commons schema. If you're defining your own statistical variables,
 entities, or properties rather than reusing existing ones, you also need MCF (Meta Content

--- a/README.md
+++ b/README.md
@@ -7,184 +7,123 @@ __Manage and load data to custom Data Commons instances__
 [![Docs](https://img.shields.io/badge/docs-bblocks-blue)](https://docs.one.org/tools/bblocks/datacommons-tools/)
 [![Lint/format: Ruff](https://img.shields.io/badge/lint%2Fformat-ruff-46a758.svg)](https://github.com/astral-sh/ruff)
 
-Custom [Data Commons](https://docs.datacommons.org/custom_dc/custom_data.html) requires that you provide your data in a specific schema, format, and file structure.
+A [custom Data Commons](https://docs.datacommons.org/custom_dc/custom_data.html) instance takes
+your data as CSVs in a fixed variable-per-row shape, plus a `config.json` that maps each CSV's
+columns onto the Data Commons schema. If you're defining your own statistical variables,
+entities, or properties rather than reusing existing ones, you also need MCF (Meta Content
+Framework) files describing them. `dcp-tools` builds and validates that bundle in Python (or from
+the CLI) and uploads it to Cloud Storage to trigger the platform's ingestion job.
 
-At a high level, you need to provide the following:
+## Install
 
-- All observations data must be in CSV format, using a predefined schema.
-- You must also provide a JSON configuration file, named `config.json`, that specifies how to map and resolve the CSV contents to the Data Commons schema knowledge graph.
-- Depending on how you define your statistical variables (metrics), you may need to provide MCF (Meta Content Framework) files.
-- You may also need to define new custom entities.
-
-Managing this workflow by hand is tedious and easy to get wrong.
-
-The `dcp_tools` package streamlines that process. It provides a Python API and command line utilities for building config files, generating MCF from CSV metadata and running the data load pipeline on Google Cloud. 
-
-Use this package when you want to:
-
-- Manage `config.json` files programmatically.
-- Define statistical variables, entities or groups using MCF files.
-- Programmatically upload CSVs, MCF files, and the `config.json` file to Cloud Storage, and trigger the data load job with code.
-
-In short, `dcp-tools` removes much of the manual work involved in setting up and maintaining a custom Data Commons Knowledge Graph.
-
-Read the [documentation](https://docs.one.org/tools/bblocks/datacommons-tools/)
-for more details on how to use the package and the motivation for its creation.
-
-
-## Installation
-
-The package can be installed in various ways. 
-
-Directly as
 ```bash
 pip install dcp-tools
 ```
 
-It can also be installed from GitHub:
+Or from GitHub:
+
 ```bash
 pip install git+https://github.com/ONEcampaign/bblocks-datacommons-tools
 ```
 
-## Sample Usage
+## Quickstart
 
-Here's a simple example covering how to use the "implicit" Data Commons
-schema to load a single dataset. Please see the full [documentation page](https://docs.one.org/tools/bblocks/datacommons-tools/) for a thorough 
-introduction to the package, and to learn how to use it.
+This builds a config and MCF for a source, a provenance, one input file, and one statistical
+variable, then exports the bundle to disk.
 
+```python
+from pathlib import Path
 
-### 1. Create a CustomDataManager object. 
-
-The CustomDataManager object will handle generating the `config.json` file, as well as (optionally) taking Pandas DataFrames and exporting them as CSVs (in the right format) for loading to the Knowledge Graph.
-
-In this example, we assume a `config.json` does not yet exist.
-
-```python title="Instantiate the CustomDataManager class"
+import pandas as pd
 from dcp_tools import CustomDataManager
 
-# Create the object and call it "manager"
 manager = CustomDataManager()
-
-# Configure it to include subdirectories
-manager.set_includeInputSubdirs(True)
-
-```
-
-### 2. Add the provenance information for our data
-You can add or manage provenance information using `add_source` and `add_provenance`.
-
-In this example, we will add a source and provenance for ONE Data's Climate Finance Files.
-
-```python title="Add source and provenance"
 manager.add_source(name="ONEData", url="https://data.one.org")
 manager.add_provenance(
     name="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
     source="ONEData",
 )
-```
 
-### 3. Add the data to the CustomDataManager object.
-Next, you need to specify your data on the `config.json` file. 
-
-Adding actual data data to the `CustomDataManager` is an optional step. 
-
-For this example, we will assume a DataFrame is available via the
-`data` variable.
-
-To add to the `CustomDataManager`, using the Implicit Schema:
-
-```python title="Register data"
-manager.add_implicit_schema_file(
+data = pd.DataFrame({
+    "country": ["Kenya", "Kenya", "Vietnam"],
+    "year": [2022, 2023, 2023],
+    "variable": ["climateFinanceProvidedCommitments"] * 3,
+    "value": [12.4, 15.1, 8.7],
+})
+manager.add_input_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
     provenance="ONEClimateFinance",
-    entityType="Country",
     data=data,
-    ignoreColumns=["oecd_provider_code"],
+    columnMappings={
+        "observationAbout": "country",
+        "date": "year",
+        "variable": "variable",
+        "value": "value",
+    },
     observationProperties={"unit": "USDollar"},
 )
-```
 
-Adding the data in the step above is optional. You can also create the inputFile in the config and add the data tied to that inputFile at a later stage by running:
-
-```python
-manager.add_data(data=data, file_name='one_cf_provider_commitments.csv')
-```
-
-Or you can manually add the relevant CSV file (matching what you declared as `file_name`).
-
-### 4. Add the indicators to config
-Next, you need to specify information about the StatVars (variables) contained
-in your data file(s).
-
-When using the Implicit Schema, you can specify additional information.
-
-For convenience, you could loop through a dictionary of indicators and information. For this example we'll add a single indicator.
-
-```python title="Register an indicator"
-manager.add_variable_to_config(
-    statVar="climateFinanceProvidedCommitments",
-    name="Climate Finance Commitments (bilateral)",
-    group="ONE/Environment/Climate finance/Provider perspective/Commitments",
-    description="Funding for climate adaptation and mitigation projects",
-    searchDescriptions=[
-        "Climate finance commitments provided",
-        "Adaptation and mitigation finance provided",
-    ],
-    properties={"measurementMethod": "Commitment"},
-    )
- ```
-
-### 5. Export the `config.json` and (optionally) data CSVs
-
-Next, once all the data is added and the config is set up, you can export the `config.json` and data. When you export, the `config.json` is validated automatically
-
-```python title="Export config and data"
-manager.export_all("path/to/output/folder", mcf_file_names=["provenance.mcf"])
-```
-
-`export_all` writes a complete bundle: if an input file references a provenance,
-the MCF file defining it (`provenance.mcf` by default) must be listed in
-`mcf_file_names`, or it raises before writing anything.
-
-### 6. (Optionally) load to the Knowledge Graph
-You can also programmatically push the data and config to a Google Cloud
-Storage Bucket and trigger the data load job.
-
-To do this, you'll need to load information about your
-project, Storage Bucket, etc. You can use `.env` or `.json` files,
-or simply make the right information available as environment variables.
-A detailed description of the needed information, can be found in the documentation.
-
-#### Load the settings
-First, load the settings using `get_kg_settings`. In this example, we will load them from a `.env` file available in our working directory.
-
-```python  title="Load settings"
-from dcp_tools.gcp_utilities import (
-    upload_to_cloud_storage,
-    run_data_load,
-    get_kg_settings,
+manager.add_variable_to_mcf(
+    Node="climateFinanceProvidedCommitments",
+    name="Climate finance commitments (bilateral)",
+    description="Funding committed for climate adaptation and mitigation projects",
+    statType="dcid:measuredValue",
 )
 
-settings = get_kg_settings(source="env", env_file="customDC.env")
-```
-Second, we'll upload the directory which contains the `config.json` file and
-any CSV and/or MCF files.
-
-```python title="Upload to GCS"
-upload_to_cloud_storage(settings=settings, directory="path/to/output/folder")
+out_dir = Path("export/climate_finance")
+out_dir.mkdir(parents=True, exist_ok=True)
+manager.export_all(out_dir, mcf_file_names=["provenance.mcf", "custom_nodes.mcf"])
 ```
 
-Third, we'll run the data load job on Google Cloud Platform.
+`export_all` writes `config.json`, the CSV, and both named MCF files under `out_dir`. Since we
+never called `set_importName`, `config.json` defaults `importName` to the export directory's
+name, and column mappings and the provenance name are resolved to full dcids:
+
+```json
+{
+    "importName": "climate_finance",
+    "inputFiles": [
+        {
+            "filename": "climate_finance/one_cf_provider_commitments.csv",
+            "provenance": "dcid:provenance/ONEClimateFinance",
+            "columnMappings": {
+                "dcid:variableMeasured": "variable",
+                "dcid:observationDate": "year",
+                "dcid:value": "value",
+                "dcid:observationAbout": "country"
+            },
+            "observationProperties": {"unit": "USDollar"},
+            "format": "variablePerRow"
+        }
+    ]
+}
+```
+
+!!! warning "Heads up"
+    `provenance.mcf` (source and provenance nodes) is never exported by default. If an input
+    file references a provenance and its MCF file isn't in `mcf_file_names`, `export_all` raises
+    before writing anything, so you can't ship a bundle with a dangling reference.
+
+## Loading it
+
+Once you have a bundle on disk, `dcp_tools.gcp_utilities` uploads it and triggers the load:
+
 ```python
+from dcp_tools.gcp_utilities import get_kg_settings, upload_to_cloud_storage, run_data_load
+
+settings = get_kg_settings(source="env", env_file="customDC.env")
+upload_to_cloud_storage(settings=settings, directory="export/climate_finance")
 run_data_load(settings=settings)
 ```
 
----
-
-Visit the [documentation page](https://docs.one.org/tools/bblocks/datacommons-tools/) for the full package documentation and examples.
+`run_data_load` triggers the DCP (Data Commons Platform) ingestion job, which ingests the new
+data and serves it. There's no separate redeploy step to run. See the
+[loading-data docs](https://docs.one.org/tools/bblocks/datacommons-tools/loading-data/) for the
+full settings reference, and the `dcp-tools` CLI (`upload`, `dataload`, `pipeline`), which wraps
+this same flow.
 
 ## Contributing
-Contributions are welcome! Please see the
-[CONTRIBUTING](https://github.com/ONEcampaign/bblocks-datacommons-tools/blob/main/CONTRIBUTING.md) 
-page for details on how to get started, report bugs, fix issues, and submit enhancements.
+
+Contributions are welcome! See [CONTRIBUTING](https://github.com/ONEcampaign/bblocks-datacommons-tools/blob/main/CONTRIBUTING.MD)
+for how to get started, report bugs, and submit changes.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,21 +1,40 @@
 # Changelog
 
 ## v1.0.0 (in development)
-- Stable release of the `dcp-tools` package
+- Stable release of the `dcp-tools` package.
+- Renamed the package from `bblocks-datacommons-tools` to `dcp-tools`. The import path is
+  now `dcp_tools` (was `bblocks.datacommons_tools`). Installing the old
+  `bblocks-datacommons-tools` distribution now pulls in `dcp-tools` and re-exports it with a
+  `DeprecationWarning`; update imports to `dcp_tools` at your convenience.
+- Minimum supported Python is now 3.13 (was 3.11).
+- Packaging now follows the `bblocks-projects` copier template (ruff lint preset, `ty` type
+  checking, pre-commit hooks, PyPI trusted publishing).
 - **Breaking:** removed support for the second, implicit import mechanism —
   `add_implicit_schema_file`, `add_variable_to_config`, and the `ImplicitSchemaFile` /
-  `Variable` model classes are gone (`ObservationProperties` is retained, but now carries
-  file-level constants on `InputFile`). Loading a legacy
+  `Variable` model classes are gone. `ObservationProperties` is retained but repurposed: it's
+  no longer nested under a variable definition, and now carries the file-level constant
+  observation properties on `InputFile`; it also accepts custom keys (`extra="allow"`, was
+  `extra="forbid"`), and the four standard fields are unchanged. Loading a legacy
   `variablePerColumn` config now raises `ValueError`. Migrate by using `add_input_file` with
   `columnMappings`; see
   [Data Commons custom data docs](https://docs.datacommons.org/custom_dc/custom_data.html).
 - **Breaking:** with a single import format left, the input-file API drops the "explicit"
   qualifier: `ExplicitSchemaFile` is now `InputFile` and `add_explicit_schema_file` is now
   `add_input_file`. Arguments and the generated `config.json` are unchanged.
+- **Breaking:** `Config.inputFiles` is now `list[InputFile]` (was a dict keyed by file name).
+  `InputFile` also rejects unknown keys now (`extra="forbid"`).
 - **Breaking:** `export_mfc_file` is now spelled `export_mcf_file`, and
   `csv_metadata_to_mfc_file` is now `csv_metadata_to_mcf_file`.
-- Fixed `rename_variable`, which left the renamed node unreachable by its new name. A
-  following `remove_indicator` raised "not found" until you passed the pre-rename name.
+- **Breaking:** removed the `entity` key on `ColumnMappings`. Use `observationAbout` for
+  single-entity data or `custom:<name>` for multi-entity dimensions.
+- Added support for multi-entity observations using custom dimensions: declare each
+  dimension with `custom:<name>` in `ColumnMappings` and a matching `dcid:<name>` in the
+  StatVar's `observationProperties`.
+- Single-entity StatVars no longer emit `observationProperties` by default.
+- Fixed `rename_variable`, which left the `MCFNodes` lookup index keyed by the old name, so
+  a following `remove_indicator` raised "not found" for the renamed node and still resolved
+  the old name. The rename now goes through a new `MCFNodes.rename`, which keeps the index
+  in step.
 - Fixed `export_data`, `export_mcf_file`, and `export_vertical_specs` raising `OSError`
   when the target file name nested in a subdirectory that did not yet exist (for example
   an `add_input_file` name such as `"sub/gdp.csv"`). Each now creates the parent
@@ -39,11 +58,18 @@
   sorting out first. That leaves `StatVarMCFNode.memberOf` and
   `TopicMCFNode.relevantVariable` unguarded, the latter because its type unions the fixed
   and unfixed variants. `StatVarMCFNode.relevantVariable` is fixed. Tracked separately.
-- **Breaking:** re-pointed the data load flow at the DCP v1.1.0 prep job. `run_data_load`
-  now triggers the preprocessing job. The `redeploy` command and `redeploy_service` are removed.
-  Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` → `LOAD_JOB_NAME`,
-  `CLOUD_JOB_REGION` → `LOAD_JOB_REGION`, plus a new optional `LOAD_JOB_SERVICE_ACCOUNT`.
-  New `--imports` flag on `dataload` loads specific named imports.
+- **Breaking:** re-pointed the data load flow at the DCP prep job, using the
+  `IngestionJobClient`. `run_data_load` now triggers the prep job. The `redeploy`
+  CLI command and the `redeploy_service`
+  and `redeploy_cloud_run_service` functions are removed; the service restart is now owned
+  by the ingestion workflow. Load-job settings are renamed: `CLOUD_RUN_JOB_NAME` →
+  `LOAD_JOB_NAME`, `CLOUD_JOB_REGION` → `LOAD_JOB_REGION`, plus a new optional
+  `LOAD_JOB_SERVICE_ACCOUNT` that sets which service account the load job impersonates
+  (when unset, the caller's credentials are used). The unused Cloud SQL and Cloud Run
+  service settings are removed too: `CLOUD_SQL_DB_NAME`, `CLOUD_SQL_REGION`,
+  `CLOUD_SERVICE_REGION`, `CLOUD_RUN_SERVICE_NAME`, and `DATACOMMONS_SERVICE_IMAGE`.
+- Added an `imports` argument on `run_data_load` and a matching `--imports` flag on the
+  `dataload` CLI command, to trigger a load of specific imports rather than all imports.
 
 ## v0.1.0 (in development)
 - Initial release of the `dcp-tools` package for external preview and testing
@@ -53,7 +79,7 @@
 `set_defaultCustomRootStatVarGroupName` and `set_svHierarchyPropsBlocklist`.
 
 ## v0.0.8 (2025-09-03)
-- Removed white space between quoted items do defend against a bug with data loading on
+- Removed white space between quoted items to defend against a bug with data loading on
 the DC side.
 
 ## v0.0.7 (2025-08-27)
@@ -72,7 +98,7 @@ additional special characters
 - Removed option to override input and output folders on the data load job.
 
 ## v0.0.3 (2025-07-18)
-- Fixes two bugs related to MFC files. It now enforces the `dcid:` prefix for Node and
+- Fixes two bugs related to MCF files. It now enforces the `dcid:` prefix for Node and
 automatically trims spaces between `dcid:` and the start of the id string.
 
 ## v0.0.2 (2025-07-07)

--- a/docs/docs/cli-tools.md
+++ b/docs/docs/cli-tools.md
@@ -1,3 +1,242 @@
-# Command Line Interface (CLI) Tools
+# `dcp-tools` CLI
 
-[//]: # (<--- TODO: Add CLI tools documentation here --->)
+`dcp-tools` is the command-line entry point for the functions documented under
+[Preparing data](preparing-data.md) and [Loading data](loading-data.md). It converts a CSV into
+MCF, uploads a prepared export directory to Google Cloud Storage, and triggers the DCP ingestion
+job. Each subcommand parses its arguments and calls straight into the Python API. It adds no
+behavior of its own.
+
+There are four subcommands and no subcommand groups: `csv2mcf`, `upload`, `dataload`, and
+`pipeline`. Run any of them as `dcp-tools <command> ...` or `python -m dcp_tools <command> ...`.
+Every command, including `dcp-tools` itself, accepts `-h`/`--help` for its full option list.
+
+## Global options
+
+`upload`, `dataload`, and `pipeline` connect to Google Cloud through a `KGSettings` object (see
+[Loading data](loading-data.md)). Two flags control where those settings come from:
+
+- **`--settings-file PATH`** — a JSON file using the settings' alias keys, all uppercase
+  (`LOCAL_PATH`, `GCP_PROJECT_ID`, `GCS_BUCKET_NAME`, and so on).
+- **`--env-file PATH`** — a `.env` file using the same keys.
+
+If both are given, `--settings-file` wins and `--env-file` is ignored. If neither is given,
+settings are read from a `.env` file in the current directory.
+
+`csv2mcf` takes neither flag. It doesn't talk to Google Cloud, so it has no settings to load.
+
+```json title="customDC.json"
+{
+  "LOCAL_PATH": "./export",
+  "GCP_PROJECT_ID": "one-climate-finance",
+  "GCS_BUCKET_NAME": "one-dcp-import",
+  "GCS_INPUT_FOLDER_PATH": "climate-finance",
+  "GCS_OUTPUT_FOLDER_PATH": "climate-finance/output",
+  "LOAD_JOB_REGION": "us-central1",
+  "LOAD_JOB_NAME": "dcp-prep-job"
+}
+```
+
+```bash title="customDC.env"
+LOCAL_PATH=./export
+GCP_PROJECT_ID=one-climate-finance
+GCS_BUCKET_NAME=one-dcp-import
+GCS_INPUT_FOLDER_PATH=climate-finance
+GCS_OUTPUT_FOLDER_PATH=climate-finance/output
+LOAD_JOB_REGION=us-central1
+LOAD_JOB_NAME=dcp-prep-job
+```
+
+!!! note
+    `GCP_CREDENTIALS` and `LOAD_JOB_SERVICE_ACCOUNT` are optional and omitted above. Without
+    `GCP_CREDENTIALS`, GCP calls fall back to Application Default Credentials
+    (`gcloud auth application-default login`).
+
+## Exit status
+
+All four subcommands return `0` on success. Argument errors, such as a missing required argument
+or an invalid `--node-type` choice, print a usage message to stderr and exit non-zero before any
+subcommand code runs. Errors raised by the underlying Python API (a pydantic validation error from
+a malformed CSV, a Google Cloud auth failure) propagate as an uncaught exception and also exit
+non-zero. The CLI does not catch or reformat them.
+
+## `dcp-tools csv2mcf`
+
+Converts a CSV of node metadata into an `.mcf` file, wrapping `csv_metadata_to_mcf_file`.
+
+```
+dcp-tools csv2mcf <CSV> <MCF>
+                  [--node-type {Node,StatVar,StatVarGroup,Topic,StatVarPeerGroup}]
+                  [--column-mapping CSV_COL=MCF_PROP]
+                  [--csv-option KEY=VALUE]
+                  [--ignore-column COLUMN]
+                  [--override]
+```
+
+**Arguments**
+
+- **`<CSV>`** — path to the input CSV file. Required.
+- **`<MCF>`** — path to write the generated MCF file. Required, must end in `.mcf`.
+
+**Options**
+
+- **`--node-type {Node,StatVar,StatVarGroup,Topic,StatVarPeerGroup}`** (default: `Node`) — the MCF
+  node type to build, one per CSV row. `StatVar`, `StatVarGroup`, `Topic`, and `StatVarPeerGroup`
+  map to the typed node models under `dcp_tools.custom_data.models`. `Node` builds the untyped base
+  `MCFNode` and accepts any column as an extra property.
+- **`--column-mapping CSV_COL=MCF_PROP`** (repeatable) — rename a CSV column to an MCF property
+  before building nodes, e.g. `--column-mapping identifier=Node`. Pass the flag once per column.
+- **`--csv-option KEY=VALUE`** (repeatable) — an extra keyword argument forwarded to
+  `pandas.read_csv`, e.g. `--csv-option delimiter=";"`.
+- **`--ignore-column COLUMN`** (repeatable) — drop a CSV column before building nodes. Pass the
+  flag once per column.
+- **`--override`** — controls how `<MCF>` is written when it already exists. Without it, new nodes
+  are appended to the file. With it, the file is truncated and written fresh.
+
+CSV values that map to a `dcid:`-typed field (`Node`, `populationType`, `measuredProperty`,
+`measurementQualifier`, `measurementDenominator`) must already carry the `dcid:` prefix. `csv2mcf`
+builds the node objects directly from the CSV, and unlike `CustomDataManager`'s `add_*` methods it
+does not mint the prefix for you. A bare value such as `climateFinanceProvidedCommitments` in the
+`Node` column fails with a pydantic `string_pattern_mismatch` error.
+
+`typeOf` isn't in that list: for `--node-type Node` it's a required column, but a bare value there
+is minted to `dcid:<value>` automatically; for the other four node types it defaults to a fixed
+value (`dcid:StatisticalVariable`, `dcid:StatVarGroup`, `dcid:Topic`, `dcid:StatVarPeerGroup`) that
+a CSV `typeOf` column doesn't need to repeat.
+
+!!! warning "Heads up"
+    Without `--override`, `csv2mcf` appends to `<MCF>` if it already exists rather than replacing
+    it. Running the same command twice against the same output path writes duplicate `Node:`
+    blocks. Pass `--override` to truncate the file first, or write to a fresh path each run.
+
+**Example**
+
+```csv title="variables.csv"
+Node,name,populationType,measuredProperty,statType,description
+dcid:climateFinanceProvidedCommitments,Climate finance provided (commitments),dcid:Thing,dcid:amount,dcid:measuredValue,"Bilateral climate finance commitments reported by the provider country, in current USD."
+```
+
+```
+$ dcp-tools csv2mcf variables.csv custom_nodes.mcf --node-type StatVar
+$ cat custom_nodes.mcf
+Node: dcid:climateFinanceProvidedCommitments
+name: "Climate finance provided (commitments)"
+typeOf: dcid:StatisticalVariable
+description: "Bilateral climate finance commitments reported by the provider country, in current USD."
+statType: dcid:measuredValue
+populationType: dcid:Thing
+measuredProperty: dcid:amount
+```
+
+`--column-mapping`, `--csv-option`, and `--ignore-column` combine to read a differently-shaped
+source file:
+
+```
+$ dcp-tools csv2mcf variables_raw.csv custom_nodes.mcf \
+    --node-type StatVar \
+    --column-mapping node_id=Node \
+    --column-mapping label=name \
+    --column-mapping pop_type=populationType \
+    --column-mapping measured_prop=measuredProperty \
+    --csv-option delimiter=";" \
+    --ignore-column source_note
+```
+
+That reads a semicolon-delimited `variables_raw.csv`, drops its `source_note` column, and renames
+the rest to the properties named on the right of each `=`.
+
+## `dcp-tools upload`
+
+Uploads every `.csv`, `.json`, and `.mcf` file under a directory to the configured GCS bucket,
+wrapping `upload_to_cloud_storage`.
+
+```
+dcp-tools upload [--settings-file PATH] [--env-file PATH] [--directory PATH] [--sync]
+```
+
+**Options**
+
+- **`--settings-file PATH`**, **`--env-file PATH`** — see [Global options](#global-options).
+- **`--directory PATH`** (default: the directory configured as `LOCAL_PATH` in settings) — local
+  directory to upload. Files are matched recursively. Anything under it that isn't `.csv`,
+  `.json`, or `.mcf` is skipped with a warning. The local directory structure is preserved under
+  the bucket's input folder.
+- **`--sync`** (default: off) — after uploading, delete remote blobs that no longer have a local
+  counterpart. Deletion is scoped to import subdirectories that have local files present. An
+  import missing from `--directory` entirely, or present but empty, is left untouched remotely.
+
+**Example**
+
+```
+$ dcp-tools upload --settings-file customDC.json --directory export/
+2026-07-21 09:14:02 | INFO     | dcp-tools | Uploaded export/config.json to climate-finance/config.json
+2026-07-21 09:14:02 | INFO     | dcp-tools | Uploaded export/provenance.mcf to climate-finance/provenance.mcf
+2026-07-21 09:14:03 | INFO     | dcp-tools | Uploaded export/custom_nodes.mcf to climate-finance/custom_nodes.mcf
+2026-07-21 09:14:03 | INFO     | dcp-tools | Uploaded 3 files to climate-finance in GCS bucket one-dcp-import
+```
+
+## `dcp-tools dataload`
+
+Triggers the DCP ingestion job that loads uploaded files into the knowledge graph, wrapping
+`run_data_load`.
+
+```
+dcp-tools dataload [--settings-file PATH] [--env-file PATH] [--imports a,b,c]
+```
+
+**Options**
+
+- **`--settings-file PATH`**, **`--env-file PATH`** — see [Global options](#global-options).
+- **`--imports a,b,c`** (default: every import) — comma-separated import names to scope the run
+  to. Omit it to load everything under the configured GCS input folder.
+
+**Example**
+
+```
+$ dcp-tools dataload --settings-file customDC.json --imports climate-finance
+2026-07-21 09:15:10 | INFO     | dcp-tools | Starting data load job 'dcp-prep-job'
+2026-07-21 09:15:11 | INFO     | dcp-tools | Started job 'projects/one-climate-finance/locations/us-central1/jobs/dcp-prep-job'
+```
+
+!!! note
+    `dataload` only triggers the ingestion job. It doesn't upload anything first, so the files it
+    loads must already be in Cloud Storage (run `upload` beforehand, or use `pipeline`). Once the
+    job finishes, the platform ingests and serves the new data on its own. There's no separate
+    redeploy or restart command to run.
+
+## `dcp-tools pipeline`
+
+Runs `upload` followed by `dataload` for every import in one call, wrapping
+`upload_to_cloud_storage` then `run_data_load`.
+
+```
+dcp-tools pipeline [--settings-file PATH] [--env-file PATH] [--directory PATH] [--sync]
+```
+
+**Options**
+
+- **`--settings-file PATH`**, **`--env-file PATH`**, **`--directory PATH`**, **`--sync`** — same
+  flags and defaults as [`upload`](#dcp-tools-upload).
+
+!!! warning "Heads up"
+    `pipeline` has no `--imports` flag. It always calls `dataload` with no import filter, loading
+    everything. To load a subset of imports, run `upload` and `dataload --imports=...` as two
+    separate commands instead.
+
+**Example**
+
+```
+$ dcp-tools pipeline --settings-file customDC.json --directory export/
+2026-07-21 09:16:40 | INFO     | dcp-tools | Uploaded export/config.json to climate-finance/config.json
+2026-07-21 09:16:40 | INFO     | dcp-tools | Uploaded export/provenance.mcf to climate-finance/provenance.mcf
+2026-07-21 09:16:41 | INFO     | dcp-tools | Uploaded export/custom_nodes.mcf to climate-finance/custom_nodes.mcf
+2026-07-21 09:16:41 | INFO     | dcp-tools | Uploaded 3 files to climate-finance in GCS bucket one-dcp-import
+2026-07-21 09:16:41 | INFO     | dcp-tools | Starting data load job 'dcp-prep-job'
+2026-07-21 09:16:42 | INFO     | dcp-tools | Started job 'projects/one-climate-finance/locations/us-central1/jobs/dcp-prep-job'
+```
+
+## Related
+
+- **[Preparing data](preparing-data.md)** — build the `config.json`, CSVs, and `.mcf` files that
+  `csv2mcf`, `upload`, and `pipeline` operate on.
+- **[Loading data](loading-data.md)** — the `KGSettings` model and the Python functions these
+  commands wrap.

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -20,9 +20,9 @@ in `config.json` uses `observationAbout` for a row about one entity, and `custom
 row about several. That split exists because a single dcid reference can't represent a bilateral
 relationship.
 
-## Background: what a custom Data Commons deployment needs
+## Background: what a Data Commons Platform deployment needs
 
-A custom Data Commons instance serves an organization's own data next to the base Data Commons
+A Data Commons Platform instance serves an organization's own data next to the base Data Commons
 knowledge graph. Getting data in isn't a matter of writing rows into a database table. The
 platform's ingestion job reads a declarative bundle (config, CSVs, MCF) and turns it into graph
 nodes and observations. `dcp-tools` builds that bundle. It doesn't talk to a database and it

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -1,85 +1,211 @@
-# Data Commons Schemas
+# Why `config.json` and MCF, not one file
 
-Data Commons uses the **explicit schema** to map your data to the knowledge graph. Each CSV file
-must include a column mapping that tells the importer which columns represent entities, time
-periods, and statistical variable values.
+## The question this page answers
 
-# Explicit schema
+`CustomDataManager.export_all` writes a `config.json` and one or more `.mcf` files side by
+side. Why two formats instead of one, and how does a CSV column end up as a predicate on a
+Data Commons observation? For the mechanics of calling `add_input_file`, `add_variable_to_mcf`,
+and friends, see [Preparing data](preparing-data.md).
 
-With the explicit schema your data must follow the variable-per-row format, where each row
-represents a single observation. Each CSV file is registered with a `columnMappings` block that
-describes the role of each column.
+## The short answer
 
-### Example explicit schema workflow
+`config.json` and `.mcf` do different jobs. `config.json` tells the importer how to *read your
+CSVs*: which column holds the variable, which holds the date, which holds the entity a row is
+about. MCF tells the importer what *new graph nodes exist* that aren't already in the base Data
+Commons graph: your StatVars, your groups, your sources and provenances, and, for genuinely new
+concepts, custom entity types, event types, properties, units, and measurement methods. Every
+input file dcp-tools produces is variable-per-row (one observation per row). That's the only
+layout the current importer accepts, so there's no format to choose. The `columnMappings` block
+in `config.json` uses `observationAbout` for a row about one entity, and `custom:<name>` for a
+row about several. That split exists because a single dcid reference can't represent a bilateral
+relationship.
 
-Here is a simple example of a workflow using the explicit schema.
+## Background: what a custom Data Commons deployment needs
 
-Let's say we have some data on GDP for different countries that we want to import into Data Commons.
-The data comes from the IMF World Economic Outlook, and we have already cleaned and formatted it:
+A custom Data Commons instance serves an organization's own data next to the base Data Commons
+knowledge graph. Getting data in isn't a matter of writing rows into a database table. The
+platform's ingestion job reads a declarative bundle (config, CSVs, MCF) and turns it into graph
+nodes and observations. `dcp-tools` builds that bundle. It doesn't talk to a database and it
+doesn't run the ingestion job itself. `CustomDataManager` assembles the files, and
+[`run_data_load`](loading-data.md) hands them to the platform's prep job.
 
-```python
-import pandas as pd
+The full shape of the bundle format, including fields not covered here, is documented at
+[docs.datacommons.org/custom_dc/custom_data.html](https://docs.datacommons.org/custom_dc/custom_data.html).
+The part `dcp-tools` exists to make easier to construct is narrower: how a CSV column becomes a
+predicate, and why the schema-defining nodes live in a separate file format.
 
-df = pd.DataFrame({
-    "country": ["USA", "Canada", "Mexico"],
-    "year": [2020, 2020, 2020],
-    "variable": ["Amount_EconomicActivity_GrossDomesticProduction_Nominal"] * 3,
-    "value": [21000000, 1700000, 1200000],
-    "unit": ["USDollar"] * 3,
-})
-```
+## The reasoning
 
-This DataFrame uses the explicit (variable-per-row) format. The `columnMappings` block will tell
-the importer which columns map to entities, dates, variable DCIDs, and observation values.
+### `config.json` declares column roles, not data
 
-First, create a `CustomDataManager` instance:
+Every entry in `config.json`'s `inputFiles` list points at a CSV and carries a `columnMappings`
+block. The block doesn't hold data. It holds a role assignment: which column in *this specific
+CSV* plays which part in *every* observation the importer will build from it.
 
 ```python
 from dcp_tools import CustomDataManager
+import pandas as pd
 
 manager = CustomDataManager()
-```
-
-Add the source and provenance:
-
-```python
-manager.add_source(
-    name="IMF",
-    url="https://www.imf.org/en/Home",
-)
+manager.add_source(name="ONEData", url="https://data.one.org")
 manager.add_provenance(
-    name="WEO",
-    url="https://www.imf.org/en/Publications/WEO",
-    source="IMF",
+    name="ONEClimateFinance",
+    url="https://datacommons.one.org/data/climate-finance-files",
+    source="ONEData",
+)
+
+commitments = pd.DataFrame({
+    "country": ["Germany", "France", "Japan"],
+    "year": [2023, 2023, 2023],
+    "variable": ["climateFinanceProvidedCommitments"] * 3,
+    "value": [2_100, 1_450, 3_200],
+})
+
+manager.add_input_file(
+    "climate-finance/commitments.csv",
+    provenance="ONEClimateFinance",
+    data=commitments,
+    columnMappings={
+        "observationAbout": "country",
+        "date": "year",
+        "variable": "variable",
+        "value": "value",
+    },
 )
 ```
 
-Register the data file with its column mappings:
+The resulting `config.json` entry:
+
+```json
+{
+    "filename": "climate-finance/commitments.csv",
+    "provenance": "dcid:provenance/ONEClimateFinance",
+    "columnMappings": {
+        "dcid:variableMeasured": "variable",
+        "dcid:observationDate": "year",
+        "dcid:value": "value",
+        "dcid:observationAbout": "country"
+    },
+    "format": "variablePerRow"
+}
+```
+
+Each key in `columnMappings` is a role the importer already understands (`observationAbout`,
+`date`, `variable`, `value`, `unit`, `scalingFactor`, `measurementMethod`,
+`observationPeriod`). The string you supply is the name of the column that fills that role in
+*this* file. `add_input_file` accepts the short names (`variable`, `date`, and so on).
+`config.json` stores them under their `dcid:`-prefixed aliases because that's the predicate
+form the importer reads them as. Two files can map the same role to differently named columns (one CSV might call
+its date column `year`, another `fiscal_year`) because the mapping is declared per file.
+
+What `columnMappings` cannot do is invent a column that isn't there, or tell the importer what a
+value like `climateFinanceProvidedCommitments` *means*. That's the MCF file's job: it defines
+the `climateFinanceProvidedCommitments` StatVar node once, and every row across every CSV that
+references it by that dcid inherits the definition.
+
+### observationAbout vs. custom dimensions: why bilateral data needs a different mechanism
+
+`observationAbout` takes exactly one column, because it fills exactly one predicate:
+"this observation is about this entity." That works for the commitments file above, one country
+per row. It stops working the moment a row describes a relationship between two entities instead
+of a fact about one.
+
+Take provider-to-recipient climate finance flows. Each row already has two country columns,
+neither of which is uniquely "the" entity the row is about. Continuing with the same `manager`
+from above, register a StatVar that names the two dimensions, then register the file:
 
 ```python
-from dcp_tools.custom_data.models.data_files import ColumnMappings
+flows = pd.DataFrame({
+    "provider": ["Germany", "France", "Japan"],
+    "recipient": ["Kenya", "Senegal", "Vietnam"],
+    "year": [2023, 2023, 2023],
+    "variable": ["climateFinanceProvidedFlows"] * 3,
+    "value": [340, 210, 480],
+})
 
-manager.add_explicit_schema_file(
-    file_name="economy/gdp.csv",
-    provenance="WEO",
-    data=df,
-    columnMappings=ColumnMappings(
-        entityColumn="country",
-        observationDateColumn="year",
-        variableColumn="variable",
-        observationValueColumn="value",
-        observationProperties={"unit": "USDollar"},
-    ),
+manager.add_variable_to_mcf(
+    Node="climateFinanceProvidedFlows",
+    name="Climate finance provided (bilateral flow)",
+    statType="dcid:measuredValue",
+    observationProperties=["dcid:providerCountry", "dcid:recipientCountry"],
+)
+
+manager.add_input_file(
+    "climate-finance/flows.csv",
+    provenance="ONEClimateFinance",
+    data=flows,
+    columnMappings={
+        "variable": "variable",
+        "date": "year",
+        "value": "value",
+        "custom:providerCountry": "provider",
+        "custom:recipientCountry": "recipient",
+    },
 )
 ```
 
-Export all files:
+`custom:<name>` in `columnMappings` doesn't replace `observationAbout`. It adds a named dimension
+alongside it. Each `custom:<name>` key becomes a `dcid:<name>` property reference on the
+observation. The StatVar's own `observationProperties` list tells the importer which
+properties to expect and validate against. Here that's `providerCountry` and `recipientCountry`,
+declared once on the StatVar rather than re-derived per file. A single-entity StatVar doesn't
+need this list at all. It's specific to the multi-entity case, because the importer has no other
+way to know that a row with two country columns is deliberately structured that way and not
+missing an `observationAbout`.
 
-```python
-manager.export_all("output_directory")
-```
+### Two dcid rules, and why they aren't the same rule
 
-The `config.json` and the data CSV will be created in `output_directory`.
+Names you pass to `add_source` and `add_provenance` go through a different minting rule than
+names you pass to `add_entity_type`, `add_property`, `add_unit`, or `Node`/`populationType`/etc.
+on `add_variable_to_mcf`. Both rules turn a bare token into a `dcid:`-prefixed one, but only one
+of them inserts a namespace segment:
 
-For more detail on the explicit schema format, see the
-[Data Commons custom data documentation](https://docs.datacommons.org/custom_dc/custom_data.html).
+- `add_source(name="ONEData", ...)` mints `dcid:source/ONEData`.
+- `add_property(Node="providerCountry", ...)` mints `dcid:providerCountry`, no `property/`
+  segment.
+
+The difference tracks what's being identified. A source or provenance name is usually a short
+organizational label: `"ONEData"`, `"WEO"`, `"IMF"`. Two different datasets, even two teams at
+the same organization, can plausibly both register a source called `"WorldBank"`. Nesting the
+name under `source/` or `provenance/` means that collision has to happen inside a much smaller
+namespace (one
+organization's list of sources) instead of the flat graph-wide dcid space, and it keeps a
+source's identity separate from a provenance's even if someone reuses the same word for both.
+
+A custom entity type, property, unit, or measurement method doesn't have that problem, because
+defining one *is* the act of claiming a unique identifier. When you call
+`add_property(Node="providerCountry", ...)`, you're not labeling something that already exists
+elsewhere. You're declaring that `dcid:providerCountry` is now a `Property` node. The
+`typeOf: dcid:Property` on the node itself is what disambiguates it from a same-named source or
+StatVar, not an extra path segment on the id. That's why these builders use `ensure_dcid`, which
+only adds the `dcid:` prefix, while sources and provenances use `mint_dcid`, which adds a
+namespace segment too.
+
+## Alternatives considered
+
+Earlier versions of this package supported two input-file formats side by side, then called
+"explicit" and "implicit" schema: the explicit one required the `columnMappings` block described
+above, and the implicit one (`variablePerColumn`) let the importer infer column roles by
+convention instead. The implicit format is gone. `Config` now rejects a `config.json` that
+declares `"format": "variablePerColumn"` with an error pointing at the migration path, rather
+than accepting it and guessing wrong. Maintaining two formats meant maintaining two mental models
+for the same underlying data (which column is the variable, which is the date) and two code paths
+for validating them, for a convenience (skipping explicit mappings) that mattered less than the
+ambiguity it introduced. Collapsing to one format also removed the need for the "explicit vs.
+implicit" name itself. A contrast only needs a name when there's something to contrast it with.
+
+## Consequences
+
+Every input file dcp-tools writes is variable-per-row. You don't choose a format when calling
+`add_input_file`. There's exactly one, so the question doesn't come up. `columnMappings` is
+always required (it's how the importer finds your columns at all), and it always uses
+`observationAbout` for single-entity data or `custom:<name>` keys for multi-entity data, never a
+bare `entity` key. That field was renamed for the same reason, to stop implying entity and
+observationAbout were different things.
+
+## Related
+
+- [Preparing data](preparing-data.md) walks through `CustomDataManager` end to end: sources,
+  provenances, variables, input files, and export.
+- [CLI tools](cli-tools.md) covers `csv2mcf`, for building MCF node files straight from a CSV
+  without going through `CustomDataManager`.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,69 +1,67 @@
-# Getting started with `dcp-tools`
+# Build your first custom Data Commons import
 
-This page walks you through the basic steps to install and start using 
-`bblocks-datacommons-tools` to prepare and load the data for your custom instance.
+> A working import bundle for a custom Data Commons instance, built with `dcp-tools` and verified by loading it back.
 
-## About custom Data Commons instances
+## What you'll build
 
-Anyone can build and manage their own Data Commons instance—combining their own datasets with the base
-data available from datacommons.org, and taking advantage of built-in features like natural language queries, 
-interactive visualisations, and data exploration tools. For many organisations, a custom instance is a practical 
-way to publish data with exploration and visualisation tools without building infrastructure from scratch.
+By the end, you'll have a complete import bundle on disk: a `config.json`, two MCF files, and a CSV of climate finance data, generated entirely from Python. This is the same shape of bundle a custom Data Commons instance loads from Google Cloud Storage.
 
-However, preparing your data for a Data Commons knowledge graph, uploading the necessary files to Google 
-Cloud Platform (GCP), and deploying the service can be a repetitive and error-prone process.
-For smaller projects with limited data and infrequent updates, managing the workflow manually may be
-sufficient. But for larger datasets or pipelines with regular refreshes, the process quickly 
-becomes tedious and difficult to maintain.
+```
+one_climate_finance/
+├── config.json
+├── custom_nodes.mcf
+├── provenance.mcf
+└── climate_finance/
+    └── one_cf_provider_commitments.csv
+```
 
-`dcp-tools` streamlines this workflow by allowing you to programmatically prepare and load data using
-a Python-based pipeline.
+## What you'll learn
 
-Before you get started, you should have a basic understanding of how custom Data Commons instances work and 
-what the data loading process involves. You can find the
-[official documentation here](docs.datacommons.org/custom_dc/custom_data.html).
+- How to register a source and a provenance as MCF nodes
+- How to register an input CSV file with column mappings
+- How to declare a StatVar for a data file
+- How to export a complete bundle with `export_all`
+- How to verify an exported bundle by loading it back
 
-At a top level, you should be familiar with:
+## What you'll need
 
-- **The `config.json` file**: the 
-[JSON configuration](https://docs.datacommons.org/custom_dc/custom_data.html#step-2-write-the-json-config-file) 
-file that specifies how to map and resolve data to the
-Data Commons schema knowledge graph.
-- **The data files**: CSV files containing the data formatted for the
-[explicit schema](https://docs.datacommons.org/custom_dc/custom_data.html#explicit).
-- **Meta Content Framework 
-([MCF](https://docs.datacommons.org/custom_dc/custom_data.html#step-1-define-statistical-variables-in-mcf)) files**: files that provide additional flexibility form modeling data for the knowledge
-graph.
-- **Uploading data and deploying**: Files need to be loaded to GCP, and the service needs to be 
-[deployed](https://docs.datacommons.org/custom_dc/deploy_cloud.html).
+- Python 3.13 or later
+- `pip install dcp-tools` (installs `pandas` and `pydantic` alongside it)
+- No GCP account or credentials. This tutorial stops at a bundle on disk. [Loading data](./loading-data.md) covers uploading it.
+- About 15-20 minutes
 
+## Step 1: Install dcp-tools and create a manager
 
-## Installation
+Install the package, then create a `CustomDataManager`. It's the object you'll register everything on (sources, variables, input files) before anything gets written to disk.
 
-The package can be installed in various ways. 
-
-Directly as
 ```bash
 pip install dcp-tools
 ```
-
-## Preparing data
-
-`dcp-tools` offers convenient functionality to prepare configuration JSON, MCF, and custom data files
-without having to manually edit these files. To access this functionality, create an instance of the 
-`CustomDataManager` class.
 
 ```python
 from dcp_tools import CustomDataManager
 
 manager = CustomDataManager()
+print(manager)
 ```
 
-The `CustomDataManager` lets you create or edit the `config.json` file without editing it manually. 
+You should see a manager with nothing registered yet:
 
-You can register variables, sources or provenances, and data files. 
+```
+<CustomDataManager config: 
+0 inputFiles, with 0 containing data
+0 sources
+0 provenances
+0 variables
+0 vertical specs
+flags: importName=None, includeInputSubdirs=None, groupStatVarsByProperty=None, defaultCustomRootStatVarGroupName=None, customIdNamespace=None, customSvgPrefix=None, svHierarchyPropsBlocklist=None, dataDownloadUrl=None, verticalSpecsFile=None>
+```
 
-```python title="Add source and provenance"
+## Step 2: Register a source and a provenance
+
+Register where the data comes from: a Source (the publishing organization) and a Provenance (this specific dataset). Every input file you register later points back at a Provenance dcid, so it has to exist first.
+
+```python
 manager.add_source(name="ONEData", url="https://data.one.org")
 manager.add_provenance(
     name="ONEClimateFinance",
@@ -72,64 +70,207 @@ manager.add_provenance(
 )
 ```
 
-You can pass pandas DataFrames to the manager and the manager will handle exporting the data as
-CSVs in the correct format.
+!!! note
+    `name` becomes part of the node's dcid, so it can't contain spaces. `add_source` turns `"ONEData"` into `dcid:source/ONEData`. If you want a spaced-out label, put it in `description` instead.
 
-```python title="Add explicit schema data"
+Both calls add MCF nodes in memory. Export them to see what they'll look like on disk:
+
+```python
+manager.export_mcf_file("one_climate_finance", mcf_file_name="provenance.mcf")
+print(open("one_climate_finance/provenance.mcf").read())
+```
+
+This also creates the `one_climate_finance/` directory, since it doesn't exist yet. You should see:
+
+```
+Node: dcid:source/ONEData
+typeOf: dcid:Source
+url: "https://data.one.org"
+
+Node: dcid:provenance/ONEClimateFinance
+typeOf: dcid:Provenance
+url: "https://datacommons.one.org/data/climate-finance-files"
+sourceLink: dcid:source/ONEData
+```
+
+## Step 3: Register the input CSV file
+
+Register a CSV of bilateral climate finance commitments, one row per observation. `columnMappings` tells `dcp-tools` which column holds which piece of an observation. The Kenya and Fiji figures below are illustrative, not published commitments.
+
+```python
 import pandas as pd
-from dcp_tools.custom_data.models.data_files import ColumnMappings
 
-df = pd.DataFrame(...)
+data = pd.DataFrame({
+    "country": ["Kenya", "Kenya", "Fiji", "Fiji"],
+    "year": [2022, 2023, 2022, 2023],
+    "variable": ["climateFinanceProvidedCommitments"] * 4,
+    "value": [12.4, 15.8, 3.1, 4.6],
+})
 
-manager.add_explicit_schema_file(
+manager.add_input_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
     provenance="ONEClimateFinance",
-    data=df,
-    columnMappings=ColumnMappings(
-        entity="country",
-        date="year",
-        variable="variable",
-        value="value",
-    ),
+    data=data,
+    columnMappings={
+        "observationAbout": "country",
+        "date": "year",
+        "variable": "variable",
+        "value": "value",
+    },
 )
 ```
 
-
-Once you are finished adding and editing data and configuration, you can 
-validate and export all the files for your custom Data Commons instance.
+`file_name` can include a subdirectory, like `climate_finance/one_cf_provider_commitments.csv` above, and `export_all` creates that subdirectory for you later. Check what landed in the config with `config_to_dict`:
 
 ```python
-manager.export_all("path/to/output/folder")
+import json
+
+print(json.dumps(manager.config_to_dict()["inputFiles"], indent=2))
 ```
 
-**Read more detailed documentation about preparing data with the `CustomDataManager` 
-[here ↗](./preparing-data.md)**
+You should see one entry, with `provenance` minted to a dcid and each mapping rewritten to its `dcid:` form:
 
-## Loading data
-
-You can programmatically push the data and config to a Google Cloud
-Storage Bucket and trigger the data load job.
-
-First, specify all the configuration settings needed to add files to the storage bucket. For convenience these
-can be specified in a `.env` file (read more about the configuration settings [here](./loading-data.md)).
-
-
-```python
-from dcp_tools.gcp_utilities import get_kg_settings
-
-settings = get_kg_settings(source="env", env_file="customDC.env")
+```json
+[
+  {
+    "filename": "climate_finance/one_cf_provider_commitments.csv",
+    "provenance": "dcid:provenance/ONEClimateFinance",
+    "columnMappings": {
+      "dcid:variableMeasured": "variable",
+      "dcid:observationDate": "year",
+      "dcid:value": "value",
+      "dcid:observationAbout": "country"
+    },
+    "format": "variablePerRow"
+  }
+]
 ```
 
+## Step 4: Declare the StatVar
 
-Now we can load data and configuration files to the storage bucket and run the data load job on GCP.
+The `variable` column holds `climateFinanceProvidedCommitments`, a dcid that has to resolve to a real StatVar node, or the importer has nothing to attach the observations to. Declare it with `add_variable_to_mcf`.
 
 ```python
-from dcp_tools.gcp_utilities import (
-    upload_to_cloud_storage,
-    run_data_load,
+manager.add_variable_to_mcf(
+    Node="climateFinanceProvidedCommitments",
+    name="Climate finance provided (commitments)",
+    description="Bilateral climate finance commitments reported by the provider country.",
+    provenance="ONEClimateFinance",
+    populationType="Thing",
+    measuredProperty="amount",
 )
+```
 
-upload_to_cloud_storage(settings=settings, directory="path/to/folder/with/data_and_config")
-run_data_load(settings=settings)
+`Node` is a bare token here, so `dcp-tools` normalizes it to `dcid:climateFinanceProvidedCommitments` for you. It must match the `variable` column values exactly. Export the checkpoint and take a look:
+
+```python
+manager.export_mcf_file("one_climate_finance", mcf_file_name="custom_nodes.mcf")
+print(open("one_climate_finance/custom_nodes.mcf").read())
+```
 
 ```
+Node: dcid:climateFinanceProvidedCommitments
+name: "Climate finance provided (commitments)"
+typeOf: dcid:StatisticalVariable
+description: "Bilateral climate finance commitments reported by the provider country."
+provenance: "ONEClimateFinance"
+statType: dcid:measuredValue
+populationType: dcid:Thing
+measuredProperty: dcid:amount
+```
+
+The `provenance` field here is the bare name you passed in, stored as a plain quoted string on the node, not the minted dcid you saw on the input file entry in Step 3.
+
+## Step 5: Export the bundle and verify it
+
+`export_all` writes the config, the data, and any MCF files you name, in one call. It doesn't export MCF files unless you list them.
+
+!!! warning "Heads up"
+    `mcf_file_names` defaults to `None`, which exports no MCF at all. Since the input file from Step 3 references the provenance node in `provenance.mcf`, leaving it off `mcf_file_names` makes `export_all` raise a `ValueError` before writing anything, rather than shipping a config with a dangling reference.
+
+Steps 2 and 4 already wrote `provenance.mcf` and `custom_nodes.mcf` once each as checkpoints, so this final call needs `override=True` to overwrite them instead of appending:
+
+```python
+manager.export_all(
+    "one_climate_finance",
+    mcf_file_names=["provenance.mcf", "custom_nodes.mcf"],
+    override=True,
+)
+```
+
+List the directory to confirm the full bundle landed:
+
+```python
+import os
+
+for root, _, files in os.walk("one_climate_finance"):
+    for f in sorted(files):
+        print(os.path.relpath(os.path.join(root, f)))
+```
+
+```
+one_climate_finance/config.json
+one_climate_finance/custom_nodes.mcf
+one_climate_finance/provenance.mcf
+one_climate_finance/climate_finance/one_cf_provider_commitments.csv
+```
+
+`config.json` now has an `importName`, defaulted from the export directory name since we never called `set_importName`:
+
+```json
+{
+    "importName": "one_climate_finance",
+    "inputFiles": [
+        {
+            "filename": "climate_finance/one_cf_provider_commitments.csv",
+            "provenance": "dcid:provenance/ONEClimateFinance",
+            "columnMappings": {
+                "dcid:variableMeasured": "variable",
+                "dcid:observationDate": "year",
+                "dcid:value": "value",
+                "dcid:observationAbout": "country"
+            },
+            "format": "variablePerRow"
+        }
+    ]
+}
+```
+
+Now confirm the bundle is self-consistent by loading it into a fresh manager:
+
+```python
+reloaded = CustomDataManager(
+    config_file="one_climate_finance/config.json",
+    mcf_files=[
+        "one_climate_finance/provenance.mcf",
+        "one_climate_finance/custom_nodes.mcf",
+    ],
+)
+print(reloaded)
+```
+
+```
+<CustomDataManager config: 
+1 inputFiles, with 0 containing data
+1 sources
+1 provenances
+1 variables
+0 vertical specs
+flags: importName=one_climate_finance, includeInputSubdirs=None, groupStatVarsByProperty=None, defaultCustomRootStatVarGroupName=None, customIdNamespace=None, customSvgPrefix=None, svHierarchyPropsBlocklist=None, dataDownloadUrl=None, verticalSpecsFile=None>
+```
+
+1 input file, 1 source, 1 provenance, 1 variable. `with 0 containing data` is expected. Reloading from `config_file`/`mcf_files` restores the config and MCF nodes, not the CSV data. That data lives in the CSV file on disk, never in `config.json`.
+
+## What you learned
+
+- You registered a source and a provenance as MCF nodes
+- You registered an input CSV file with column mappings
+- You declared a StatVar for a data file
+- You exported a complete bundle with `export_all`
+- You verified an exported bundle by loading it back
+
+## What's next
+
+- **[Preparing data](./preparing-data.md)**. The full `CustomDataManager` catalogue: schema-node builders, multi-entity dimensions, vertical specs, config merging.
+- **[Why config.json and MCF](./dc-schemas.md)**. The reasoning behind the `config.json`/MCF split and the column-mapping shapes.
+- **[Loading data](./loading-data.md)**. Upload `one_climate_finance/` to Google Cloud Storage and trigger the ingestion job.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,10 +1,10 @@
-# Build your first custom Data Commons import
+# Build your first Data Commons Platform import
 
-> A working import bundle for a custom Data Commons instance, built with `dcp-tools` and verified by loading it back.
+> A working import bundle for a Data Commons Platform instance, built with `dcp-tools` and verified by loading it back.
 
 ## What you'll build
 
-By the end, you'll have a complete import bundle on disk: a `config.json`, two MCF files, and a CSV of climate finance data, generated entirely from Python. This is the same shape of bundle a custom Data Commons instance loads from Google Cloud Storage.
+By the end, you'll have a complete import bundle on disk: a `config.json`, two MCF files, and a CSV of climate finance data, generated entirely from Python. This is the same shape of bundle a Data Commons Platform instance loads from Google Cloud Storage.
 
 ```
 one_climate_finance/

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,41 +1,29 @@
 # dcp-tools
 
-__Tools to manage and load data for custom [Data Commons](https://datacommons.org/)
-instances__
+**Prepare and load data for custom Data Commons instances.**
 
-[![GitHub Repo](https://img.shields.io/badge/GitHub-bblocks--datacommons--tools-181717?style=flat-square&labelColor=%23ddd&logo=github&color=%23555&logoColor=%23000)](https://github.com/ONEcampaign/bblocks-datacommons-tools)
-[![GitHub License](https://img.shields.io/github/license/ONEcampaign/bblocks-datacommons-tools?style=flat-square&labelColor=%23ddd)](https://github.com/ONEcampaign/bblocks-datacommons-tools/blob/main/LICENSE)
-[![PyPI - Version](https://img.shields.io/pypi/v/dcp-tools?style=flat-square&labelColor=%23ddd)](https://pypi.org/project/dcp-tools/)
+`dcp-tools` is a Python package for building the config, metadata, and data files a custom Data
+Commons instance needs, then uploading them and triggering ingestion. Use it as a library or
+through the `dcp-tools` command-line tool.
 
-
-The `dcp-tools` package simplifies the process of preparing and loading data to custom 
-Data Commons instances. It provides utilities for building and editing configuration, metadata, and data files, 
-and automating the data load pipeline.
-
-[Data Commons](https://datacommons.org/) is a Google initiative that brings together public data from a
-wide range of sources into a unified knowledge graph, making it easier to explore and analyze 
-information across domains. Organisations can create custom instances of Data Commons to host their 
-own datasets, integrate them into the graph, and build tailored tools on top of the platform.
-
-Custom instances allow you to take advantage of core features such as natural language search and interactive 
-visualisations, while combining your own data with everything available in the base Data Commons.
-
-`dcp-tools` is designed to simplify and automate steps to build your custom instance—removing
-much of the manual work involved in formatting and loading data, and helping you get your custom 
-knowledge graph up and running quickly.
-
+A custom Data Commons instance lets an organization combine its own datasets with the public
+knowledge graph at [datacommons.org](https://datacommons.org/), while reusing the platform's
+search and visualization tools. The official
+[Custom Data Commons documentation](https://docs.datacommons.org/custom_dc/index.html) covers how
+the platform itself works. This site covers the tooling that prepares and loads data into it.
 
 **Key features**
 
 - Build and edit `config.json` files programmatically
-- Generate MCF files from simple metadata
-- Upload CSV, MCF, and config files to Google Cloud Storage
-- Trigger the data load job
-- Use as a Python module or from the command line
+- Register single- and multi-entity observations from CSV data
+- Declare custom schema nodes (entity types, event types, properties, units, measurement methods, StatVars, and StatVar groups) with typed builders
+- Upload prepared files to Google Cloud Storage and trigger the DCP (Data Commons Platform) ingestion job
+- Usable as a Python API or through the `dcp-tools` CLI
 
-Ready to get started using `dcp-tools`?<br> 
-**Read [Getting started ↗](./getting-started.md).**
+## Where to go next
 
-Want to learn more about Data Commons? <br>
-**Read the official 
-[Custom Data Commons documentation ↗](https://docs.datacommons.org/custom_dc/index.html).**
+- **[Getting started](getting-started.md)**: install `dcp-tools` and build a first import, from an empty config to files ready to upload.
+- **[Preparing data](preparing-data.md)**: task recipes covering the full `CustomDataManager` surface, from input files and custom dimensions to schema nodes and config merging.
+- **[Why config.json and MCF](dc-schemas.md)**: the reasoning behind the `config.json`/MCF split, dcid minting rules, and how multi-entity observations use custom dimensions.
+- **[Loading data](loading-data.md)**: upload prepared files to Cloud Storage and trigger the job that loads them into your instance.
+- **[CLI tools](cli-tools.md)**: reference for the `dcp-tools` command and its subcommands.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,12 +1,12 @@
 # dcp-tools
 
-**Prepare and load data for custom Data Commons instances.**
+**Prepare and load data for Data Commons Platform instances.**
 
-`dcp-tools` is a Python package for building the config, metadata, and data files a custom Data
-Commons instance needs, then uploading them and triggering ingestion. Use it as a library or
+`dcp-tools` is a Python package for building the config, metadata, and data files a Data Commons
+Platform instance needs, then uploading them and triggering ingestion. Use it as a library or
 through the `dcp-tools` command-line tool.
 
-A custom Data Commons instance lets an organization combine its own datasets with the public
+A Data Commons Platform instance lets an organization combine its own datasets with the public
 knowledge graph at [datacommons.org](https://datacommons.org/), while reusing the platform's
 search and visualization tools. The official
 [Custom Data Commons documentation](https://docs.datacommons.org/custom_dc/index.html) covers how

--- a/docs/docs/loading-data.md
+++ b/docs/docs/loading-data.md
@@ -1,83 +1,145 @@
-# Loading data to the knowledge graph
+# How to upload and load data into a custom Data Commons instance
 
-This page walks through the process of loading data into a custom Data Commons knowledge graph. There are two
-main steps involved:
-- Pushing data files, MCF files and the `config.json` file to Google Cloud Storage.
-- Triggering the Data Commons load job.
+Upload an exported data bundle to Google Cloud Storage, then trigger the Data Commons Platform (DCP) job that loads it into your custom knowledge graph and serves it.
 
-Before starting, specify all the settings to connect to GCP, push data to Google Cloud Storage, 
-and trigger the Data Commons load job. 
-This can be done using a `.env` file, a `.json` file, or by instantiating a `KGSettings` object directly.
-The settings should include the following information:
+## Before you start
 
-- `LOCAL_PATH`: Path to the local directory that will be exported.
-- `GCP_PROJECT_ID`: GCP project ID.
-- `GCP_CREDENTIALS`: GCP credentials in JSON format.
-- `GCS_BUCKET_NAME`: Google Cloud Storage bucket name.
-- `GCS_INPUT_FOLDER_PATH`: Google Cloud Storage input folder path.
-- `GCS_OUTPUT_FOLDER_PATH`: Google Cloud Storage output folder path.
-- `LOAD_JOB_REGION`: Cloud Run load job region.
-- `LOAD_JOB_NAME`: Cloud Run load job name.
-- `LOAD_JOB_SERVICE_ACCOUNT`: Cloud Run service account email to impersonate, optional.
+- A custom Data Commons instance with the DCP ingestion pipeline already deployed. `dcp-tools` doesn't provision instances. Follow Google's [guide to deploying a custom instance ↗](https://docs.datacommons.org/custom_dc/deploy_cloud.html) first.
+- An exported bundle: a local directory holding `config.json`, your CSV data files, and any `.mcf` files, built with `CustomDataManager.export_all` (see [Preparing data](preparing-data.md)).
+- The settings `dcp-tools` needs to reach GCP and your load job, gathered into a `KGSettings` object:
 
-create a KGSettings object from a `.env` file, a `.json` file, or directly instantiating an object.
+    - `local_path` (`LOCAL_PATH`): local directory to export and upload. This is the bundle directory from the step above.
+    - `gcp_project_id` (`GCP_PROJECT_ID`): your GCP project ID.
+    - `gcp_credentials` (`GCP_CREDENTIALS`, optional): GCP service account credentials as a JSON string. Leave unset to use Application Default Credentials (after `gcloud auth application-default login`).
+    - `gcs_bucket_name` (`GCS_BUCKET_NAME`): the Cloud Storage bucket the DCP pipeline reads from.
+    - `gcs_input_folder_path` (`GCS_INPUT_FOLDER_PATH`): folder in that bucket to upload the bundle to.
+    - `gcs_output_folder_path` (`GCS_OUTPUT_FOLDER_PATH`): folder the pipeline writes its output to.
+    - `load_job_region` (`LOAD_JOB_REGION`): region of the Cloud Run load job.
+    - `load_job_name` (`LOAD_JOB_NAME`): name of the Cloud Run load job.
+    - `load_job_service_account` (`LOAD_JOB_SERVICE_ACCOUNT`, optional): service account to impersonate when triggering the job. Leave unset to use your own credentials.
 
-```python title="settings from .env file"
-from dcp_tools.gcp_utilities import get_kg_settings
+## Steps
 
-settings = get_kg_settings(source="env", env_file="customDC.env")
+1. **Build a `KGSettings` object.** `dcp-tools` reads these settings through `KGSettings`, a `pydantic-settings` model. Build one from a `.env` file, a JSON file, or directly, whichever fits how you manage secrets.
 
-```
+    ```python title="from a .env file"
+    from dcp_tools.gcp_utilities import get_kg_settings
 
-```python title="settings from .json file"
-from dcp_tools.gcp_utilities import get_kg_settings
+    settings = get_kg_settings(source="env", env_file="customDC.env")
+    ```
 
-settings = get_kg_settings(source="json", env_file="customDC.json")
+    ```python title="from a JSON file"
+    from dcp_tools.gcp_utilities import get_kg_settings
 
-```
+    settings = get_kg_settings(source="json", file="customDC.json")
+    ```
 
-```python title="settings from KGSettings object"
-from pathlib import Path
-from dcp_tools.gcp_utilities import KGSettings
+    `customDC.json` uses the same names as the environment variables:
 
-settings = KGSettings(
-    LOCAL_PATH=Path("path/to/local/directory"),
-    GCP_PROJECT_ID="your-gcp-project-id",
-    GCP_CREDENTIALS="path/to/credentials.json",
-    GCS_BUCKET_NAME="your-gcs-bucket-name",
-    GCS_INPUT_FOLDER_PATH="input/folder/path",
-    GCS_OUTPUT_FOLDER_PATH="output/folder/path",
-    LOAD_JOB_REGION="your-load-job-region",
-    LOAD_JOB_NAME="your-load-job-name",
-    LOAD_JOB_SERVICE_ACCOUNT="your-service-account-email"
-)
-```
+    ```json
+    {
+      "LOCAL_PATH": "path/to/output/folder",
+      "GCP_PROJECT_ID": "one-campaign-dc",
+      "GCS_BUCKET_NAME": "one-campaign-dc-custom-data",
+      "GCS_INPUT_FOLDER_PATH": "customdc/input",
+      "GCS_OUTPUT_FOLDER_PATH": "customdc/output",
+      "LOAD_JOB_REGION": "us-central1",
+      "LOAD_JOB_NAME": "dc-load-job"
+    }
+    ```
 
-## Load data into the custom Data Commons instance
+    ```python title="constructing KGSettings directly"
+    from pathlib import Path
 
-Once you have specified the settings, you can take the next steps to load data into your custom Data 
-Commons knowledge graph.
+    from dcp_tools.gcp_utilities import KGSettings
 
-First, you need to upload the directory containing the `config.json` file and any CSV or MCF files to 
-Google Cloud Storage.
+    settings = KGSettings(
+        LOCAL_PATH=Path("path/to/output/folder"),
+        GCP_PROJECT_ID="one-campaign-dc",
+        GCS_BUCKET_NAME="one-campaign-dc-custom-data",
+        GCS_INPUT_FOLDER_PATH="customdc/input",
+        GCS_OUTPUT_FOLDER_PATH="customdc/output",
+        LOAD_JOB_REGION="us-central1",
+        LOAD_JOB_NAME="dc-load-job",
+    )
+    ```
 
-```python title="Upload to GCS"
-from dcp_tools.gcp_utilities import (
-    upload_to_cloud_storage,
-    run_data_load
-)
+    Using the CLI instead of the Python API? Skip building a `KGSettings` object yourself and pass `--env-file customDC.env` or `--settings-file customDC.json` to any of the commands in the next two steps.
 
-upload_to_cloud_storage(settings=settings, directory="path/to/output/folder")
-```
+2. **Upload the bundle to Cloud Storage.** This pushes every `.csv`, `.json`, and `.mcf` file under `settings.local_path` to `gs://<gcs_bucket_name>/<gcs_input_folder_path>/`, preserving the directory structure. Other file types are skipped with a warning.
 
-Next, we'll run the data load job on Google Cloud Platform.
+    ```python
+    from dcp_tools.gcp_utilities import upload_to_cloud_storage
+
+    upload_to_cloud_storage(settings=settings)
+    ```
+
+    ```bash
+    dcp-tools upload --env-file customDC.env
+    ```
+
+    Pass `sync=True` (Python) or `--sync` (CLI) to also delete remote files that no longer have a local counterpart. This is useful when you've removed or renamed a CSV since the last upload. Sync only prunes import subdirectories that are present locally. It won't touch an import that isn't in your local bundle at all.
+
+    ```bash
+    dcp-tools upload --env-file customDC.env --sync
+    ```
+
+3. **Trigger ingestion.** This starts the DCP prep job against whatever is currently in `gcs_input_folder_path`.
+
+    ```python
+    from dcp_tools.gcp_utilities import run_data_load
+
+    run_data_load(settings=settings)                           # every import
+    run_data_load(settings=settings, imports="climateFinance")  # one import
+    ```
+
+    ```bash
+    dcp-tools dataload --env-file customDC.env --imports=climateFinance
+    ```
+
+    To upload and trigger ingestion in one call, use `pipeline` instead of running `upload` and `dataload` separately:
+
+    ```bash
+    dcp-tools pipeline --env-file customDC.env --sync
+    ```
+
+    `pipeline` always loads every import. It has no `--imports` flag. If you need to load a subset, run `upload` then `dataload --imports=...` separately.
+
+`run_data_load` returns as soon as the job starts. It doesn't wait for the job to finish. Under the hood it calls `datacommons-admin`'s `IngestionJobClient`, which starts the DCP prep job. That job ingests the uploaded data and serves it automatically. There's nothing further to trigger from `dcp-tools`.
+
+!!! note
+    Older versions of this package required a separate `redeploy` call after the load job, plus a set of `CLOUD_SQL_*` settings to reach the underlying database. Both are gone. The DCP prep job now owns the restart, and there's no Cloud SQL in the current architecture.
+
+## Verify it worked
+
+Compare what's registered in `config.json` against what actually landed in the bucket:
+
 ```python
-# Load all data
-run_data_load(settings=settings)
+import json
+from pathlib import Path
 
-# Load specific imports
-run_data_load(settings=settings, imports="import_a,import_b")
+from dcp_tools.gcp_utilities import get_missing_csv_files, get_unregistered_csv_files
+from dcp_tools.gcp_utilities.clients import get_gcs_client
+
+config = json.loads(Path("path/to/output/folder/config.json").read_text())
+bucket = get_gcs_client(settings.gcp_credentials).get_bucket(settings.gcs_bucket_name)
+
+print(get_missing_csv_files(bucket, config, gcs_folder_name=settings.gcs_input_folder_path))
+print(get_unregistered_csv_files(bucket, config, gcs_folder_name=settings.gcs_input_folder_path))
 ```
 
-**Read more about deploying your custom instance to Google Cloud 
-[here ↗](https://docs.datacommons.org/custom_dc/deploy_cloud.html)**
+Both should return `[]`. A non-empty `get_missing_csv_files` result means a file the config expects never made it to GCS (upload failed, or it ran against the wrong folder). A non-empty `get_unregistered_csv_files` result means there's a stray CSV in the bucket that no `inputFiles` entry points at.
+
+The load job itself runs as a Cloud Run job (`load_job_name` in `load_job_region`). Its run history and logs are visible in the Google Cloud Console under Cloud Run > Jobs, not through `dcp-tools`.
+
+## Troubleshooting
+
+- **`KGSettings`/`get_kg_settings` raises a `pydantic.ValidationError` listing several fields as "Field required".** One or more required settings are missing from your `.env`/JSON file, or weren't passed to the constructor. Every field except `gcp_credentials` and `load_job_service_account` is required. Check the list under [Before you start](#before-you-start).
+- **`GCP_CREDENTIALS` raises `Invalid JSON`.** `gcp_credentials` expects the *contents* of a service-account key as a JSON string, not a file path. Read the key file and pass its contents (`Path("key.json").read_text()`), or leave the setting unset to use Application Default Credentials.
+- **`get_missing_csv_files` reports every registered CSV as missing, even though the upload succeeded.** Both functions treat a `gcs_folder_name` that doesn't match anything in the bucket as an empty folder rather than raising: `get_missing_csv_files` then reports every `inputFiles` entry as missing, and `get_unregistered_csv_files` reports nothing (there's nothing to compare against). Check `gcs_input_folder_path` for a typo, or confirm the upload step ran first. Leading and trailing slashes are stripped automatically, so those aren't the issue.
+- **`run_data_load` raises `RuntimeError: Failed to start data load job: ...`.** The underlying `IngestionJobClient` call failed, most often from a wrong `load_job_name`/`load_job_region`, or a `load_job_service_account` that isn't allowed to invoke the job.
+
+## See also
+
+- [Preparing data](preparing-data.md): build the `config.json`, CSV, and MCF bundle before uploading it.
+- [CLI tools](cli-tools.md): full flag reference for `upload`, `dataload`, and `pipeline`.

--- a/docs/docs/loading-data.md
+++ b/docs/docs/loading-data.md
@@ -1,10 +1,10 @@
-# How to upload and load data into a custom Data Commons instance
+# How to upload and load data into a Data Commons Platform instance
 
 Upload an exported data bundle to Google Cloud Storage, then trigger the Data Commons Platform (DCP) job that loads it into your custom knowledge graph and serves it.
 
 ## Before you start
 
-- A custom Data Commons instance with the DCP ingestion pipeline already deployed. `dcp-tools` doesn't provision instances. Follow Google's [guide to deploying a custom instance ↗](https://docs.datacommons.org/custom_dc/deploy_cloud.html) first.
+- A Data Commons Platform instance with the DCP ingestion pipeline already deployed. `dcp-tools` doesn't provision instances. Follow Google's [guide to deploying a custom instance ↗](https://docs.datacommons.org/custom_dc/deploy_cloud.html) first.
 - An exported bundle: a local directory holding `config.json`, your CSV data files, and any `.mcf` files, built with `CustomDataManager.export_all` (see [Preparing data](preparing-data.md)).
 - The settings `dcp-tools` needs to reach GCP and your load job, gathered into a `KGSettings` object:
 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -1,14 +1,14 @@
-# Preparing data for Data Commons
+# Preparing data
 
-`dcp-tools` offers convenient functionality to prepare configuration JSON, 
-MCF, and custom data files without having to manually edit these files. The `CustomDataManager`
-lets you create or edit an existing `config.json` file, work with MCF files, export data stored as pandas
-DataFrames in correct CSV formats, and validate all the files ensuring they are correctly structured for
-Data Commons.
+`CustomDataManager` builds a custom Data Commons import bundle (a `config.json` file, CSV data,
+and `.mcf` files) without hand-editing any of the three. Each section below is a standalone
+recipe. Jump to the one you need.
 
-## Creating a `CustomDataManager`
+!!! note
+    Assumes `dcp-tools` is installed (`pip install dcp-tools`). See
+    [Getting started](getting-started.md) if it isn't.
 
-To start preparing your data, create a `CustomDataManager` instance.
+## How to create a `CustomDataManager`
 
 ```python
 from dcp_tools import CustomDataManager
@@ -16,230 +16,438 @@ from dcp_tools import CustomDataManager
 manager = CustomDataManager()
 ```
 
-This will create a custom data manager without a blank `config.json` and no MCF files, which you can use if you are
-building the files from scratch. If you already have a `config.json` or any MCF files you can specify them at
-instantiation.
+This creates a blank config (an empty `inputFiles` list) and one empty MCF collection named
+`custom_nodes.mcf`. Every `add_*`/`set_*` method below returns the manager, so calls chain.
+
+To load files you already have:
 
 ```python
-manager = CustomDataManager(config_file="path/to/config.json", mcf_file="path/to/mcf_file.mcf")
-```
-
-You might store several config files in subdirectories. You can create a `CustomDataManager` instance specifying 
-the directory containing the `config.json` files which will be merged into a single `config.json` file.
-
-```python
-manager = CustomDataManager.from_config_files_in_directory("path/to/directory")
-```
-
-## Managing provenances and sources
-
-The `CustomDataManager` allows you to define the sources and provenances for your data. Sources and
-provenances are written as MCF `Source` and `Provenance` nodes — by default into a file called
-`provenance.mcf`. Each input file references a provenance by name; internally that reference is stored
-as `dcid:provenance/<name>`.
-
-Add a source first, then add one or more provenances that point to it:
-
-```python
-manager.add_source(name="SourceName", url="https://example.com/source")
-manager.add_provenance(
-    name="ProvenanceName",
-    url="https://example.com/provenance",
-    source="SourceName",
+manager = CustomDataManager(
+    config_file="path/to/config.json",
+    mcf_files=["path/to/provenance.mcf", "path/to/custom_nodes.mcf"],
 )
 ```
 
-Each `name` becomes part of a dcid (`dcid:source/<name>`, `dcid:provenance/<name>`), so it must be a
-valid dcid token — no whitespace (use `"ONEData"`, not `"ONE Data"`). A name containing whitespace
-raises a `ValueError`.
+`mcf_files` takes one path or a list. Each file is loaded and keyed internally by its filename.
+To merge several `config.json` files from a directory tree into one manager, see
+[How to merge config files](#how-to-merge-config-files).
 
-`add_provenance` requires the named source to already exist (added via `add_source`). If a source or
-provenance with the same name already exists, a `ValueError` is raised unless you pass `override=True`.
+## How to register a source and provenance
 
-Both methods accept optional metadata kwargs (`description`, `license`, `isPartOf` on both; additionally
+Every input file must reference a provenance, and every provenance must reference a source. Add
+the source first:
+
+```python
+from dcp_tools import CustomDataManager
+
+manager = CustomDataManager()
+
+manager.add_source(
+    name="ONEData",
+    url="https://data.one.org",
+)
+manager.add_provenance(
+    name="ONEClimateFinance",
+    url="https://datacommons.one.org/data/climate-finance-files",
+    source="ONEData",
+)
+```
+
+This writes two nodes to `provenance.mcf` (the default file for both methods): a `dcid:Source`
+node at `dcid:source/ONEData`, and a `dcid:Provenance` node at `dcid:provenance/ONEClimateFinance`
+linking to it. `add_provenance` raises `ValueError` if `source` isn't registered yet.
+
+!!! note
+    `name` mints part of a dcid. A bare name becomes `dcid:source/<name>` or
+    `dcid:provenance/<name>`. An already `dcid:`-prefixed name is used as-is. Names can't
+    contain whitespace (`"ONEData"`, not `"ONE Data"`). Put a whitespace-friendly display string
+    in `description=` instead. See [Why config.json and MCF](dc-schemas.md) for why the importer
+    needs dcids shaped this way.
+
+Both methods take `description`, `license`, and `isPartOf`. `add_provenance` additionally takes
 `licenseType`, `lastDataRefreshDate`, `nextDataRefreshDate`, `nextSourceReleaseDate`,
-`sourceReleaseFrequency`, `earliestObservationDate`, `latestObservationDate`, and `curator` on
-`add_provenance`). Use the `additional_properties` dict for any property not covered by those kwargs.
+`sourceReleaseFrequency`, `earliestObservationDate`, `latestObservationDate`, and `curator`. Use
+`additional_properties={"someProperty": "value"}` for anything else. Pass `override=True` to
+replace a node that's already registered under the same name.
 
-Source and Provenance nodes live in `provenance.mcf` by default. To write that file to disk you must list
-it explicitly when exporting:
+!!! warning "Heads up"
+    `provenance.mcf` isn't exported automatically. List it explicitly when you export:
 
-```python
-manager.export_all("path/to/output/folder", mcf_file_names=["provenance.mcf"])
-```
+    ```python
+    manager.export_all("output", mcf_file_names=["provenance.mcf"])
+    ```
 
-This is the same mechanism used for any other MCF file — `provenance.mcf` is not exported automatically.
+    If a registered input file references a provenance whose MCF file isn't in
+    `mcf_file_names`, `export_all` raises before writing anything, rather than shipping a
+    `config.json` with a dangling reference. See
+    [How to validate and export the bundle](#how-to-validate-and-export-the-bundle).
 
+## How to register a single-entity input file
 
-## Managing variables
-
-The `CustomDataManager` lets you add variables to MCF files for the explicit schema. Read more
-about the explicit schema [here](dc-schemas.md).
-
-You can rename variables using the `rename_variable` method, optionally specifying the MCF file.
-
-
-```python
-manager.rename_variable("ghed_che", "ghed_current_health_expenditure",
-                        mcf_file="path/to/mcf_file.mcf")
-```
-
-You can also remove variables from the `config.json` or MCF files using the `remove_variable` method.
-
-```python
-manager.remove_variable("ghed_che", mcf_file="path/to/mcf_file.mcf")
-```
-
-## Managing the data files
-
-The `CustomDataManager` allows you to manage the data files you want to import into Data Commons. 
-**Note:** This doesn't mean formatting or transforming the data, but rather managing the files that will be used
-to import the data into Data Commons and registering them according to the schema you are using. 
-
-The `CustomDataManager` provides support for working with pandas DataFrames, allowing you to register
-data stored in a DataFrame to the manager which will export the data to a CSV file in the correct format
-for Data Commons.
-
-To register a data file, use the `add_explicit_schema_file` method:
+Use this when each row of data is about one entity (a country, a facility, a person).
 
 ```python
 import pandas as pd
-from dcp_tools.custom_data.models.data_files import ColumnMappings
 
 df = pd.DataFrame({
-    "country": ["USA", "Canada", "Mexico"],
-    "year": [2020, 2020, 2020],
-    "variable": ["Amount_EconomicActivity_GrossDomesticProduction_Nominal"] * 3,
-    "value": [21000000, 1700000, 1200000],
+    "country": ["country/KEN", "country/BGD", "country/KEN"],
+    "year": [2022, 2022, 2023],
+    "variable": ["climateFinanceProvidedCommitments"] * 3,
+    "value": [4.2, 1.8, 5.1],
 })
 
-manager.add_explicit_schema_file(
-    file_name="gdp.csv",
-    provenance="IMF",
+manager.add_input_file(
+    file_name="climate_finance_commitments.csv",
+    provenance="ONEClimateFinance",
     data=df,
-    columnMappings=ColumnMappings(
-        entity="country",
-        date="year",
-        variable="variable",
-        value="value",
-    ),
+    columnMappings={
+        "observationAbout": "country",
+        "date": "year",
+        "variable": "variable",
+        "value": "value",
+    },
+    observationProperties={"unit": "USDollar"},
 )
 ```
 
-Adding data when registering a data file is optional. You can also add the data later using the `add_data` method:
+`columnMappings` keys map a role to a CSV column name. Allowed keys: `variable`,
+`observationAbout`, `date`, `value`, `unit`, `scalingFactor`, `measurementMethod`,
+`observationPeriod`, plus `custom:<name>` for multi-entity data (see the next section).
+`observationAbout` is the entity column for single-entity data. It holds a dcid per row (here,
+country dcids like `country/KEN`).
+
+`observationProperties` here differs from `add_variable_to_mcf`'s parameter of the same
+name. On `add_input_file` it's a dict of file-level constants applied to every row (every
+observation in this file is in US dollars), not a list of dcid refs.
+
+Data is optional at registration:
 
 ```python
-manager.add_data(data=df, file_name="gdp.csv")
+manager.add_input_file(
+    file_name="climate_finance_disbursements.csv",
+    provenance="ONEClimateFinance",
+    columnMappings={
+        "observationAbout": "country",
+        "date": "year",
+        "variable": "variable",
+        "value": "value",
+    },
+)
+# ...later, once the DataFrame is ready:
+manager.add_data(df, "climate_finance_disbursements.csv")
 ```
 
-## Removing variables and data files
+`add_data` raises `ValueError` if `file_name` isn't already registered via `add_input_file`. To
+register many files by glob pattern instead of one at a time, pass `pattern=` instead of
+`file_name=`. Pattern entries are config-only and can't carry a `data=` DataFrame.
 
-You can remove variables and data files using the `remove_indicator` and `rename_variable` methods.
+## How to register multi-entity observations with custom dimensions
 
-
-## Adding and merging config files
-
-[//]: # (<---TODO: adding and merging config files here --->)
-
-
-
-
-
-## Additional settings
-
-There are some additional settings you can configure in the `CustomDataManager`:
+Use this when a row of data is about more than one entity, such as a bilateral flow between a
+provider and a recipient country, rather than a value about a single country.
 
 ```python
-manager.set_includeInputSubdirs(True)  # Include input subdirectories in the config.json
-```
+import pandas as pd
 
-This method will add the `includeInputSubdirs` field to the `config.json` file, which allows you
-to place data files in subdirectories inside the main output directory. This is useful for organizing your data files
-and keeping them structured. By default, this is not set and the Data Commons importer will expect all data files
-to be in the main output directory. If this is set to `True`, You can specify the subdirectory when adding a data file:
+flows = pd.DataFrame({
+    "provider": ["country/KEN", "country/KEN", "country/BGD"],
+    "recipient": ["country/BGD", "country/UGA", "country/UGA"],
+    "year": [2022, 2022, 2022],
+    "variable": ["climateFinanceBilateralFlow"] * 3,
+    "value": [1.4, 0.9, 0.6],
+})
 
-```python
-manager.add_explicit_schema_file(
-    file_name="economics/gdp.csv",
-    provenance="IMF",
-    columnMappings=ColumnMappings(
-        entity="country",
-        date="year",
-        variable="variable",
-        value="value",
-    ),
+manager.add_input_file(
+    file_name="bilateral_climate_finance_flows.csv",
+    provenance="ONEClimateFinance",
+    data=flows,
+    columnMappings={
+        "variable": "variable",
+        "date": "year",
+        "value": "value",
+        "custom:providerCountry": "provider",
+        "custom:recipientCountry": "recipient",
+    },
+)
+
+manager.add_variable_to_mcf(
+    Node="climateFinanceBilateralFlow",
+    name="Climate finance bilateral flow",
+    description="Bilateral climate finance commitments between a provider and a recipient country.",
+    statType="dcid:measuredValue",
+    observationProperties=["dcid:providerCountry", "dcid:recipientCountry"],
 )
 ```
 
-You can also set the `groupStatVarsByProperty` field in the `config.json` file, 
-which allows you to group statistical variables by their properties. 
+There's no `observationAbout` here. Multi-entity rows use one `custom:<name>` mapping key per
+dimension instead (`ColumnMappings` collects any `custom:`-prefixed key automatically, so you
+don't build the `customDimensions` dict by hand). Each `custom:<name>` key must have a matching
+`dcid:<name>` entry in the StatVar's `observationProperties` list. `custom:providerCountry` pairs
+with `dcid:providerCountry`.
+
+!!! note
+    `providerCountry` and `recipientCountry` are properties, not entities. If they aren't already
+    part of the base Data Commons schema, declare them with `add_property` first (see the next
+    section).
+
+See [Why config.json and MCF](dc-schemas.md#observationabout-vs-custom-dimensions-why-bilateral-data-needs-a-different-mechanism)
+for why `observationAbout` can't represent a row about two entities.
+
+## How to declare StatVars and custom schema nodes
+
+`CustomDataManager` has six MCF node builders. Use `add_variable_to_mcf` for the StatVars
+themselves. Use the other five when your data needs a schema concept Data Commons doesn't already
+define.
+
+| Method | Emits | Use when |
+|---|---|---|
+| `add_variable_to_mcf` | `dcid:StatisticalVariable` | Declaring a StatVar (see above) |
+| `add_entity_type` | `dcid:Class` | Your data describes something Data Commons doesn't have a `Class` for yet, such as a program type or a facility category |
+| `add_event_type` | `dcid:Class` (`subClassOf` defaults to `dcid:Event`) | Your data is about events (a pledge announcement, a policy change) rather than a state |
+| `add_property` | `dcid:Property` | You need a new predicate, such as a custom dimension from the previous section |
+| `add_unit` | `dcid:UnitOfMeasure` | Your values are in a unit Data Commons doesn't already define |
+| `add_measurement_method` | `dcid:MeasurementMethodEnum` | You want to record how an observation was produced (survey, estimate, administrative data) |
+
+All six accept a bare or `dcid:`-prefixed `Node` token. Bare tokens are normalized to
+`dcid:<token>` (no namespace segment, unlike source/provenance names). `add_measurement_method` is
+the only one where `name` is optional.
+
+Declaring the StatVar the single-entity input file from earlier references:
+
+```python
+manager.add_variable_to_mcf(
+    Node="climateFinanceProvidedCommitments",
+    name="Climate finance committed",
+    description="Bilateral climate finance commitments provided by a country.",
+    statType="dcid:measuredValue",
+    populationType="Country",
+    measuredProperty="amount",
+)
+```
+
+This emits a `dcid:StatisticalVariable` node to `custom_nodes.mcf` (the default file for this
+builder). `populationType` and `measuredProperty` go through the same bare-or-`dcid:` normalization
+as `Node`.
+
+Declaring the two properties the multi-entity StatVar from the previous section depends on:
+
+```python
+manager.add_property(
+    Node="providerCountry",
+    name="provider country",
+    description="The country providing climate finance in a bilateral flow.",
+    domainIncludes="StatisticalVariable",
+    rangeIncludes="Country",
+)
+manager.add_property(
+    Node="recipientCountry",
+    name="recipient country",
+    description="The country receiving climate finance in a bilateral flow.",
+    domainIncludes="StatisticalVariable",
+    rangeIncludes="Country",
+)
+```
+
+This mints `dcid:providerCountry` and `dcid:recipientCountry`. These are the same tokens the
+StatVar's `observationProperties` and the input file's `custom:` columnMappings keys referenced.
+
+`add_entity_type` and `add_event_type` take an `includedIn` kwarg that's a bare **provenance**
+name, not a dcid, unlike every other ref parameter on these builders:
+
+```python
+manager.add_entity_type(
+    Node="ClimateFinanceProgram",
+    name="Climate finance program",
+    description="A named climate finance program or initiative tracked by ONE.",
+    includedIn="ONEClimateFinance",
+)
+```
+
+The provenance must already be registered via `add_provenance`, or this raises `ValueError`. The
+builder expands one bare name into `includedIn` dcids for **both** the Provenance node and its
+linked Source node.
+
+## How to add StatVar groups and bulk-import variables from a CSV
+
+Add a top-level StatVarGroup for all of an organization's custom variables:
+
+```python
+manager.add_variable_group_to_mcf(
+    Node="dcid:one/g/ONEData",
+    name="ONE Data",
+    specializationOf="dcid:dc/g/Root",
+)
+```
+
+`Node` must contain `g/`. `specializationOf` is `"dcid:dc/g/Root"` for a top-level group, or
+another group's dcid for a sub-group. Unlike the schema-node builders above,
+`add_variable_group_to_mcf` doesn't normalize a bare `Node`. Pass it already `dcid:`-prefixed.
+
+To declare many StatVars at once instead of calling `add_variable_to_mcf` per variable, put them
+in a CSV with one row per StatVar and columns matching `StatVarMCFNode` field names:
+
+```csv
+Node,name,statType,memberOf
+dcid:climateFinanceProvidedGrants,Climate finance committed as grants,dcid:measuredValue,Economic/ClimateFinance/BilateralCommitments
+dcid:climateFinanceProvidedLoans,Climate finance committed as loans,dcid:measuredValue,Economic/ClimateFinance/BilateralCommitments
+```
+
+```python
+manager.add_variables_to_mcf_from_csv(
+    "climate_finance_variables.csv",
+    parse_groups=True,
+    group_namespace="one",
+)
+```
+
+`parse_groups=True` treats `memberOf` as a slash-separated group path
+(`"Economic/ClimateFinance/BilateralCommitments"`) instead of a dcid, and expands it into a chain
+of `StatVarGroupMCFNode`s under `group_namespace` (here, `dcid:one/g/economic`, then
+`.../climatefinance`, then `.../bilateralcommitments`). Each StatVar's `memberOf` is rewritten to
+the deepest group's dcid. Rename CSV columns to node field names with
+`column_to_property_mapping` if your headers don't already match.
+
+!!! note
+    The groups `parse_groups` generates land in the same `mcf_file_name` as the StatVars
+    (`custom_nodes.mcf` by default), not in `add_variable_group_to_mcf`'s default of
+    `custom_groups.mcf`. If you export both files, this doesn't matter. If you only export one,
+    it does.
+
+The `dcp-tools csv2mcf` CLI command wraps the same conversion for a CSV that isn't going through a
+`CustomDataManager` at all. See [CLI tools](cli-tools.md) for the command reference.
+
+## How to rename and remove variables
+
+```python
+manager.rename_variable("dcid:climateFinanceProvidedCommitments", "dcid:climateFinanceCommitmentsProvided")
+```
+
+Pass the full node id on both sides, matching what's stored (the value after minting, not the bare
+name you might have originally passed to `add_variable_to_mcf`). Raises `ValueError` if the old
+name isn't found or the new name is already taken. Scope the search to one file with
+`mcf_file_name=`. Omit it and all loaded MCF files are searched.
+
+```python
+manager.remove_indicator("dcid:climateFinanceCommitmentsProvided")
+```
+
+!!! warning "Heads up"
+    There's no `remove_variable` method. The real name is `remove_indicator`.
+
+## How to merge config files
+
+Use this when different teams maintain separate `config.json` files for the same custom Data
+Commons instance and you need one combined bundle.
+
+```python
+from dcp_tools import CustomDataManager
+
+merged = CustomDataManager.from_config_files_in_directory("path/to/configs")
+```
+
+This recursively finds every `config.json` under the directory and merges them into one manager,
+replacing whatever config the manager already had. To merge into an existing manager instead of
+starting fresh, call `merge_configs_from_directory` directly:
+
+```python
+manager.merge_configs_from_directory("path/to/configs", replace_loaded_config=False)
+```
+
+To merge a single config (an object, a dict, or a path to a JSON file) rather than a whole
+directory:
+
+```python
+manager.merge_config("path/to/other/config.json")
+```
+
+All three take `policy`, one of `"error"` (default, raises on any conflicting value),
+`"override"` (the new config wins), or `"ignore"` (the existing value is kept). Input files are
+merged by `filename`/`pattern`. Everything else (`importName`, `customIdNamespace`,
+`svHierarchyPropsBlocklist`, and so on) is merged field by field.
+
+!!! warning "Heads up"
+    `export_config` defaults an unset `importName` to the export directory's name. If two configs
+    were each exported without an explicit `importName`, merging them raises a conflict on
+    `importName` (`"climate"` vs. `"health"`) even though neither config set it on purpose. Call
+    `set_importName` explicitly on configs you intend to merge later.
+
+## How to add vertical specs to guide the StatVar hierarchy
+
+Vertical specs tell the importer which top-level groups to file matching StatVars under when
+`groupStatVarsByProperty` is set. Skip this unless you're using that setting.
 
 ```python
 manager.set_groupStatVarsByProperty(True)
+manager.add_vertical_spec(
+    verticals=["ClimateFinanceVertical"],
+    population_type="Country",
+    measured_properties=["amount"],
+)
 ```
 
-You can control the generated StatVar and StatVarGroup identifiers in the `config.json` file.
+Each call appends one spec matching StatVars about `population_type` with the given
+`measured_properties` to `verticals`. The first call also sets the config's `verticalSpecsFile` to
+`"vertical_specs.json"`, unless you already set one with `set_verticalSpecsFile` or passed
+`file_name=` here. `export_all` (or `export_vertical_specs` directly) writes the accumulated specs
+as `{"specs": [...]}` JSON. Exporting with no specs added raises `ValueError`.
 
+## How to validate and export the bundle
 
-```python
-manager.set_customIdNamespace("ONE")
-manager.set_customSvgPrefix("ONE/g/")  # Optional – overrides the default of "geo/g/"
-manager.set_defaultCustomRootStatVarGroupName("ONE Data")
-```
-
-Finally, you can update the hierarchy blocklist used when generating StatVar groups
-from the config. Any duplicates you provide are ignored automatically:
-
-```python
-manager.set_svHierarchyPropsBlocklist([
-    "WhoCode",
-    "aggregationDimensions",
-])
-```
-
-
-
-## Validating and exporting files
-
-To ensure that your `config.json` is correctly structured, you can validate it using the `validate_config` method:
+Validate without writing anything:
 
 ```python
 manager.validate_config()
 ```
 
-The config is automatically validated when you export it. You can export the `config.json` file to disk
-or get the config as a dictionary.
+Raises a pydantic `ValidationError` or `ValueError` if the config is invalid, including if an
+input file references a provenance that was never registered.
 
-```python title="Export config to disk"
-manager.export_config("path/to/output/config.json")
-```
-
-```python title="Get config as dictionary"
-config_dict = manager.config_to_dict()
-```
-
-Additionally, you can export the data or MCF files to disk.
-
-```python title="Export data files"
-manager.export_data("path/to/output/folder")
-```
-
-```python title="Export MCF files"
-manager.export_mfc_file("path/to/output/folder")
-```
-
-To export all files at once, you can use the `export_all` method:
+Export everything in one call:
 
 ```python
-manager.export_all("path/to/output/folder")
+manager.export_all(
+    "output_directory",
+    mcf_file_names=["provenance.mcf", "custom_nodes.mcf", "custom_groups.mcf"],
+)
 ```
-**Note**: By default this will export the `config.json` and all data files. MCF files are not exported by default.
-To export MCF files as well, you should specify the `mcf_file_names` parameter:
+
+`export_all` writes `config.json` always, data CSVs if any DataFrames are registered,
+`vertical_specs.json` if any specs were added, and each file in `mcf_file_names`. `mcf_file_names`
+defaults to `None`, which exports **no MCF file at all**. Omitting it is the most common way to
+end up with a `config.json` that references StatVars and provenances nobody wrote to disk.
+
+Before writing anything, `export_all` checks that every provenance an input file references (and
+that provenance's linked source) lives in one of the MCF files you're exporting. If not, it raises
+rather than shipping an incomplete bundle:
+
+```text
+ValueError: export_all() would write a config.json referencing source/provenance node(s)
+defined in MCF file(s) not being exported: ['provenance.mcf']. Add them to mcf_file_names
+(e.g. mcf_file_names=['provenance.mcf']) so the bundle is complete.
+```
+
+Pass `validate_data=True` to also raise if any declared input file has no registered DataFrame
+(pattern entries are exempt, since they carry no local data by design):
 
 ```python
-manager.export_all("path/to/output/folder", mcf_file_names=["mcf_file1.mcf", "mcf_file2.mcf"])
+manager.export_all("output_directory", mcf_file_names=["provenance.mcf"], validate_data=True)
 ```
 
-If an input file references a provenance, the MCF file defining it (`provenance.mcf` by default)
-must be among `mcf_file_names`; otherwise `export_all` raises before writing anything, so the
-exported bundle can never reference a provenance node that is missing from disk.
+To export pieces individually instead of all at once:
+
+- `export_config(dir_path)` writes only `config.json` (and defaults `importName` to the directory
+  name if you never set one).
+- `export_data(dir_path)` writes the registered DataFrames as CSVs.
+- `export_mcf_file(dir_path, mcf_file_name=...)` writes one MCF file.
+- `export_vertical_specs(dir_path)` writes the vertical specs file.
+- `config_to_dict()` returns the validated config as a dict without writing anything, and without
+  defaulting `importName`, since there's no export directory to name it after.
+
+## See also
+
+- [Why config.json and MCF](dc-schemas.md): why column mappings and dcids are shaped the way they
+  are.
+- [Loading data](loading-data.md): upload the exported bundle to Google Cloud Storage and trigger
+  the ingestion job.
+- [CLI tools](cli-tools.md): the `dcp-tools csv2mcf` command for CSV-to-MCF conversion outside a
+  `CustomDataManager`.

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -1,6 +1,6 @@
 # Preparing data
 
-`CustomDataManager` builds a custom Data Commons import bundle (a `config.json` file, CSV data,
+`CustomDataManager` builds a Data Commons Platform import bundle (a `config.json` file, CSV data,
 and `.mcf` files) without hand-editing any of the three. Each section below is a standalone
 recipe. Jump to the one you need.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -4,7 +4,7 @@ nav:
     - index.md
     - Getting started: getting-started.md
     - Preparing data: preparing-data.md
-    - Data Commons schemas: dc-schemas.md
+    - Why config.json and MCF: dc-schemas.md
     - Loading data: loading-data.md
     - CLI tools: cli-tools.md
     - Changelog: changelog.md


### PR DESCRIPTION
## Summary
- Full rewrite of README, `docs/docs/*.md`, CONTRIBUTING.MD, closes #105
- Replaces the pre-v1.1.0 load-job/redeploy/Cloud SQL story with the current DCP upload-and-ingest flow
- Documents what shipped without docs: schema-node builders, custom dimensions, vertical specs, config merging, full CLI reference
- Every code example checked against source (several run live); an independent pass for voice and consistency
