### PR TITLE
Refactor Node models

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ manager.add_input_file(
 )
 
 manager.add_variable_to_mcf(
-    Node="climateFinanceProvidedCommitments",
+    dcid="climateFinanceProvidedCommitments",
     name="Climate finance commitments (bilateral)",
     description="Funding committed for climate adaptation and mitigation projects",
     statType="dcid:measuredValue",

--- a/docs/docs/cli-tools.md
+++ b/docs/docs/cli-tools.md
@@ -82,7 +82,7 @@ dcp-tools csv2mcf <CSV> <MCF>
 - **`--node-type {Node,StatVar,StatVarGroup,Topic,StatVarPeerGroup}`** (default: `Node`) — the MCF
   node type to build, one per CSV row. `StatVar`, `StatVarGroup`, `Topic`, and `StatVarPeerGroup`
   map to the typed node models under `dcp_tools.custom_data.models`. `Node` builds the untyped base
-  `MCFNode` and accepts any column as an extra property.
+  model and accepts any column as an extra property.
 - **`--column-mapping CSV_COL=MCF_PROP`** (repeatable) — rename a CSV column to an MCF property
   before building nodes, e.g. `--column-mapping identifier=Node`. Pass the flag once per column.
 - **`--csv-option KEY=VALUE`** (repeatable) — an extra keyword argument forwarded to

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -124,7 +124,7 @@ flows = pd.DataFrame({
 })
 
 manager.add_variable_to_mcf(
-    Node="climateFinanceProvidedFlows",
+    dcid="climateFinanceProvidedFlows",
     name="Climate finance provided (bilateral flow)",
     statType="dcid:measuredValue",
     observationProperties=["dcid:providerCountry", "dcid:recipientCountry"],
@@ -161,7 +161,7 @@ on `add_variable_to_mcf`. Both rules turn a bare token into a `dcid:`-prefixed o
 of them inserts a namespace segment:
 
 - `add_source(name="ONEData", ...)` mints `dcid:source/ONEData`.
-- `add_property(Node="providerCountry", ...)` mints `dcid:providerCountry`, no `property/`
+- `add_property(dcid="providerCountry", ...)` mints `dcid:providerCountry`, no `property/`
   segment.
 
 The difference tracks what's being identified. A source or provenance name is usually a short
@@ -174,7 +174,7 @@ source's identity separate from a provenance's even if someone reuses the same w
 
 A custom entity type, property, unit, or measurement method doesn't have that problem, because
 defining one *is* the act of claiming a unique identifier. When you call
-`add_property(Node="providerCountry", ...)`, you're not labeling something that already exists
+`add_property(dcid="providerCountry", ...)`, you're not labeling something that already exists
 elsewhere. You're declaring that `dcid:providerCountry` is now a `Property` node. The
 `typeOf: dcid:Property` on the node itself is what disambiguates it from a same-named source or
 StatVar, not an extra path segment on the id. That's why these builders use `ensure_dcid`, which

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -152,7 +152,7 @@ The `variable` column holds `climateFinanceProvidedCommitments`, a dcid that has
 
 ```python
 manager.add_variable_to_mcf(
-    Node="climateFinanceProvidedCommitments",
+    dcid="climateFinanceProvidedCommitments",
     name="Climate finance provided (commitments)",
     description="Bilateral climate finance commitments reported by the provider country.",
     provenance="ONEClimateFinance",
@@ -161,7 +161,7 @@ manager.add_variable_to_mcf(
 )
 ```
 
-`Node` is a bare token here, so `dcp-tools` normalizes it to `dcid:climateFinanceProvidedCommitments` for you. It must match the `variable` column values exactly. Export the checkpoint and take a look:
+`dcid` is a bare token here, so `dcp-tools` normalizes it to `dcid:climateFinanceProvidedCommitments` for you. It must match the `variable` column values exactly. Export the checkpoint and take a look:
 
 ```python
 manager.export_mcf_file("one_climate_finance", mcf_file_name="custom_nodes.mcf")

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -171,7 +171,7 @@ manager.add_input_file(
 )
 
 manager.add_variable_to_mcf(
-    Node="climateFinanceBilateralFlow",
+    dcid="climateFinanceBilateralFlow",
     name="Climate finance bilateral flow",
     description="Bilateral climate finance commitments between a provider and a recipient country.",
     statType="dcid:measuredValue",
@@ -216,7 +216,7 @@ Declaring the StatVar the single-entity input file from earlier references:
 
 ```python
 manager.add_variable_to_mcf(
-    Node="climateFinanceProvidedCommitments",
+    dcid="climateFinanceProvidedCommitments",
     name="Climate finance committed",
     description="Bilateral climate finance commitments provided by a country.",
     statType="dcid:measuredValue",
@@ -233,14 +233,14 @@ Declaring the two properties the multi-entity StatVar from the previous section 
 
 ```python
 manager.add_property(
-    Node="providerCountry",
+    dcid="providerCountry",
     name="provider country",
     description="The country providing climate finance in a bilateral flow.",
     domainIncludes="StatisticalVariable",
     rangeIncludes="Country",
 )
 manager.add_property(
-    Node="recipientCountry",
+    dcid="recipientCountry",
     name="recipient country",
     description="The country receiving climate finance in a bilateral flow.",
     domainIncludes="StatisticalVariable",
@@ -256,7 +256,7 @@ name, not a dcid, unlike every other ref parameter on these builders:
 
 ```python
 manager.add_entity_type(
-    Node="ClimateFinanceProgram",
+    dcid="ClimateFinanceProgram",
     name="Climate finance program",
     description="A named climate finance program or initiative tracked by ONE.",
     includedIn="ONEClimateFinance",
@@ -273,7 +273,7 @@ Add a top-level StatVarGroup for all of an organization's custom variables:
 
 ```python
 manager.add_variable_group_to_mcf(
-    Node="dcid:one/g/ONEData",
+    dcid="dcid:one/g/ONEData",
     name="ONE Data",
     specializationOf="dcid:dc/g/Root",
 )

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -284,7 +284,7 @@ another group's dcid for a sub-group. Unlike the schema-node builders above,
 `add_variable_group_to_mcf` doesn't normalize a bare `Node`. Pass it already `dcid:`-prefixed.
 
 To declare many StatVars at once instead of calling `add_variable_to_mcf` per variable, put them
-in a CSV with one row per StatVar and columns matching `StatVarMCFNode` field names:
+in a CSV with one row per StatVar and columns matching `StatVarNode` field names:
 
 ```csv
 Node,name,statType,memberOf
@@ -302,7 +302,7 @@ manager.add_variables_to_mcf_from_csv(
 
 `parse_groups=True` treats `memberOf` as a slash-separated group path
 (`"Economic/ClimateFinance/BilateralCommitments"`) instead of a dcid, and expands it into a chain
-of `StatVarGroupMCFNode`s under `group_namespace` (here, `dcid:one/g/economic`, then
+of `StatVarGroupNode`s under `group_namespace` (here, `dcid:one/g/economic`, then
 `.../climatefinance`, then `.../bilateralcommitments`). Each StatVar's `memberOf` is rewritten to
 the deepest group's dcid. Rename CSV columns to node field names with
 `column_to_property_mapping` if your headers don't already match.

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -23,19 +23,19 @@ from dcp_tools.custom_data.models.data_files import (
     MCFFileName,
     ObservationProperties,
 )
-from dcp_tools.custom_data.models.mcf import MCFNode, MCFNodes
+from dcp_tools.custom_data.models.mcf import Node, Nodes
 from dcp_tools.custom_data.models.schema_nodes import (
-    EntityTypeMCFNode,
-    EventTypeMCFNode,
-    MeasurementMethodMCFNode,
-    PropertyMCFNode,
-    UnitOfMeasureMCFNode,
+    EntityTypeNode,
+    EventTypeNode,
+    MeasurementMethodNode,
+    PropertyNode,
+    UnitOfMeasureNode,
 )
-from dcp_tools.custom_data.models.sources import ProvenanceMCFNode, SourceMCFNode
+from dcp_tools.custom_data.models.sources import ProvenanceNode, SourceNode
 from dcp_tools.custom_data.models.stat_vars import (
     StatType,
-    StatVarGroupMCFNode,
-    StatVarMCFNode,
+    StatVarGroupNode,
+    StatVarNode,
 )
 from dcp_tools.custom_data.models.vertical_specs import VerticalSpec
 from dcp_tools.custom_data.schema_tools import (
@@ -73,7 +73,7 @@ class CustomDataManager:
 
     Args:
         config_file: Path to the config json file. If not provided, a new config object will be created.
-        mcf_files: Path to one or more MCF files. If not provided, a new MCFNodes object will be created.
+        mcf_files: Path to one or more MCF files. If not provided, a new Nodes object will be created.
 
     Usage:
 
@@ -195,7 +195,7 @@ class CustomDataManager:
         Initialize the CustomDataManager object
         Args:
             config_file: Path to the config json file. If not provided, a new config object will be created.
-            mcf_files: Path to one or more MCF files. If not provided, a new MCFNodes object will be created.
+            mcf_files: Path to one or more MCF files. If not provided, a new Nodes object will be created.
         """
 
         self._config = (
@@ -209,14 +209,11 @@ class CustomDataManager:
             else:
                 paths = [Path(p) for p in mcf_files]
 
-            self._mcf_nodes: dict[str, MCFNodes] = {
-                path.name: MCFNodes().load_from_mcf_file(file_path=path)
-                for path in paths
+            self._mcf_nodes: dict[str, Nodes] = {
+                path.name: Nodes().load_from_mcf_file(file_path=path) for path in paths
             }
         else:
-            self._mcf_nodes: dict[str, MCFNodes] = {
-                DEFAULT_STATVAR_MCF_NAME: MCFNodes()
-            }
+            self._mcf_nodes: dict[str, Nodes] = {DEFAULT_STATVAR_MCF_NAME: Nodes()}
 
         self._data = {}
         self._vertical_specs: list[VerticalSpec] = []
@@ -443,10 +440,10 @@ class CustomDataManager:
         dcid = mint_dcid(prefix="source", name=name)
         url = str(url)
         props = _parse_kwargs_into_properties(locals(), extra_exclude={"name"})
-        node = SourceMCFNode(**props)
+        node = SourceNode(**props)
 
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
 
         return self
 
@@ -517,10 +514,10 @@ class CustomDataManager:
         props = _parse_kwargs_into_properties(
             locals(), extra_exclude={"name", "source"}
         )
-        node = ProvenanceMCFNode(**props)
+        node = ProvenanceNode(**props)
 
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
 
         return self
 
@@ -585,10 +582,10 @@ class CustomDataManager:
             measurementDenominator = ensure_dcid(measurementDenominator)
 
         props = _parse_kwargs_into_properties(locals())
-        node = StatVarMCFNode(**props)
+        node = StatVarNode(**props)
 
         name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(name, Nodes()).add(node, override=override)
 
         return self
 
@@ -628,10 +625,10 @@ class CustomDataManager:
         """
         props = _parse_kwargs_into_properties(locals())
 
-        node = StatVarGroupMCFNode(**props)
+        node = StatVarGroupNode(**props)
 
         name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(name, Nodes()).add(node, override=override)
         return self
 
     def add_entity_type(
@@ -680,9 +677,9 @@ class CustomDataManager:
         if includedIn is not None:
             includedIn = self._expand_included_in(includedIn)
         props = _parse_kwargs_into_properties(locals())
-        node = EntityTypeMCFNode(**props)
+        node = EntityTypeNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
         return self
 
     def add_event_type(
@@ -735,9 +732,9 @@ class CustomDataManager:
         if includedIn is not None:
             includedIn = self._expand_included_in(includedIn)
         props = _parse_kwargs_into_properties(locals())
-        node = EventTypeMCFNode(**props)
+        node = EventTypeNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
         return self
 
     def add_property(
@@ -793,9 +790,9 @@ class CustomDataManager:
         if subPropertyOf is not None:
             subPropertyOf = ensure_dcid(subPropertyOf)
         props = _parse_kwargs_into_properties(locals())
-        node = PropertyMCFNode(**props)
+        node = PropertyNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
         return self
 
     def add_unit(
@@ -841,9 +838,9 @@ class CustomDataManager:
         dcid = ensure_dcid(dcid)
         typeOf = ensure_dcid(typeOf)
         props = _parse_kwargs_into_properties(locals())
-        node = UnitOfMeasureMCFNode(**props)
+        node = UnitOfMeasureNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
         return self
 
     def add_measurement_method(
@@ -888,9 +885,9 @@ class CustomDataManager:
         dcid = ensure_dcid(dcid)
         typeOf = ensure_dcid(typeOf)
         props = _parse_kwargs_into_properties(locals())
-        node = MeasurementMethodMCFNode(**props)
+        node = MeasurementMethodNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
-        self._mcf_nodes.setdefault(mcf_name, MCFNodes()).add(node, override=override)
+        self._mcf_nodes.setdefault(mcf_name, Nodes()).add(node, override=override)
         return self
 
     def add_variables_to_mcf_from_csv(
@@ -906,17 +903,17 @@ class CustomDataManager:
         override: bool = False,
     ) -> CustomDataManager:
         """
-        Read a CSV containing StatVar nodes and parse them into StatVarMCFNode objects.
+        Read a CSV containing StatVar nodes and parse them into StatVarNode objects.
 
         Args:
             csv_file_path: Path to the CSV file.
             mcf_file_name: Name of the MCF file. Defaults to "custom_nodes.mcf".
             column_to_property_mapping: Optional map from CSV column names to
-                ``StatVarMCFNode`` attribute names.
+                ``StatVarNode`` attribute names.
             parse_groups: If True, parse groups into StatVar nodes. That means the `memberOf`
                 attribute of each StatVar node in `stat_vars`, which is expected to be a
                 slash-separated string path describing its group hierarchy
-                (e.g.,"Economic/Employment/Unemployment"), gets transformed into StatVarGroupMCFNode
+                (e.g.,"Economic/Employment/Unemployment"), gets transformed into StatVarGroupNode
                 objects for each group level. This sets up their parent-child relationships,
                 and updates the original memberOf attribute to reference the deepest group DCID.
                 Defaults to False.
@@ -947,7 +944,7 @@ class CustomDataManager:
 
         name = validate_mcf_file_name(mcf_file_name)
         for node in stat_vars.nodes:
-            self._mcf_nodes.setdefault(name, MCFNodes()).add(node, override=override)
+            self._mcf_nodes.setdefault(name, Nodes()).add(node, override=override)
 
         return self
 
@@ -1116,12 +1113,12 @@ class CustomDataManager:
         found_old = any(
             node.dcid == old_name
             for name in file_names
-            for node in (self._mcf_nodes.get(name) or MCFNodes()).nodes
+            for node in (self._mcf_nodes.get(name) or Nodes()).nodes
         )
         found_new = any(
             node.dcid == new_name
             for name in file_names
-            for node in (self._mcf_nodes.get(name) or MCFNodes()).nodes
+            for node in (self._mcf_nodes.get(name) or Nodes()).nodes
         )
 
         if not found_old:
@@ -1184,9 +1181,7 @@ class CustomDataManager:
 
         return self
 
-    def _require_provenance_exists(
-        self, provenance: str, provenance_link: str
-    ) -> MCFNode:
+    def _require_provenance_exists(self, provenance: str, provenance_link: str) -> Node:
         """Return the Provenance MCF node with id ``provenance_link``, or raise ValueError.
 
         Args:
@@ -1603,7 +1598,7 @@ class CustomDataManager:
         Args:
             directory: The directory to search for config files.
             policy: How to resolve collisions. Can be "error", "override", or "ignore".
-            mcf_files: Path to one or more MCF files. If not provided, a new MCFNodes object
+            mcf_files: Path to one or more MCF files. If not provided, a new Nodes object
                 will be created.
 
         Returns:

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -96,7 +96,7 @@ class CustomDataManager:
     To add a variable for export to an MCF file, use the add_variable_to_mcf method.
     ``Node`` accepts a bare or ``dcid:``-prefixed token, as the schema-node builders below do:
     >>> dc_manager.add_variable_to_mcf(
-    >>>    Node="StatVar",
+    >>>    dcid="StatVar",
     >>>    name="Variable Name",
     >>>    description="Variable Description",
     >>>    ...
@@ -108,16 +108,16 @@ class CustomDataManager:
     measurement methods), use the five typed builders. All five accept bare or
     ``dcid:``-prefixed ``Node`` tokens. Note: ``add_measurement_method`` is the only
     builder where ``name`` is optional — only ``Node`` is required.
-    >>> dc_manager.add_entity_type(Node="MyClass", name="My Class")
-    >>> dc_manager.add_event_type(Node="MyEvent", name="My Event")
+    >>> dc_manager.add_entity_type(dcid="MyClass", name="My Class")
+    >>> dc_manager.add_event_type(dcid="MyEvent", name="My Event")
     >>> dc_manager.add_property(
-    >>>     Node="myProp",
+    >>>     dcid="myProp",
     >>>     name="My Property",
     >>>     domainIncludes="Person",
     >>>     rangeIncludes="Number",
     >>> )
-    >>> dc_manager.add_unit(Node="USD", name="US Dollar", shortDisplayName="$")
-    >>> dc_manager.add_measurement_method(Node="MyCensus")
+    >>> dc_manager.add_unit(dcid="USD", name="US Dollar", shortDisplayName="$")
+    >>> dc_manager.add_measurement_method(dcid="MyCensus")
 
     You can also add variables for export to an MCF file using a CSV file. The CSV file should
     contain the variables you want to add.
@@ -146,7 +146,7 @@ class CustomDataManager:
     >>>    },
     >>> )
     >>> dc_manager.add_variable_to_mcf(
-    >>>    Node="dcid:var/StatVar",
+    >>>    dcid="dcid:var/StatVar",
     >>>    name="Variable Name",
     >>>    observationProperties=["dcid:originCountry", "dcid:destinationCountry"],
     >>> )
@@ -440,7 +440,7 @@ class CustomDataManager:
                 already exists and ``override`` is False, or if the file name is invalid.
         """
 
-        Node = mint_dcid(prefix="source", name=name)
+        dcid = mint_dcid(prefix="source", name=name)
         url = str(url)
         props = _parse_kwargs_into_properties(locals(), extra_exclude={"name"})
         node = SourceMCFNode(**props)
@@ -510,7 +510,7 @@ class CustomDataManager:
                 ``override`` is False, or if the file name is invalid.
         """
 
-        Node = mint_dcid(prefix="provenance", name=name)
+        dcid = mint_dcid(prefix="provenance", name=name)
         url = str(url)
         sourceLink = mint_dcid(prefix="source", name=source)
         self._require_source_exists(source, sourceLink)
@@ -527,7 +527,7 @@ class CustomDataManager:
     def add_variable_to_mcf(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str,
         memberOf: list[str] | str | None = None,
         statType: str | StatType | None = None,
@@ -547,7 +547,7 @@ class CustomDataManager:
         """Add a StatVar node for the MCF file
 
         Args:
-            Node: The identifier of the statistical variable. A bare token is
+            dcid: The identifier of the statistical variable. A bare token is
                 normalized to ``dcid:<token>`` and an already ``dcid:``-prefixed token
                 is kept as-is; either way whitespace raises ``ValueError``. The same
                 applies to ``populationType``, ``measuredProperty``,
@@ -574,7 +574,7 @@ class CustomDataManager:
             CustomDataManager object
         """
 
-        Node = ensure_dcid(Node)
+        dcid = ensure_dcid(dcid)
         if populationType is not None:
             populationType = ensure_dcid(populationType)
         if measuredProperty is not None:
@@ -595,7 +595,7 @@ class CustomDataManager:
     def add_variable_group_to_mcf(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str,
         specializationOf: str,
         description: str | None = None,
@@ -608,7 +608,7 @@ class CustomDataManager:
         """Add a StatVarGroup node for the MCF file
 
         Args:
-            Node: DCID of the group you are defining. It must be prefixed by g/ and may include
+            dcid: DCID of the group you are defining. It must be prefixed by g/ and may include
                 an additional prefix before the g.
             name: This is the name of the heading that will appear in the Statistical Variable Explorer.
             specializationOf: Specialization of the variable group. For a top-level group,
@@ -637,7 +637,7 @@ class CustomDataManager:
     def add_entity_type(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str,
         description: str | None = None,
         includedIn: str | list[str] | None = None,
@@ -650,7 +650,7 @@ class CustomDataManager:
         Emits a ``dcid:Class`` node to the MCF collection (default: ``custom_nodes.mcf``).
 
         Args:
-            Node: Identifier token for the Class. Bare tokens are normalized to
+            dcid: Identifier token for the Class. Bare tokens are normalized to
                 ``dcid:<token>`` (e.g. ``"MyClass"`` → ``"dcid:MyClass"``); already
                 ``dcid:``-prefixed values are passed through verbatim. Names must be
                 valid dcid tokens (no whitespace).
@@ -676,7 +676,7 @@ class CustomDataManager:
                 exists and ``override`` is False, if the file name is invalid, or if any
                 provenance referenced by ``includedIn`` has not been registered.
         """
-        Node = ensure_dcid(Node)
+        dcid = ensure_dcid(dcid)
         if includedIn is not None:
             includedIn = self._expand_included_in(includedIn)
         props = _parse_kwargs_into_properties(locals())
@@ -688,7 +688,7 @@ class CustomDataManager:
     def add_event_type(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str,
         description: str | None = None,
         subClassOf: str = "dcid:Event",
@@ -703,7 +703,7 @@ class CustomDataManager:
         (default: ``custom_nodes.mcf``).
 
         Args:
-            Node: Identifier token for the event type. Bare tokens are normalized to
+            dcid: Identifier token for the event type. Bare tokens are normalized to
                 ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Human-readable name for the event type.
@@ -730,7 +730,7 @@ class CustomDataManager:
                 exists and ``override`` is False, if the file name is invalid, or if any
                 provenance referenced by ``includedIn`` has not been registered.
         """
-        Node = ensure_dcid(Node)
+        dcid = ensure_dcid(dcid)
         subClassOf = ensure_dcid(subClassOf)
         if includedIn is not None:
             includedIn = self._expand_included_in(includedIn)
@@ -743,7 +743,7 @@ class CustomDataManager:
     def add_property(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str,
         domainIncludes: str | list[str] | None = None,
         rangeIncludes: str | list[str] | None = None,
@@ -758,7 +758,7 @@ class CustomDataManager:
         Emits a ``dcid:Property`` node to the MCF collection (default: ``custom_nodes.mcf``).
 
         Args:
-            Node: Identifier token for the property. Bare tokens are normalized to
+            dcid: Identifier token for the property. Bare tokens are normalized to
                 ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Human-readable name for the property.
@@ -785,7 +785,7 @@ class CustomDataManager:
             ValueError: If Node contains whitespace, if a node with the same id already
                 exists and ``override`` is False, or if the file name is invalid.
         """
-        Node = ensure_dcid(Node)
+        dcid = ensure_dcid(dcid)
         if domainIncludes is not None:
             domainIncludes = ensure_dcid(domainIncludes)
         if rangeIncludes is not None:
@@ -801,7 +801,7 @@ class CustomDataManager:
     def add_unit(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str,
         shortDisplayName: str | None = None,
         description: str | None = None,
@@ -816,7 +816,7 @@ class CustomDataManager:
         collection (default: ``custom_nodes.mcf``).
 
         Args:
-            Node: Identifier token for the unit. Bare tokens are normalized to
+            dcid: Identifier token for the unit. Bare tokens are normalized to
                 ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Human-readable name for the unit.
@@ -838,7 +838,7 @@ class CustomDataManager:
             ValueError: If Node contains whitespace, if a node with the same id already
                 exists and ``override`` is False, or if the file name is invalid.
         """
-        Node = ensure_dcid(Node)
+        dcid = ensure_dcid(dcid)
         typeOf = ensure_dcid(typeOf)
         props = _parse_kwargs_into_properties(locals())
         node = UnitOfMeasureMCFNode(**props)
@@ -849,7 +849,7 @@ class CustomDataManager:
     def add_measurement_method(
         self,
         *,
-        Node: str,
+        dcid: str,
         name: str | None = None,
         description: str | None = None,
         typeOf: str = "dcid:MeasurementMethodEnum",
@@ -864,7 +864,7 @@ class CustomDataManager:
         ``name`` is optional here — only ``Node`` is required.
 
         Args:
-            Node: Identifier token for the measurement method. Bare tokens are normalized
+            dcid: Identifier token for the measurement method. Bare tokens are normalized
                 to ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Optional human-readable name. (Optional)
@@ -885,7 +885,7 @@ class CustomDataManager:
             ValueError: If Node contains whitespace, if a node with the same id already
                 exists and ``override`` is False, or if the file name is invalid.
         """
-        Node = ensure_dcid(Node)
+        dcid = ensure_dcid(dcid)
         typeOf = ensure_dcid(typeOf)
         props = _parse_kwargs_into_properties(locals())
         node = MeasurementMethodMCFNode(**props)
@@ -1114,12 +1114,12 @@ class CustomDataManager:
         )
 
         found_old = any(
-            node.Node == old_name
+            node.dcid == old_name
             for name in file_names
             for node in (self._mcf_nodes.get(name) or MCFNodes()).nodes
         )
         found_new = any(
-            node.Node == new_name
+            node.dcid == new_name
             for name in file_names
             for node in (self._mcf_nodes.get(name) or MCFNodes()).nodes
         )
@@ -1133,7 +1133,7 @@ class CustomDataManager:
             nodes = self._mcf_nodes.get(name)
             if not nodes:
                 continue
-            if any(node.Node == old_name for node in nodes.nodes):
+            if any(node.dcid == old_name for node in nodes.nodes):
                 nodes.rename(old_name, new_name)
 
         return self
@@ -1197,7 +1197,7 @@ class CustomDataManager:
             for n in nodes.nodes:
                 if (
                     getattr(n, "typeOf", None) == "dcid:Provenance"
-                    and n.Node == provenance_link
+                    and n.dcid == provenance_link
                 ):
                     return n
         raise ValueError(
@@ -1245,7 +1245,7 @@ class CustomDataManager:
             source_link: The minted dcid for the source (used for the lookup).
         """
         if not any(
-            getattr(n, "typeOf", None) == "dcid:Source" and n.Node == source_link
+            getattr(n, "typeOf", None) == "dcid:Source" and n.dcid == source_link
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
         ):
@@ -1261,7 +1261,7 @@ class CustomDataManager:
         ``inputFiles`` entry with a ``provenance`` ref has a corresponding node.
         """
         known = {
-            n.Node
+            n.dcid
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
             if getattr(n, "typeOf", None) == "dcid:Provenance"
@@ -1294,10 +1294,10 @@ class CustomDataManager:
             for n in nodes.nodes:
                 node_type = getattr(n, "typeOf", None)
                 if node_type == "dcid:Provenance":
-                    prov_file[n.Node] = fname
-                    prov_source[n.Node] = getattr(n, "sourceLink", None)
+                    prov_file[n.dcid] = fname
+                    prov_source[n.dcid] = getattr(n, "sourceLink", None)
                 elif node_type == "dcid:Source":
-                    source_file[n.Node] = fname
+                    source_file[n.dcid] = fname
 
         missing: dict[str, str] = {}
         for entry in self._config.inputFiles:

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -15,7 +15,7 @@ from dcp_tools.custom_data.models.common import (
 )
 
 
-class MCFNode(BaseModel):
+class Node(BaseModel):
     """Represents a Data Commons graph node.
 
     Attributes:
@@ -37,9 +37,9 @@ class MCFNode(BaseModel):
     shortDisplayName: QuotedStr | None = None
     subClassOf: StrOrListStr | None = None
 
-    # Allow extra fields since MCF can have arbitrary properties and this
-    # class is not comprehensive of all possible MCF properties. Assignments are
-    # validated too, so patterns like Dcid/GroupDcid are enforced on `MCFNodes.rename`
+    # Allow extra fields since nodes can have arbitrary properties and this
+    # class is not comprehensive of all possible node properties. Assignments are
+    # validated too, so patterns like Dcid/GroupDcid are enforced on `Nodes.rename`
     # (which assigns `.dcid`), not just on construction.
     model_config = ConfigDict(extra="allow", validate_assignment=True)
 
@@ -86,7 +86,7 @@ class MCFNode(BaseModel):
         but its cleaned output is applied only to the *other*, already-set fields and
         is discarded for the field actually being assigned. Cleaning here instead
         covers both declared fields and the `extra="allow"` keys that carry arbitrary
-        MCF properties, neither of which a wildcard field validator would reach in
+        node properties, neither of which a wildcard field validator would reach in
         full.
         """
         super().__setattr__(name, self._clean_value(value))
@@ -107,14 +107,14 @@ class MCFNode(BaseModel):
         return "\n".join(lines) + "\n\n"
 
 
-class MCFNodes(BaseModel):
+class Nodes(BaseModel):
     """Represents a collection of Nodes.
 
     Attributes:
         nodes: A list of Node instances.
     """
 
-    nodes: list[MCFNode] = Field(default_factory=list)
+    nodes: list[Node] = Field(default_factory=list)
     _pos: dict[str, int] = PrivateAttr(default_factory=dict)
 
     def _reindex(self) -> None:
@@ -132,7 +132,7 @@ class MCFNodes(BaseModel):
             raise ValueError(f"Node '{node_id}' not found.") from None
 
     def _flush(self, block: dict[str, str]) -> None:
-        """Convert the current block into an `MCFNode` and store it."""
+        """Convert the current block into a `Node` and store it."""
         if not block:
             return
         if "Node" not in block:
@@ -141,10 +141,10 @@ class MCFNodes(BaseModel):
                 f"{next(iter(block.items()))!r}"
             )
         block["dcid"] = block.pop("Node")
-        self.add(MCFNode(**block))
+        self.add(Node(**block))
         block.clear()
 
-    def load_from_mcf_file(self, file_path: str | PathLike) -> MCFNodes:
+    def load_from_mcf_file(self, file_path: str | PathLike) -> Nodes:
         """Parses MCF nodes from a file and populates the collection.
 
         Each node block is expected to start with
@@ -180,11 +180,11 @@ class MCFNodes(BaseModel):
 
         return self
 
-    def add(self, node: MCFNode, override: bool = False) -> MCFNodes:
+    def add(self, node: Node, override: bool = False) -> Nodes:
         """Adds a new node to the collection.
 
         Args:
-            node: The MCFNode instance to add.
+            node: The Node instance to add.
             override: If True, overwrite the existing node with the same ID.
                 If False, raise an error if a node with the same ID already exists.
         """
@@ -202,7 +202,7 @@ class MCFNodes(BaseModel):
 
         return self
 
-    def remove(self, node_id: str) -> MCFNodes:
+    def remove(self, node_id: str) -> Nodes:
         """Removes a node from the collection by its ID.
 
         Args:
@@ -219,7 +219,7 @@ class MCFNodes(BaseModel):
 
         return self
 
-    def rename(self, old_id: str, new_id: str) -> MCFNodes:
+    def rename(self, old_id: str, new_id: str) -> Nodes:
         """Renames a node in place, keeping the lookup index consistent.
 
         Args:
@@ -241,7 +241,7 @@ class MCFNodes(BaseModel):
 
     def export_to_mcf_file(
         self, file_path: str | PathLike, *, override: bool = True
-    ) -> MCFNodes:
+    ) -> Nodes:
         """Exports the MCF nodes to a file.
 
         Args:

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -16,24 +16,22 @@ from dcp_tools.custom_data.models.common import (
 
 
 class MCFNode(BaseModel):
-    """Represents a general node for MCF.
+    """Represents a Data Commons graph node.
 
     Attributes:
-        Node: Identifier for the Node.
+        dcid: Unique identifier for the Node.
         name: The human-readable name for the Node.
         typeOf: The DCID representing the typeOf this Node. It can be a single DCID
             or a list of DCIDs if the Node belongs to multiple types.
-        dcid: Optional DCID for uniquely identifying the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.
         shortDisplayName: Optional human-readable short name for display.
         subClassOf: Optional DCID indicating the 'parent' Node class.
     """
 
-    Node: Dcid
+    dcid: Dcid
     name: QuotedStr | None = None
     typeOf: DcidOrListDcid
-    dcid: Dcid | None = None
     description: QuotedStr | None = None
     provenance: QuotedStr | None = None
     shortDisplayName: QuotedStr | None = None
@@ -42,7 +40,7 @@ class MCFNode(BaseModel):
     # Allow extra fields since MCF can have arbitrary properties and this
     # class is not comprehensive of all possible MCF properties. Assignments are
     # validated too, so patterns like Dcid/GroupDcid are enforced on `MCFNodes.rename`
-    # (which assigns `.Node`), not just on construction.
+    # (which assigns `.dcid`), not just on construction.
     model_config = ConfigDict(extra="allow", validate_assignment=True)
 
     @staticmethod
@@ -98,13 +96,12 @@ class MCFNode(BaseModel):
         """Generates an MCF-formatted string representing this node.
 
         Returns:
-            A string formatted according to MCF conventions, sorted alphabetically
-                except for 'Node', which appears first.
+            A string formatted according to MCF conventions.
         """
         data = self.model_dump(exclude_none=True)
 
-        # Pull Node first, then sort for consistent ordering
-        lines = [f"Node: {data.pop('Node')}"]
+        # Pull dcid first
+        lines = [f"Node: {data.pop('dcid')}"]
         lines.extend(f"{k}: {v}" for k, v in data.items())
 
         return "\n".join(lines) + "\n\n"
@@ -122,7 +119,7 @@ class MCFNodes(BaseModel):
 
     def _reindex(self) -> None:
         """If needed, rebuild the index of nodes."""
-        self._pos = {n.Node: i for i, n in enumerate(self.nodes)}
+        self._pos = {n.dcid: i for i, n in enumerate(self.nodes)}
 
     def model_post_init(self, context: Any, /) -> None:
         self._reindex()
@@ -143,6 +140,7 @@ class MCFNodes(BaseModel):
                 f"Missing mandatory 'Node:' line in block starting with "
                 f"{next(iter(block.items()))!r}"
             )
+        block["dcid"] = block.pop("Node")
         self.add(MCFNode(**block))
         block.clear()
 
@@ -190,16 +188,16 @@ class MCFNodes(BaseModel):
             override: If True, overwrite the existing node with the same ID.
                 If False, raise an error if a node with the same ID already exists.
         """
-        idx = self._pos.get(node.Node)
+        idx = self._pos.get(node.dcid)
 
         if idx is not None:
             if not override:
                 raise ValueError(
-                    f"Node '{node.Node}' already exists; pass override=True to replace it."
+                    f"Node '{node.dcid}' already exists; pass override=True to replace it."
                 )
             self.nodes[idx] = node
         else:
-            self._pos[node.Node] = len(self.nodes)
+            self._pos[node.dcid] = len(self.nodes)
             self.nodes.append(node)
 
         return self
@@ -235,7 +233,7 @@ class MCFNodes(BaseModel):
         if new_id in self._pos:
             raise ValueError(f"Node '{new_id}' already exists.")
 
-        self.nodes[idx].Node = new_id
+        self.nodes[idx].dcid = new_id
         self._pos.pop(old_id)
         self._pos[new_id] = idx
 

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -91,8 +91,7 @@ class Node(BaseModel):
         """
         super().__setattr__(name, self._clean_value(value))
 
-    @property
-    def mcf(self) -> str:
+    def to_mcf(self) -> str:
         """Generates an MCF-formatted string representing this node.
 
         Returns:
@@ -252,6 +251,6 @@ class Nodes(BaseModel):
 
         with open(file_path, mode) as f:
             for node in self.nodes:
-                f.write(node.mcf)
+                f.write(node.to_mcf())
 
         return self

--- a/src/dcp_tools/custom_data/models/schema_nodes.py
+++ b/src/dcp_tools/custom_data/models/schema_nodes.py
@@ -12,7 +12,7 @@ class EntityTypeMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (e.g. ``dcid:MyClass``).
+        dcid: Identifier for the Node (e.g. ``dcid:MyClass``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
 
@@ -33,7 +33,7 @@ class EventTypeMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (e.g. ``dcid:MyEventType``).
+        dcid: Identifier for the Node (e.g. ``dcid:MyEventType``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
 
@@ -56,7 +56,7 @@ class PropertyMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (e.g. ``dcid:myProperty``).
+        dcid: Identifier for the Node (e.g. ``dcid:myProperty``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
 
@@ -82,7 +82,7 @@ class UnitOfMeasureMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (e.g. ``dcid:MyUnit``).
+        dcid: Identifier for the Node (e.g. ``dcid:MyUnit``).
         name: The human-readable name for the Node.
         shortDisplayName: Optional short display name (e.g. ``"$"``).
         description: Optional human-readable description.
@@ -102,7 +102,7 @@ class MeasurementMethodMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (e.g. ``dcid:MyMethod``).
+        dcid: Identifier for the Node (e.g. ``dcid:MyMethod``).
         name: Optional human-readable name for the Node.
         description: Optional human-readable description.
 

--- a/src/dcp_tools/custom_data/models/schema_nodes.py
+++ b/src/dcp_tools/custom_data/models/schema_nodes.py
@@ -1,17 +1,17 @@
 from typing import Literal
 
 from dcp_tools.custom_data.models.common import DcidOrListDcid
-from dcp_tools.custom_data.models.mcf import MCFNode
+from dcp_tools.custom_data.models.mcf import Node
 
 
-class EntityTypeMCFNode(MCFNode):
-    """Represents a custom entity-type (Class) node for MCF.
+class EntityTypeNode(Node):
+    """Represents a Data Commons entity-type (Class) node.
 
     typeOf is fixed to ``dcid:Class``. ``includedIn`` references the provenance(s) — and,
     via the builder, their linked source(s) — the type is defined in.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (e.g. ``dcid:MyClass``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
@@ -25,14 +25,14 @@ class EntityTypeMCFNode(MCFNode):
     includedIn: DcidOrListDcid | None = None
 
 
-class EventTypeMCFNode(MCFNode):
-    """Represents a custom event-type node for MCF.
+class EventTypeNode(Node):
+    """Represents a Data Commons event-type node.
 
     typeOf is fixed to ``dcid:Class``; ``subClassOf`` defaults to ``dcid:Event`` and is
     overridable. ``includedIn`` mirrors EntityType.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (e.g. ``dcid:MyEventType``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
@@ -48,14 +48,14 @@ class EventTypeMCFNode(MCFNode):
     includedIn: DcidOrListDcid | None = None
 
 
-class PropertyMCFNode(MCFNode):
-    """Represents a custom Property node for MCF.
+class PropertyNode(Node):
+    """Represents a Data Commons Property node.
 
     typeOf is fixed to ``dcid:Property``. Optional schema refs describe the property's
     domain, range, and parent property.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (e.g. ``dcid:myProperty``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
@@ -73,15 +73,15 @@ class PropertyMCFNode(MCFNode):
     subPropertyOf: DcidOrListDcid | None = None
 
 
-class UnitOfMeasureMCFNode(MCFNode):
-    """Represents a custom unit-of-measure node for MCF.
+class UnitOfMeasureNode(Node):
+    """Represents a Data Commons UnitOfMeasure node.
 
     typeOf defaults to ``dcid:UnitOfMeasure`` and is overridable (e.g.
     ``dcid:CurrencyUnitOfMeasure``). ``name``/``shortDisplayName``/``description`` are
-    inherited from MCFNode.
+    inherited from Node.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (e.g. ``dcid:MyUnit``).
         name: The human-readable name for the Node.
         shortDisplayName: Optional short display name (e.g. ``"$"``).
@@ -94,14 +94,14 @@ class UnitOfMeasureMCFNode(MCFNode):
     typeOf: DcidOrListDcid = "dcid:UnitOfMeasure"
 
 
-class MeasurementMethodMCFNode(MCFNode):
-    """Represents a custom measurement-method node for MCF.
+class MeasurementMethodNode(Node):
+    """Represents a Data Commons MeasurementMethod node.
 
     typeOf defaults to ``dcid:MeasurementMethodEnum`` and is overridable (e.g.
     ``dcid:CensusSurveyEnum``). ``name`` is optional (inherited).
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (e.g. ``dcid:MyMethod``).
         name: Optional human-readable name for the Node.
         description: Optional human-readable description.

--- a/src/dcp_tools/custom_data/models/sources.py
+++ b/src/dcp_tools/custom_data/models/sources.py
@@ -1,14 +1,14 @@
 from typing import Literal
 
 from dcp_tools.custom_data.models.common import Dcid, QuotedStr
-from dcp_tools.custom_data.models.mcf import MCFNode
+from dcp_tools.custom_data.models.mcf import Node
 
 
-class SourceMCFNode(MCFNode):
-    """Represents a Source node for MCF.
+class SourceNode(Node):
+    """Represents a Data Commons Source node.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (minted as ``dcid:source/<name>``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
@@ -26,11 +26,11 @@ class SourceMCFNode(MCFNode):
     isPartOf: Dcid | None = None
 
 
-class ProvenanceMCFNode(MCFNode):
-    """Represents a Provenance node for MCF.
+class ProvenanceNode(Node):
+    """Represents a Data Commons Provenance node.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node (minted as ``dcid:provenance/<name>``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.

--- a/src/dcp_tools/custom_data/models/sources.py
+++ b/src/dcp_tools/custom_data/models/sources.py
@@ -9,7 +9,7 @@ class SourceMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (minted as ``dcid:source/<name>``).
+        dcid: Identifier for the Node (minted as ``dcid:source/<name>``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
 
@@ -31,7 +31,7 @@ class ProvenanceMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node (minted as ``dcid:provenance/<name>``).
+        dcid: Identifier for the Node (minted as ``dcid:provenance/<name>``).
         name: The human-readable name for the Node.
         description: Optional human-readable description.
 

--- a/src/dcp_tools/custom_data/models/stat_vars.py
+++ b/src/dcp_tools/custom_data/models/stat_vars.py
@@ -31,9 +31,8 @@ class StatVarMCFNode(MCFNode):
 
     Attributes:
         # Inherited from MCFNode
-        Node: Identifier for the Node.
+        dcid: Identifier for the Node.
         name: The human-readable name for the Node.
-        dcid: Optional DCID for uniquely identifying the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.
         shortDisplayName: Optional human-readable short name for display.
@@ -71,7 +70,7 @@ class StatVarGroupMCFNode(MCFNode):
 
     Attributes:
         # Additional Attributes specific to StatVarGroup
-        Node: Node identifier, must contain '/g'.
+        dcid: Node identifier, must contain '/g'.
         typeOf: Fixed type indicating this is a StatVarGroup.
         specializationOf: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
 
@@ -84,7 +83,7 @@ class StatVarGroupMCFNode(MCFNode):
         subClassOf: Optional DCID indicating the 'parent' Node class.
     """
 
-    Node: GroupDcid
+    dcid: GroupDcid
     typeOf: Literal["dcid:StatVarGroup"] = "dcid:StatVarGroup"
     specializationOf: GroupDcid
 
@@ -95,19 +94,18 @@ class StatVarPeerGroupMCFNode(MCFNode):
 
     Attributes:
         # Additional Attributes specific to StatVarPeerGroup
-        Node: Node identifier, must contain '/svpg'.
+        dcid: Node identifier, must contain '/svpg'.
         typeOf: Fixed type indicating this is a StatVarPeerGroup.
         member: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
 
          # Inherits from MCFNode
         name: The human-readable name for the Node.
-        dcid: Optional DCID for uniquely identifying the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.
         shortDisplayName: Optional human-readable short name for display.
         subClassOf: Optional DCID indicating the 'parent' Node class.
     """
 
-    Node: PeerGroupDcid
+    dcid: PeerGroupDcid
     typeOf: Literal["dcid:StatVarPeerGroup"] = "dcid:StatVarPeerGroup"
     member: DcidOrListDcid

--- a/src/dcp_tools/custom_data/models/stat_vars.py
+++ b/src/dcp_tools/custom_data/models/stat_vars.py
@@ -9,7 +9,7 @@ from dcp_tools.custom_data.models.common import (
     PeerGroupDcid,
     QuotedStrListOrStr,
 )
-from dcp_tools.custom_data.models.mcf import MCFNode
+from dcp_tools.custom_data.models.mcf import Node
 
 
 class StatType(StrEnum):
@@ -26,11 +26,11 @@ class StatType(StrEnum):
     STANDARD_ERROR = "dcid:stdErr"
 
 
-class StatVarMCFNode(MCFNode):
+class StatVarNode(Node):
     """Represents a Statistical Variable node in MCF.
 
     Attributes:
-        # Inherited from MCFNode
+        # Inherited from Node
         dcid: Identifier for the Node.
         name: The human-readable name for the Node.
         description: Optional human-readable description.
@@ -65,7 +65,7 @@ class StatVarMCFNode(MCFNode):
     observationProperties: DcidOrListDcid | None = None
 
 
-class StatVarGroupMCFNode(MCFNode):
+class StatVarGroupNode(Node):
     """Represents a Statistical Variable Group node in MCF.
 
     Attributes:
@@ -74,7 +74,7 @@ class StatVarGroupMCFNode(MCFNode):
         typeOf: Fixed type indicating this is a StatVarGroup.
         specializationOf: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
 
-         # Inherits from MCFNode
+         # Inherits from Node
         name: The human-readable name for the Node.
         dcid: Optional DCID for uniquely identifying the Node.
         description: Optional human-readable description.
@@ -88,7 +88,7 @@ class StatVarGroupMCFNode(MCFNode):
     specializationOf: GroupDcid
 
 
-class StatVarPeerGroupMCFNode(MCFNode):
+class StatVarPeerGroupNode(Node):
     """Represents a Statistical Variable Peer Group node in MCF.
     A StatVarPeerGroup represents a group of StatisticalVariable nodes that are comparable peers.
 
@@ -98,7 +98,7 @@ class StatVarPeerGroupMCFNode(MCFNode):
         typeOf: Fixed type indicating this is a StatVarPeerGroup.
         member: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
 
-         # Inherits from MCFNode
+         # Inherits from Node
         name: The human-readable name for the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.

--- a/src/dcp_tools/custom_data/models/topics.py
+++ b/src/dcp_tools/custom_data/models/topics.py
@@ -1,11 +1,11 @@
 from typing import Literal
 
 from dcp_tools.custom_data.models.common import DcidOrListDcid, TopicDcid
-from dcp_tools.custom_data.models.mcf import MCFNode
+from dcp_tools.custom_data.models.mcf import Node
 
 
-class TopicMCFNode(MCFNode):
-    """Represents a Topic node as MCF Nodes.
+class TopicNode(Node):
+    """Represents a Data Commons Topic node.
     A Topic represents a broad topic in the real-world such as economy, poverty,
     crime, etc. Typically used to associated variables (StatisticalVariable)
     related to a common concept.
@@ -19,7 +19,7 @@ class TopicMCFNode(MCFNode):
             (``.../topic/...``) dcids: both are already valid ``dcid:\\S+`` tokens,
             so DcidOrListDcid covers them without a separate union member.
 
-        Inherits from MCFNode:
+        Inherits from Node:
             name: The human-readable name for the Node.
             dcid: Optional DCID for uniquely identifying the Node.
             description: Optional human-readable description.

--- a/src/dcp_tools/custom_data/models/topics.py
+++ b/src/dcp_tools/custom_data/models/topics.py
@@ -11,7 +11,7 @@ class TopicMCFNode(MCFNode):
     related to a common concept.
 
     Attributes:
-        Node: Node identifier, must start with 'dcid:' and contain 'topic/'.
+        dcid: Node identifier, must start with 'dcid:' and contain 'topic/'.
         typeOf: Fixed type indicating this is a Topic.
         relevantVariable: Variable or list of variables relevant to a topic.
             Contains a list of ordered values. Must start with 'dcid:'. Accepts
@@ -28,6 +28,6 @@ class TopicMCFNode(MCFNode):
             subClassOf: Optional DCID indicating the 'parent' Node class.
     """
 
-    Node: TopicDcid
+    dcid: TopicDcid
     typeOf: Literal["dcid:Topic"] = "dcid:Topic"
     relevantVariable: DcidOrListDcid

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -11,13 +11,13 @@ from typing import Any
 import pandas as pd
 
 from dcp_tools.custom_data.models.data_files import MCFFileName
-from dcp_tools.custom_data.models.mcf import MCFNode, MCFNodes
+from dcp_tools.custom_data.models.mcf import Node, Nodes
 from dcp_tools.custom_data.models.stat_vars import (
-    StatVarGroupMCFNode,
-    StatVarMCFNode,
-    StatVarPeerGroupMCFNode,
+    StatVarGroupNode,
+    StatVarNode,
+    StatVarPeerGroupNode,
 )
-from dcp_tools.custom_data.models.topics import TopicMCFNode
+from dcp_tools.custom_data.models.topics import TopicNode
 
 
 class NodeTypes(StrEnum):
@@ -48,7 +48,7 @@ def _parse_maybe_list(s: str | Any) -> str | list[str]:
 
 def _rows_to_stat_var_nodes(
     data: pd.DataFrame, node_type: str | NodeTypes = "StatVar"
-) -> MCFNodes[StatVarMCFNode]:
+) -> Nodes[StatVarNode]:
     """Convert a DataFrame into a collection of Node objects (of the type selected).
 
     Empty/NA values are removed from each row before constructing the node.
@@ -70,11 +70,11 @@ def _rows_to_stat_var_nodes(
     nodes = []
 
     constructor = {
-        "Node": MCFNode,
-        "StatVar": StatVarMCFNode,
-        "StatVarGroup": StatVarGroupMCFNode,
-        "Topic": TopicMCFNode,
-        "StatVarPeerGroup": StatVarPeerGroupMCFNode,
+        "Node": Node,
+        "StatVar": StatVarNode,
+        "StatVarGroup": StatVarGroupNode,
+        "Topic": TopicNode,
+        "StatVarPeerGroup": StatVarPeerGroupNode,
     }
 
     for record in records:
@@ -87,7 +87,7 @@ def _rows_to_stat_var_nodes(
             clean["dcid"] = clean.pop("Node")
         nodes.append(constructor[node_type](**clean))
 
-    return MCFNodes(nodes=nodes)
+    return Nodes(nodes=nodes)
 
 
 def to_camelCase(segment: str) -> str:
@@ -113,11 +113,11 @@ def to_camelCase(segment: str) -> str:
 
 def resolve_group_paths(
     paths: Iterable[str], *, group_namespace: str
-) -> tuple[dict[str, str], list[StatVarGroupMCFNode]]:
+) -> tuple[dict[str, str], list[StatVarGroupNode]]:
     """Resolve slash-separated group path strings into StatVarGroup dcids.
 
     Each path (e.g. "Economic/Employment/Unemployment") is split into segments,
-    each segment is camelCased and minted into a chain of StatVarGroupMCFNode
+    each segment is camelCased and minted into a chain of StatVarGroupNode
     objects rooted at "dcid:dc/g/Root". A segment shared by two paths (a common
     prefix, or the same path repeated) mints only one node.
 
@@ -135,12 +135,12 @@ def resolve_group_paths(
             - A mapping from each input path (as given) to the dcid of its
               deepest group. A path with no non-empty segments once cleaned
               (e.g. "-", "/") is omitted.
-            - The StatVarGroupMCFNode objects for every unique group, in
+            - The StatVarGroupNode objects for every unique group, in
               first-seen order.
     """
 
     resolved: dict[str, str] = {}
-    group_nodes: list[StatVarGroupMCFNode] = []
+    group_nodes: list[StatVarGroupNode] = []
     seen: set[str] = set()
     root = f"dcid:{group_namespace}/g/"
 
@@ -149,11 +149,11 @@ def resolve_group_paths(
             continue
 
         # Strip line breaks and trailing spaces first. Group paths used to reach the
-        # resolver through `StatVarMCFNode(memberOf=...)`, which cleaned them on the
+        # resolver through `StatVarNode(memberOf=...)`, which cleaned them on the
         # way in; resolving before construction skips that. Segments that are only
         # whitespace are dropped too, or `to_camelCase` yields an empty slug and the
         # path mints a group whose dcid ends in a bare "g/".
-        cleaned = MCFNode._clean_value(raw).lstrip("-").strip("/ ")
+        cleaned = Node._clean_value(raw).lstrip("-").strip("/ ")
         parts = [p for p in cleaned.split("/") if p.strip()]
         if not parts:
             continue
@@ -166,7 +166,7 @@ def resolve_group_paths(
                 seen.add(group_dcid)
                 parent = "dcid:dc/g/Root" if idx == 0 else root + slug_parts[idx - 1]
                 group_nodes.append(
-                    StatVarGroupMCFNode(
+                    StatVarGroupNode(
                         dcid=group_dcid, name=part, specializationOf=parent
                     )
                 )
@@ -185,21 +185,21 @@ def csv_metadata_to_nodes(
     ignore_columns: list[str] | None = None,
     parse_groups: bool = False,
     group_namespace: str | None = None,
-) -> MCFNodes[StatVarMCFNode]:
+) -> Nodes[StatVarNode]:
     """Read a CSV of StatVar metadata and return the corresponding MCF StatVar nodes.
 
     Args:
         file_path: Path to the CSV file.
         node_type: The type of node to create. Default is "StatVar".
         column_to_property_mapping: Optional map from CSV column names to
-            ``StatVarMCFNode`` attribute names.
+            ``StatVarNode`` attribute names.
         csv_options: Extra keyword arguments forwarded verbatim to
             ``pandas.read_csv``.
         ignore_columns: Optional list of columns to ignore when reading the CSV.
         parse_groups: If True, the ``memberOf`` column is treated as a
             slash-separated group path (e.g. "Economic/Employment/Unemployment"),
             resolved via ``resolve_group_paths``, and the minted
-            ``StatVarGroupMCFNode`` objects are appended to the returned
+            ``StatVarGroupNode`` objects are appended to the returned
             container. A row whose ``memberOf`` carries no group path, whether
             missing, empty, or cleaning to no segments at all (e.g. "-", "/"), is
             left unset rather than raising. Defaults to False.
@@ -208,8 +208,8 @@ def csv_metadata_to_nodes(
             used if not provided.
 
     Returns:
-        A ``Nodes`` container populated with ``StatVarMCFNode`` objects, followed
-        by any ``StatVarGroupMCFNode`` objects minted from ``memberOf`` paths.
+        A ``Nodes`` container populated with ``StatVarNode`` objects, followed
+        by any ``StatVarGroupNode`` objects minted from ``memberOf`` paths.
 
     Raises:
         ValueError: If ``parse_groups`` is True and the CSV has no ``memberOf``
@@ -231,7 +231,7 @@ def csv_metadata_to_nodes(
         .rename(columns=column_to_property_mapping)
     )
 
-    group_nodes: list[StatVarGroupMCFNode] = []
+    group_nodes: list[StatVarGroupNode] = []
     if parse_groups:
         if "memberOf" not in data.columns:
             raise ValueError(

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -48,7 +48,7 @@ def _parse_maybe_list(s: str | Any) -> str | list[str]:
 
 def _rows_to_stat_var_nodes(
     data: pd.DataFrame, node_type: str | NodeTypes = "StatVar"
-) -> Nodes[StatVarNode]:
+) -> Nodes:
     """Convert a DataFrame into a collection of Node objects (of the type selected).
 
     Empty/NA values are removed from each row before constructing the node.
@@ -185,7 +185,7 @@ def csv_metadata_to_nodes(
     ignore_columns: list[str] | None = None,
     parse_groups: bool = False,
     group_namespace: str | None = None,
-) -> Nodes[StatVarNode]:
+) -> Nodes:
     """Read a CSV of StatVar metadata and return the corresponding MCF StatVar nodes.
 
     Args:

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -83,6 +83,8 @@ def _rows_to_stat_var_nodes(
             for k, v in record.items()
             if not pd.isna(v) and v != ""
         }
+        if "Node" in clean:
+            clean["dcid"] = clean.pop("Node")
         nodes.append(constructor[node_type](**clean))
 
     return MCFNodes(nodes=nodes)
@@ -165,7 +167,7 @@ def resolve_group_paths(
                 parent = "dcid:dc/g/Root" if idx == 0 else root + slug_parts[idx - 1]
                 group_nodes.append(
                     StatVarGroupMCFNode(
-                        Node=group_dcid, name=part, specializationOf=parent
+                        dcid=group_dcid, name=part, specializationOf=parent
                     )
                 )
 

--- a/src/dcp_tools/gcp_utilities/storage.py
+++ b/src/dcp_tools/gcp_utilities/storage.py
@@ -12,7 +12,7 @@ import pandas as pd
 from google.cloud.storage import Bucket
 
 from dcp_tools.custom_data.models.config_file import Config
-from dcp_tools.custom_data.models.mcf import MCFNodes
+from dcp_tools.custom_data.models.mcf import Nodes
 from dcp_tools.logger import logger
 
 _VALID_EXTENSIONS = {".csv", ".json", ".mcf"}
@@ -398,7 +398,7 @@ def get_bucket_files(
             with tempfile.NamedTemporaryFile(suffix=".mcf", delete=False) as tmp:
                 tmp.write(raw)
             try:
-                results[name] = MCFNodes().load_from_mcf_file(tmp.name)
+                results[name] = Nodes().load_from_mcf_file(tmp.name)
             finally:
                 os.unlink(tmp.name)
         else:

--- a/tests/goldens/sample_csv_nodes.mcf
+++ b/tests/goldens/sample_csv_nodes.mcf
@@ -1,13 +1,11 @@
 Node: dcid:foo
 name: "FooVar"
 typeOf: dcid:StatisticalVariable
-dcid: dcid:foo
 description: "A foo var"
 statType: dcid:measuredValue
 
 Node: dcid:bar
 name: "BarVar"
 typeOf: dcid:StatisticalVariable
-dcid: dcid:bar
 statType: dcid:measuredValue
 

--- a/tests/goldens/sample_node.mcf
+++ b/tests/goldens/sample_node.mcf
@@ -1,7 +1,6 @@
 Node: dcid:X/foo
 name: "Some Name"
 typeOf: dcid:StatisticalVariable
-dcid: dcid:foo
 description: "Foo description"
 provenance: "Some foo provenance"
 shortDisplayName: "F"

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -40,8 +40,8 @@ def test_custom_data_manager_add_provenance_and_override():
     prov_node = next(
         n for n in prov_nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
     )
-    assert source_node.Node == "dcid:source/new_source"
-    assert prov_node.Node == "dcid:provenance/pA"
+    assert source_node.dcid == "dcid:source/new_source"
+    assert prov_node.dcid == "dcid:provenance/pA"
     assert prov_node.sourceLink == "dcid:source/new_source"
 
     # duplicate provenance without override raises
@@ -73,7 +73,7 @@ def test_add_source_metadata_lands_on_node():
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
     node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcid:Source")
-    assert node.Node == "dcid:source/MySource"
+    assert node.dcid == "dcid:source/MySource"
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert node.description == "A test source"
     assert node.license == "CC-BY-4.0"
@@ -246,7 +246,7 @@ def test_export_methods(tmp_path):
         data=df,
         columnMappings={"observationAbout": "A"},
     )
-    manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
+    manager.add_variable_to_mcf(dcid="dcid:vX", name="VX")
 
     manager.export_config(tmp_path)
     config_file = tmp_path / "config.json"
@@ -286,7 +286,7 @@ def test_export_mcf_file_creates_missing_subdirectory(tmp_path):
     """export_mcf_file creates the parent directory for a nested mcf_file_name."""
     manager = CustomDataManager()
     manager.add_variable_to_mcf(
-        Node="dcid:vX", name="VX", mcf_file_name="sub/custom_nodes.mcf"
+        dcid="dcid:vX", name="VX", mcf_file_name="sub/custom_nodes.mcf"
     )
 
     manager.export_mcf_file(tmp_path, mcf_file_name="sub/custom_nodes.mcf")
@@ -332,22 +332,22 @@ def test_add_variable_group_to_mcf_and_override():
     """
     manager = CustomDataManager()
     manager.add_variable_group_to_mcf(
-        Node="dcid:test/g/1", name="Group1", specializationOf="dcid:dc/g/Root"
+        dcid="dcid:test/g/1", name="Group1", specializationOf="dcid:dc/g/Root"
     )
     groups = manager._mcf_nodes[DEFAULT_GROUP_NAME].nodes
     assert any(
-        n.Node == "dcid:test/g/1" and n.specializationOf == "dcid:dc/g/Root"
+        n.dcid == "dcid:test/g/1" and n.specializationOf == "dcid:dc/g/Root"
         for n in groups
     )
 
     manager.add_variable_group_to_mcf(
-        Node="dcid:test/g/1",
+        dcid="dcid:test/g/1",
         name="Group2",
         specializationOf="dcid:dc/g/Root",
         override=True,
     )
     updated = manager._mcf_nodes[DEFAULT_GROUP_NAME].nodes
-    assert any(n.name == "Group2" for n in updated if n.Node == "dcid:test/g/1")
+    assert any(n.name == "Group2" for n in updated if n.dcid == "dcid:test/g/1")
 
 
 def test_add_variables_to_mcf_from_csv_parse_groups(tmp_path):
@@ -367,10 +367,10 @@ def test_add_variables_to_mcf_from_csv_parse_groups(tmp_path):
     )
 
     nodes = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes
-    node_ids = [n.Node for n in nodes]
+    node_ids = [n.dcid for n in nodes]
     assert node_ids == ["dcid:n1", "dcid:ns/g/economic", "dcid:ns/g/employment"]
 
-    statvar = next(n for n in nodes if n.Node == "dcid:n1")
+    statvar = next(n for n in nodes if n.dcid == "dcid:n1")
     assert statvar.memberOf == "dcid:ns/g/employment"
 
 
@@ -413,7 +413,7 @@ def test_custom_data_manager_repr():
         data=df,
         columnMappings={"observationAbout": "A"},
     )
-    manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
+    manager.add_variable_to_mcf(dcid="dcid:vX", name="VX")
     r = repr(manager)
     assert "1 inputFiles" in r
     assert "1 containing data" in r
@@ -434,11 +434,11 @@ def test_remove_indicator():
         data=df,
         columnMappings={"observationAbout": "A"},
     )
-    manager.add_variable_to_mcf(Node="dcid:sv1", name="Var", provenance="p1")
+    manager.add_variable_to_mcf(dcid="dcid:sv1", name="Var", provenance="p1")
 
     manager.remove_indicator("dcid:sv1")
     for nodes in manager._mcf_nodes.values():
-        assert all(n.Node != "dcid:sv1" for n in nodes.nodes)
+        assert all(n.dcid != "dcid:sv1" for n in nodes.nodes)
 
     with pytest.raises(ValueError):
         manager.remove_indicator("missing")
@@ -736,20 +736,20 @@ def test_merge_configs_blocklist_override(tmp_path):
 def test_rename_variable_mcf_only():
     """rename_variable operates on MCF nodes exclusively (no config.variables)."""
     manager = CustomDataManager()
-    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+    manager.add_variable_to_mcf(dcid="dcid:v1", name="Var1")
 
     manager.rename_variable("dcid:v1", "dcid:v2")
     for nodes in manager._mcf_nodes.values():
-        assert any(n.Node == "dcid:v2" for n in nodes.nodes)
+        assert any(n.dcid == "dcid:v2" for n in nodes.nodes)
     for nodes in manager._mcf_nodes.values():
-        assert all(n.Node != "dcid:v1" for n in nodes.nodes)
+        assert all(n.dcid != "dcid:v1" for n in nodes.nodes)
 
     # Renaming a missing variable raises ValueError
     with pytest.raises(ValueError):
         manager.rename_variable("missing", "dcid:v3")
 
     # Renaming to an existing MCF node name raises ValueError
-    manager.add_variable_to_mcf(Node="dcid:v3", name="Var3")
+    manager.add_variable_to_mcf(dcid="dcid:v3", name="Var3")
     with pytest.raises(ValueError):
         manager.rename_variable("dcid:v2", "dcid:v3")
 
@@ -760,19 +760,19 @@ def test_rename_variable_mints_bare_tokens():
     never matched the stored dcid:-prefixed Node), so minting both is strictly an
     improvement, not a behaviour change any test pinned."""
     manager = CustomDataManager()
-    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+    manager.add_variable_to_mcf(dcid="dcid:v1", name="Var1")
 
     manager.rename_variable("v1", "v2")
 
     for nodes in manager._mcf_nodes.values():
-        assert any(n.Node == "dcid:v2" for n in nodes.nodes)
-        assert all(n.Node != "dcid:v1" for n in nodes.nodes)
+        assert any(n.dcid == "dcid:v2" for n in nodes.nodes)
+        assert all(n.dcid != "dcid:v1" for n in nodes.nodes)
 
 
 def test_rename_variable_keeps_lookup_index_consistent():
     """A renamed node is addressable by its new name, and its old name is freed."""
     manager = CustomDataManager()
-    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+    manager.add_variable_to_mcf(dcid="dcid:v1", name="Var1")
     manager.rename_variable("dcid:v1", "dcid:v2")
 
     # The old name no longer resolves...
@@ -782,18 +782,18 @@ def test_rename_variable_keeps_lookup_index_consistent():
     # ...and the new one does.
     manager.remove_indicator("dcid:v2")
     for nodes in manager._mcf_nodes.values():
-        assert all(n.Node not in {"dcid:v1", "dcid:v2"} for n in nodes.nodes)
+        assert all(n.dcid not in {"dcid:v1", "dcid:v2"} for n in nodes.nodes)
 
 
 def test_rename_variable_frees_the_old_name_for_reuse():
     """After a rename the old name is available again, and both nodes survive."""
     manager = CustomDataManager()
-    manager.add_variable_to_mcf(Node="dcid:v1", name="Var1")
+    manager.add_variable_to_mcf(dcid="dcid:v1", name="Var1")
     manager.rename_variable("dcid:v1", "dcid:v2")
 
-    manager.add_variable_to_mcf(Node="dcid:v1", name="A different Var1")
+    manager.add_variable_to_mcf(dcid="dcid:v1", name="A different Var1")
 
-    stored = {n.Node for nodes in manager._mcf_nodes.values() for n in nodes.nodes}
+    stored = {n.dcid for nodes in manager._mcf_nodes.values() for n in nodes.nodes}
     assert {"dcid:v1", "dcid:v2"} <= stored
 
 
@@ -995,16 +995,16 @@ def test_column_mappings_rejects_malformed_custom_dimension_names(dimension_name
 def test_add_variable_to_mcf_normalizes_bare_node():
     """add_variable_to_mcf normalizes a bare Node to dcid:, matching the other builders."""
     manager = CustomDataManager()
-    manager.add_variable_to_mcf(Node="StatVar", name="Variable Name")
+    manager.add_variable_to_mcf(dcid="StatVar", name="Variable Name")
     node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
-    assert node.Node == "dcid:StatVar"
+    assert node.dcid == "dcid:StatVar"
 
 
 def test_add_variable_to_mcf_normalizes_bare_reference_fields():
     """The Dcid-typed reference kwargs accept bare tokens too, like Node."""
     manager = CustomDataManager()
     manager.add_variable_to_mcf(
-        Node="StatVar",
+        dcid="StatVar",
         name="Variable Name",
         populationType="Person",
         measuredProperty="count",
@@ -1022,13 +1022,13 @@ def test_add_variable_to_mcf_passes_prefixed_reference_fields_through():
     """Already dcid:-prefixed values are not double-prefixed."""
     manager = CustomDataManager()
     manager.add_variable_to_mcf(
-        Node="dcid:StatVar",
+        dcid="dcid:StatVar",
         name="Variable Name",
         populationType="dcid:Person",
         measuredProperty="dcid:count",
     )
     node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
-    assert node.Node == "dcid:StatVar"
+    assert node.dcid == "dcid:StatVar"
     assert node.populationType == "dcid:Person"
     assert node.measuredProperty == "dcid:count"
 
@@ -1036,26 +1036,26 @@ def test_add_variable_to_mcf_passes_prefixed_reference_fields_through():
 def test_add_entity_type_lands_node():
     """add_entity_type normalizes bare Node to dcid: and sets typeOf."""
     manager = CustomDataManager()
-    manager.add_entity_type(Node="MyClass", name="My Class")
+    manager.add_entity_type(dcid="MyClass", name="My Class")
     nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
     node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcid:Class")
-    assert node.Node == "dcid:MyClass"
+    assert node.dcid == "dcid:MyClass"
     assert node.typeOf == "dcid:Class"
 
 
 def test_add_entity_type_dcid_prefixed_node_verbatim():
     """An already dcid:-prefixed Node is passed through verbatim."""
     manager = CustomDataManager()
-    manager.add_entity_type(Node="dcid:Already", name="x")
+    manager.add_entity_type(dcid="dcid:Already", name="x")
     nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
     node = nodes[0]
-    assert node.Node == "dcid:Already"
+    assert node.dcid == "dcid:Already"
 
 
 def test_add_event_type_default_subclassof():
     """add_event_type defaults subClassOf to dcid:Event."""
     manager = CustomDataManager()
-    manager.add_event_type(Node="Quake", name="Q")
+    manager.add_event_type(dcid="Quake", name="Q")
     nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
     node = nodes[0]
     assert node.typeOf == "dcid:Class"
@@ -1065,7 +1065,7 @@ def test_add_event_type_default_subclassof():
 def test_add_event_type_subclassof_override():
     """A bare subClassOf override is normalized to dcid:."""
     manager = CustomDataManager()
-    manager.add_event_type(Node="Quake", name="Q", subClassOf="DisasterEvent")
+    manager.add_event_type(dcid="Quake", name="Q", subClassOf="DisasterEvent")
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.subClassOf == "dcid:DisasterEvent"
 
@@ -1074,13 +1074,13 @@ def test_add_property_lands_node():
     """add_property emits a Property node with dcid:Property typeOf."""
     manager = CustomDataManager()
     manager.add_property(
-        Node="myProp",
+        dcid="myProp",
         name="My Prop",
         domainIncludes="dcid:Person",
         rangeIncludes="dcid:Number",
     )
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert node.Node == "dcid:myProp"
+    assert node.dcid == "dcid:myProp"
     assert node.typeOf == "dcid:Property"
     assert isinstance(node, PropertyMCFNode)
     assert node.domainIncludes == "dcid:Person"
@@ -1091,7 +1091,7 @@ def test_add_property_normalizes_bare_refs():
     """Bare domainIncludes/rangeIncludes/subPropertyOf refs are normalized to dcid:."""
     manager = CustomDataManager()
     manager.add_property(
-        Node="myProp",
+        dcid="myProp",
         name="x",
         domainIncludes="Person",
         rangeIncludes=["Number", "dcid:Already"],
@@ -1107,7 +1107,7 @@ def test_add_unit_lands_node_and_typeof_override():
     """add_unit normalizes bare typeOf override and stores shortDisplayName."""
     manager = CustomDataManager()
     manager.add_unit(
-        Node="USD",
+        dcid="USD",
         name="US Dollar",
         shortDisplayName="$",
         typeOf="CurrencyUnitOfMeasure",
@@ -1120,7 +1120,7 @@ def test_add_unit_lands_node_and_typeof_override():
 def test_add_measurement_method_lands_node_and_typeof_override():
     """add_measurement_method normalizes bare typeOf and allows absent name."""
     manager = CustomDataManager()
-    manager.add_measurement_method(Node="MyCensus", typeOf="CensusSurveyEnum")
+    manager.add_measurement_method(dcid="MyCensus", typeOf="CensusSurveyEnum")
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.typeOf == "dcid:CensusSurveyEnum"
     assert node.name is None
@@ -1131,7 +1131,7 @@ def test_included_in_expands_to_provenance_and_source():
     manager = CustomDataManager()
     manager.add_source(name="src", url="http://s")
     manager.add_provenance(name="prov", url="http://p", source="src")
-    manager.add_entity_type(Node="T", name="T", includedIn="prov")
+    manager.add_entity_type(dcid="T", name="T", includedIn="prov")
 
     entity_node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert entity_node.includedIn == ["dcid:provenance/prov", "dcid:source/src"]
@@ -1148,7 +1148,7 @@ def test_included_in_accepts_list_of_provenances():
     manager.add_source(name="srcB", url="http://b")
     manager.add_provenance(name="provA", url="http://pa", source="srcA")
     manager.add_provenance(name="provB", url="http://pb", source="srcB")
-    manager.add_entity_type(Node="T", name="T", includedIn=["provA", "provB"])
+    manager.add_entity_type(dcid="T", name="T", includedIn=["provA", "provB"])
 
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.includedIn == [
@@ -1165,7 +1165,7 @@ def test_included_in_dedups_shared_source():
     manager.add_source(name="src", url="http://s")
     manager.add_provenance(name="provA", url="http://pa", source="src")
     manager.add_provenance(name="provB", url="http://pb", source="src")
-    manager.add_entity_type(Node="T", name="T", includedIn=["provA", "provB"])
+    manager.add_entity_type(dcid="T", name="T", includedIn=["provA", "provB"])
 
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     # provA is processed first: emits provenance/provA then source/src.
@@ -1181,16 +1181,16 @@ def test_included_in_raises_for_missing_provenance():
     """includedIn referencing an unregistered provenance raises ValueError."""
     manager = CustomDataManager()
     with pytest.raises(ValueError, match="ghost"):
-        manager.add_event_type(Node="E", name="E", includedIn="ghost")
+        manager.add_event_type(dcid="E", name="E", includedIn="ghost")
 
 
 def test_add_entity_type_override():
     """Duplicate Node without override raises; with override=True replaces."""
     manager = CustomDataManager()
-    manager.add_entity_type(Node="T", name="First")
+    manager.add_entity_type(dcid="T", name="First")
     with pytest.raises(ValueError):
-        manager.add_entity_type(Node="T", name="Second")
-    manager.add_entity_type(Node="T", name="Updated", override=True)
+        manager.add_entity_type(dcid="T", name="Second")
+    manager.add_entity_type(dcid="T", name="Updated", override=True)
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.name == "Updated"
 
@@ -1198,13 +1198,13 @@ def test_add_entity_type_override():
 def test_add_unit_custom_mcf_file_name():
     """add_unit with mcf_file_name lands the node in the specified file."""
     manager = CustomDataManager()
-    manager.add_unit(Node="MyUnit", name="My Unit", mcf_file_name="units.mcf")
+    manager.add_unit(dcid="MyUnit", name="My Unit", mcf_file_name="units.mcf")
     assert "units.mcf" in manager._mcf_nodes
     assert "custom_nodes.mcf" not in manager._mcf_nodes or not any(
-        n.Node == "dcid:MyUnit"
+        n.dcid == "dcid:MyUnit"
         for n in manager._mcf_nodes.get(
             "custom_nodes.mcf", type("", (), {"nodes": []})()
         ).nodes
     )
     node = manager._mcf_nodes["units.mcf"].nodes[0]
-    assert node.Node == "dcid:MyUnit"
+    assert node.dcid == "dcid:MyUnit"

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -16,7 +16,7 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     InputFile,
 )
-from dcp_tools.custom_data.models.schema_nodes import PropertyMCFNode
+from dcp_tools.custom_data.models.schema_nodes import PropertyNode
 
 
 def test_custom_data_manager_add_provenance_and_override():
@@ -1082,7 +1082,7 @@ def test_add_property_lands_node():
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.dcid == "dcid:myProp"
     assert node.typeOf == "dcid:Property"
-    assert isinstance(node, PropertyMCFNode)
+    assert isinstance(node, PropertyNode)
     assert node.domainIncludes == "dcid:Person"
     assert node.rangeIncludes == "dcid:Number"
 

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -23,7 +23,7 @@ def test_node_snapshot():
         shortDisplayName='"F"',
         subClassOf="dcid:Parent",
     )
-    assert node.mcf.strip() == got
+    assert node.to_mcf().strip() == got
 
 
 def test_config_json_snapshot(tmp_path):
@@ -123,9 +123,8 @@ def test_mcf_export_multi_entity(tmp_path):
 
 
 def test_csv_to_mcf_snapshot():
-
     nodes = csv_metadata_to_nodes(GOLDEN_DIR / "sample.csv", ignore_columns=None)
-    got = nodes.mcf if hasattr(nodes, "mcf") else "".join(n.mcf for n in nodes.nodes)
+    got = "".join(n.to_mcf() for n in nodes.nodes)
     expected = (GOLDEN_DIR / "sample_csv_nodes.mcf").read_text()
     assert got == expected
 

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -5,16 +5,16 @@ import pytest
 
 from dcp_tools.custom_data.data_management import CustomDataManager
 from dcp_tools.custom_data.models.config_file import Config
-from dcp_tools.custom_data.models.mcf import MCFNode
+from dcp_tools.custom_data.models.mcf import Node
 from dcp_tools.custom_data.schema_tools import csv_metadata_to_nodes
 
 GOLDEN_DIR = Path(__file__).parent / "goldens"
 
 
-def test_mcfnode_snapshot():
+def test_node_snapshot():
     got = (GOLDEN_DIR / "sample_node.mcf").read_text()
 
-    node = MCFNode(
+    node = Node(
         dcid="dcid:X/foo",
         name='"Some Name"',
         typeOf="dcid:StatisticalVariable",

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -15,10 +15,9 @@ def test_mcfnode_snapshot():
     got = (GOLDEN_DIR / "sample_node.mcf").read_text()
 
     node = MCFNode(
-        Node="dcid:X/foo",
+        dcid="dcid:X/foo",
         name='"Some Name"',
         typeOf="dcid:StatisticalVariable",
-        dcid="dcid:foo",
         description='"Foo description',
         provenance='"Some foo provenance"',
         shortDisplayName='"F"',
@@ -93,10 +92,10 @@ def test_provenance_mcf_snapshot(tmp_path):
 def test_full_mcf_export(tmp_path):
     mgr = CustomDataManager()
     mgr.add_variable_group_to_mcf(
-        Node="dcid:one/g/group1", name="Group One", specializationOf="dcid:dc/g/Root"
+        dcid="dcid:one/g/group1", name="Group One", specializationOf="dcid:dc/g/Root"
     )
     mgr.add_variable_to_mcf(
-        Node="dcid:var/one",
+        dcid="dcid:var/one",
         name="Test Var",
         description="Test var",
         memberOf="dcid:one/g/group1",
@@ -110,7 +109,7 @@ def test_full_mcf_export(tmp_path):
 def test_mcf_export_multi_entity(tmp_path):
     manager = CustomDataManager()
     manager.add_variable_to_mcf(
-        Node="dcid:var/one",
+        dcid="dcid:var/one",
         name="Test Var",
         description="Test var",
         observationProperties=["dcid:originCountry", "dcid:destinationCountry"],

--- a/tests/test_input_file_characterization.py
+++ b/tests/test_input_file_characterization.py
@@ -190,7 +190,7 @@ def test_config_to_dict_shape():
 def test_export_mcf_file(tmp_path):
     """variable added via add_variable_to_mcf appears in exported MCF."""
     manager, _ = _manager()
-    manager.add_variable_to_mcf(Node="dcid:vX", name="VX")
+    manager.add_variable_to_mcf(dcid="dcid:vX", name="VX")
 
     manager.export_mcf_file(tmp_path, mcf_file_name="custom_nodes.mcf")
 

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -186,10 +186,10 @@ def test_dcid_or_list_dcid_rejects_non_string_input():
 # GroupDcidOrListGroupDcid, PeerGroupDcidOrListPeerGroupDcid and TopicDcidOrListTopicDcid
 # used to still use PlainValidator (their slug pattern bypassed), tracked separately from
 # #126. #131 switched all three to the same BeforeValidator as DcidOrListDcid, once
-# StatVarMCFNode.memberOf no longer used the field as a scratch value for an unresolved
+# StatVarNode.memberOf no longer used the field as a scratch value for an unresolved
 # raw group path (see resolve_group_paths in schema_tools.py). PeerGroupDcidOrListPeerGroupDcid
 # and TopicDcidOrListTopicDcid were then deleted, along with the TopicDcid they wrapped: no
-# field references them (TopicMCFNode.relevantVariable collapsed to plain DcidOrListDcid — see
+# field references them (TopicNode.relevantVariable collapsed to plain DcidOrListDcid — see
 # test_models_topics.py).
 
 

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -3,15 +3,15 @@ from enum import StrEnum
 import pytest
 from pydantic import ValidationError
 
-from dcp_tools.custom_data.models.mcf import MCFNode, MCFNodes
-from dcp_tools.custom_data.models.stat_vars import StatType, StatVarMCFNode
+from dcp_tools.custom_data.models.mcf import Node, Nodes
+from dcp_tools.custom_data.models.stat_vars import StatType, StatVarNode
 
 
-def test_mcfnode_mcf_output_order_and_formatting():
+def test_node_mcf_output_order_and_formatting():
     """
-    Ensures MCFNode.mcf outputs correctly with 'Node:' line first.
+    Ensures Node.mcf outputs correctly with 'Node:' line first.
     """
-    node = MCFNode(
+    node = Node(
         name='"My Name"',
         typeOf="dcid:TypeA",
         description='"Desc"',
@@ -28,26 +28,26 @@ def test_mcfnode_mcf_output_order_and_formatting():
 @pytest.mark.parametrize(
     "type_of", [["dcid:TypeA", "dcid:TypeB"], "dcid:TypeA, dcid:TypeB"]
 )
-def test_mcfnode_typeof_accepts_list_and_serializes(type_of):
+def test_node_typeof_accepts_list_and_serializes(type_of):
     """
     Accepts a list of DCIDs for typeOf and serializes as CSV.
     """
-    node = MCFNode(dcid="dcid:TestNode", name='"My Name"', typeOf=type_of)
+    node = Node(dcid="dcid:TestNode", name='"My Name"', typeOf=type_of)
     assert node.mcf == (
         'Node: dcid:TestNode\nname: "My Name"\ntypeOf: dcid:TypeA, dcid:TypeB\n\n'
     )
 
 
-def test_mcfnode_allows_missing_name_and_serializes_without_it():
+def test_node_allows_missing_name_and_serializes_without_it():
     """
     `name` is optional; when omitted it should not appear in MCF output.
     """
-    node = MCFNode(dcid="dcid:NoNameNode", typeOf="dcid:TypeA")
+    node = Node(dcid="dcid:NoNameNode", typeOf="dcid:TypeA")
     assert node.mcf == ("Node: dcid:NoNameNode\ntypeOf: dcid:TypeA\n\n")
 
 
-def test_mcfnode_strips_linebreaks_and_trailing_spaces():
-    node = MCFNode(
+def test_node_strips_linebreaks_and_trailing_spaces():
+    node = Node(
         dcid="dcid:TestNode \n",  # newline and trailing space
         name="My name\n ",
         typeOf="dcid:TypeA \n",
@@ -55,7 +55,7 @@ def test_mcfnode_strips_linebreaks_and_trailing_spaces():
     assert node.mcf == ('Node: dcid:TestNode\nname: "My name"\ntypeOf: dcid:TypeA\n\n')
 
 
-def test_mcfnodes_load_from_file_without_name(tmp_path):
+def test_nodes_load_from_file_without_name(tmp_path):
     """
     Loading MCF where a block has no `name` should succeed.
     """
@@ -70,7 +70,7 @@ def test_mcfnodes_load_from_file_without_name(tmp_path):
     path = tmp_path / "nodes.mcf"
     path.write_text(mcf_text)
 
-    nodes = MCFNodes().load_from_mcf_file(str(path))
+    nodes = Nodes().load_from_mcf_file(str(path))
     assert len(nodes.nodes) == 2
     # First node should have no name, but have typeOf
     first = nodes.nodes[0]
@@ -79,28 +79,28 @@ def test_mcfnodes_load_from_file_without_name(tmp_path):
     assert first.typeOf == "dcid:TypeA"
 
 
-def test_mcfnode_typeof_normalizes_bare_token():
+def test_node_typeof_normalizes_bare_token():
     """typeOf is DcidOrListDcid; a bare token is minted to dcid:<token> (regression for #126)."""
-    node = MCFNode(dcid="dcid:TestNode", typeOf="TypeA")
+    node = Node(dcid="dcid:TestNode", typeOf="TypeA")
     assert node.typeOf == "dcid:TypeA"
 
 
-def test_mcfnode_typeof_rejects_whitespace_bearing_token():
+def test_node_typeof_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        MCFNode(dcid="dcid:TestNode", typeOf="has space")
+        Node(dcid="dcid:TestNode", typeOf="has space")
 
 
-def test_mcfnodes_add_override_and_remove():
+def test_nodes_add_override_and_remove():
     """
-    Tests adding nodes, override behavior, and removal from MCFNodes.
+    Tests adding nodes, override behavior, and removal from Nodes.
     """
-    nodes = MCFNodes()
-    node1 = MCFNode(dcid="dcid:n1", name='"First"', typeOf="dcid:T1")
+    nodes = Nodes()
+    node1 = Node(dcid="dcid:n1", name='"First"', typeOf="dcid:T1")
     nodes.add(node1)
     assert nodes._expect_present("dcid:n1") == 0
 
     # Adding same node without override should error
-    node1b = MCFNode(dcid="dcid:n1", name='"Second"', typeOf="dcid:T1")
+    node1b = Node(dcid="dcid:n1", name='"Second"', typeOf="dcid:T1")
     with pytest.raises(ValueError):
         nodes.add(node1b, override=False)
 
@@ -116,25 +116,25 @@ def test_mcfnodes_add_override_and_remove():
 
 # --- validate_assignment (regression tests for #131) ---
 #
-# MCFNode.model_config gained validate_assignment=True so that the patterns restored on
+# Node.model_config gained validate_assignment=True so that the patterns restored on
 # the slug-variant types (GroupDcidOrListGroupDcid and friends, see models/common.py) are
 # enforced on assignment too, not just on construction.
 
 
-def test_mcfnode_assignment_is_validated():
+def test_node_assignment_is_validated():
     """An invalid value assigned to a pattern-constrained field raises, the same as
     construction would."""
-    node = MCFNode(dcid="dcid:n1", typeOf="dcid:T1")
+    node = Node(dcid="dcid:n1", typeOf="dcid:T1")
     with pytest.raises(ValidationError):
         node.typeOf = "has space"
 
 
-def test_mcfnode_assignment_cleans_the_assigned_value():
+def test_node_assignment_cleans_the_assigned_value():
     """A newly-assigned value is cleaned (newlines/trailing spaces stripped) the same
     way construction cleans it, for declared fields and for the extra keys that carry
     arbitrary MCF properties. An uncleaned value would emit a line break mid-node and
     break the MCF file (the bug fixed in v0.0.7, for construction only)."""
-    node = MCFNode(dcid="dcid:n1", typeOf="dcid:T1")
+    node = Node(dcid="dcid:n1", typeOf="dcid:T1")
 
     node.name = "text\nwith newline  "
     assert node.name == "textwith newline"
@@ -152,7 +152,7 @@ def test_stat_type_survives_assignment():
     returned a plain str, silently degrading the enum member on any unrelated
     assignment. `_clean_value` now keeps an Enum member that cleaning would not
     change."""
-    sv = StatVarMCFNode(dcid="dcid:v1")
+    sv = StatVarNode(dcid="dcid:v1")
     assert isinstance(sv.statType, StatType)
 
     sv.name = "Var"
@@ -170,18 +170,18 @@ def test_enum_carrying_a_line_break_is_still_cleaned():
     class Dirty(StrEnum):
         BAD = "line\nbreak  "
 
-    node = MCFNode(dcid="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
+    node = Node(dcid="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
 
     assert node.custom == "linebreak"
     assert "custom: linebreak\n" in node.mcf
 
 
-def test_mcfnodes_rename_rejected_leaves_index_intact():
+def test_nodes_rename_rejected_leaves_index_intact():
     """A rename to a value that fails Node's dcid pattern raises, and leaves the
     node and the lookup index exactly as they were (assignment happens before
     `_pos` is mutated)."""
-    nodes = MCFNodes()
-    nodes.add(MCFNode(dcid="dcid:n1", typeOf="dcid:T1"))
+    nodes = Nodes()
+    nodes.add(Node(dcid="dcid:n1", typeOf="dcid:T1"))
 
     with pytest.raises(ValidationError):
         nodes.rename("dcid:n1", "not-a-dcid")

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -9,7 +9,7 @@ from dcp_tools.custom_data.models.stat_vars import StatType, StatVarNode
 
 def test_node_mcf_output_order_and_formatting():
     """
-    Ensures Node.mcf outputs correctly with 'Node:' line first.
+    Ensures Node.to_mcf() outputs correctly with 'Node:' line first.
     """
     node = Node(
         name='"My Name"',
@@ -17,7 +17,7 @@ def test_node_mcf_output_order_and_formatting():
         description='"Desc"',
         dcid="dcid:TestNode",
     )
-    assert node.mcf == (
+    assert node.to_mcf() == (
         "Node: dcid:TestNode\n"
         'name: "My Name"\n'
         "typeOf: dcid:TypeA\n"
@@ -33,7 +33,7 @@ def test_node_typeof_accepts_list_and_serializes(type_of):
     Accepts a list of DCIDs for typeOf and serializes as CSV.
     """
     node = Node(dcid="dcid:TestNode", name='"My Name"', typeOf=type_of)
-    assert node.mcf == (
+    assert node.to_mcf() == (
         'Node: dcid:TestNode\nname: "My Name"\ntypeOf: dcid:TypeA, dcid:TypeB\n\n'
     )
 
@@ -43,7 +43,7 @@ def test_node_allows_missing_name_and_serializes_without_it():
     `name` is optional; when omitted it should not appear in MCF output.
     """
     node = Node(dcid="dcid:NoNameNode", typeOf="dcid:TypeA")
-    assert node.mcf == ("Node: dcid:NoNameNode\ntypeOf: dcid:TypeA\n\n")
+    assert node.to_mcf() == ("Node: dcid:NoNameNode\ntypeOf: dcid:TypeA\n\n")
 
 
 def test_node_strips_linebreaks_and_trailing_spaces():
@@ -52,7 +52,9 @@ def test_node_strips_linebreaks_and_trailing_spaces():
         name="My name\n ",
         typeOf="dcid:TypeA \n",
     )
-    assert node.mcf == ('Node: dcid:TestNode\nname: "My name"\ntypeOf: dcid:TypeA\n\n')
+    assert node.to_mcf() == (
+        'Node: dcid:TestNode\nname: "My name"\ntypeOf: dcid:TypeA\n\n'
+    )
 
 
 def test_nodes_load_from_file_without_name(tmp_path):
@@ -141,7 +143,7 @@ def test_node_assignment_cleans_the_assigned_value():
 
     node.customProperty = "extra\nvalue  "
     assert node.customProperty == "extravalue"
-    assert "customProperty: extravalue\n" in node.mcf
+    assert "customProperty: extravalue\n" in node.to_mcf()
 
 
 def test_stat_type_survives_assignment():
@@ -173,7 +175,7 @@ def test_enum_carrying_a_line_break_is_still_cleaned():
     node = Node(dcid="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
 
     assert node.custom == "linebreak"
-    assert "custom: linebreak\n" in node.mcf
+    assert "custom: linebreak\n" in node.to_mcf()
 
 
 def test_nodes_rename_rejected_leaves_index_intact():

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -9,70 +9,50 @@ from dcp_tools.custom_data.models.stat_vars import StatType, StatVarMCFNode
 
 def test_mcfnode_mcf_output_order_and_formatting():
     """
-    Ensures MCFNode.mcf outputs properties sorted alphabetically
-    after 'Node:' line.
+    Ensures MCFNode.mcf outputs correctly with 'Node:' line first.
     """
     node = MCFNode(
-        Node="dcid:TestNode",
         name='"My Name"',
         typeOf="dcid:TypeA",
         description='"Desc"',
+        dcid="dcid:TestNode",
     )
-    lines = node.mcf.strip().splitlines()
-    assert lines[0] == "Node: dcid:TestNode"
-    assert lines[1] == 'name: "My Name"'
-    assert lines[2] == "typeOf: dcid:TypeA"
-    assert lines[3] == 'description: "Desc"'
+    assert node.mcf == (
+        "Node: dcid:TestNode\n"
+        'name: "My Name"\n'
+        "typeOf: dcid:TypeA\n"
+        'description: "Desc"\n\n'
+    )
 
 
-def test_mcfnode_typeof_accepts_list_and_serializes():
+@pytest.mark.parametrize(
+    "type_of", [["dcid:TypeA", "dcid:TypeB"], "dcid:TypeA, dcid:TypeB"]
+)
+def test_mcfnode_typeof_accepts_list_and_serializes(type_of):
     """
     Accepts a list of DCIDs for typeOf and serializes as CSV.
     """
-    node = MCFNode(
-        Node="dcid:TestNode", name='"My Name"', typeOf=["dcid:TypeA", "dcid:TypeB"]
+    node = MCFNode(dcid="dcid:TestNode", name='"My Name"', typeOf=type_of)
+    assert node.mcf == (
+        'Node: dcid:TestNode\nname: "My Name"\ntypeOf: dcid:TypeA, dcid:TypeB\n\n'
     )
-    lines = node.mcf.strip().splitlines()
-    assert lines[0] == "Node: dcid:TestNode"
-    # Field order keeps name before typeOf
-    assert lines[2] == "typeOf: dcid:TypeA, dcid:TypeB"
-
-
-def test_mcfnode_typeof_accepts_comma_string_and_serializes():
-    """
-    Accepts a comma-delimited string for typeOf and serializes consistently.
-    """
-    node = MCFNode(
-        Node="dcid:TestNode", name='"My Name"', typeOf="dcid:TypeA, dcid:TypeB"
-    )
-    lines = node.mcf.strip().splitlines()
-    assert lines[0] == "Node: dcid:TestNode"
-    assert lines[2] == "typeOf: dcid:TypeA, dcid:TypeB"
 
 
 def test_mcfnode_allows_missing_name_and_serializes_without_it():
     """
     `name` is optional; when omitted it should not appear in MCF output.
     """
-    node = MCFNode(Node="dcid:NoNameNode", typeOf="dcid:TypeA")
-    lines = node.mcf.strip().splitlines()
-    assert lines[0] == "Node: dcid:NoNameNode"
-    # With no name, typeOf should be next
-    assert lines[1] == "typeOf: dcid:TypeA"
-    assert not any(line.startswith("name:") for line in lines)
+    node = MCFNode(dcid="dcid:NoNameNode", typeOf="dcid:TypeA")
+    assert node.mcf == ("Node: dcid:NoNameNode\ntypeOf: dcid:TypeA\n\n")
 
 
 def test_mcfnode_strips_linebreaks_and_trailing_spaces():
     node = MCFNode(
-        Node="dcid:TestNode \n",  # newline and trailing space
+        dcid="dcid:TestNode \n",  # newline and trailing space
         name="My name\n ",
         typeOf="dcid:TypeA \n",
-        extra_field="extra value \n",
     )
-    assert node.Node == "dcid:TestNode"
-    assert node.name == "My name"
-    assert node.typeOf == "dcid:TypeA"
-    assert node.extra_field == "extra value"
+    assert node.mcf == ('Node: dcid:TestNode\nname: "My name"\ntypeOf: dcid:TypeA\n\n')
 
 
 def test_mcfnodes_load_from_file_without_name(tmp_path):
@@ -81,7 +61,8 @@ def test_mcfnodes_load_from_file_without_name(tmp_path):
     """
     mcf_text = (
         "Node: dcid:NoName\n"
-        "typeOf: dcid:TypeA\n\n"
+        "typeOf: dcid:TypeA\n"
+        "\n"
         "Node: dcid:WithName\n"
         'name: "Some Name"\n'
         "typeOf: dcid:TypeB\n\n"
@@ -93,20 +74,20 @@ def test_mcfnodes_load_from_file_without_name(tmp_path):
     assert len(nodes.nodes) == 2
     # First node should have no name, but have typeOf
     first = nodes.nodes[0]
-    assert first.Node == "dcid:NoName"
+    assert first.dcid == "dcid:NoName"
     assert getattr(first, "name", None) is None
     assert first.typeOf == "dcid:TypeA"
 
 
 def test_mcfnode_typeof_normalizes_bare_token():
     """typeOf is DcidOrListDcid; a bare token is minted to dcid:<token> (regression for #126)."""
-    node = MCFNode(Node="dcid:TestNode", typeOf="TypeA")
+    node = MCFNode(dcid="dcid:TestNode", typeOf="TypeA")
     assert node.typeOf == "dcid:TypeA"
 
 
 def test_mcfnode_typeof_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        MCFNode(Node="dcid:TestNode", typeOf="has space")
+        MCFNode(dcid="dcid:TestNode", typeOf="has space")
 
 
 def test_mcfnodes_add_override_and_remove():
@@ -114,12 +95,12 @@ def test_mcfnodes_add_override_and_remove():
     Tests adding nodes, override behavior, and removal from MCFNodes.
     """
     nodes = MCFNodes()
-    node1 = MCFNode(Node="dcid:n1", name='"First"', typeOf="dcid:T1")
+    node1 = MCFNode(dcid="dcid:n1", name='"First"', typeOf="dcid:T1")
     nodes.add(node1)
     assert nodes._expect_present("dcid:n1") == 0
 
     # Adding same node without override should error
-    node1b = MCFNode(Node="dcid:n1", name='"Second"', typeOf="dcid:T1")
+    node1b = MCFNode(dcid="dcid:n1", name='"Second"', typeOf="dcid:T1")
     with pytest.raises(ValueError):
         nodes.add(node1b, override=False)
 
@@ -143,7 +124,7 @@ def test_mcfnodes_add_override_and_remove():
 def test_mcfnode_assignment_is_validated():
     """An invalid value assigned to a pattern-constrained field raises, the same as
     construction would."""
-    node = MCFNode(Node="dcid:n1", typeOf="dcid:T1")
+    node = MCFNode(dcid="dcid:n1", typeOf="dcid:T1")
     with pytest.raises(ValidationError):
         node.typeOf = "has space"
 
@@ -153,7 +134,7 @@ def test_mcfnode_assignment_cleans_the_assigned_value():
     way construction cleans it, for declared fields and for the extra keys that carry
     arbitrary MCF properties. An uncleaned value would emit a line break mid-node and
     break the MCF file (the bug fixed in v0.0.7, for construction only)."""
-    node = MCFNode(Node="dcid:n1", typeOf="dcid:T1")
+    node = MCFNode(dcid="dcid:n1", typeOf="dcid:T1")
 
     node.name = "text\nwith newline  "
     assert node.name == "textwith newline"
@@ -171,7 +152,7 @@ def test_stat_type_survives_assignment():
     returned a plain str, silently degrading the enum member on any unrelated
     assignment. `_clean_value` now keeps an Enum member that cleaning would not
     change."""
-    sv = StatVarMCFNode(Node="dcid:v1")
+    sv = StatVarMCFNode(dcid="dcid:v1")
     assert isinstance(sv.statType, StatType)
 
     sv.name = "Var"
@@ -189,7 +170,7 @@ def test_enum_carrying_a_line_break_is_still_cleaned():
     class Dirty(StrEnum):
         BAD = "line\nbreak  "
 
-    node = MCFNode(Node="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
+    node = MCFNode(dcid="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
 
     assert node.custom == "linebreak"
     assert "custom: linebreak\n" in node.mcf
@@ -200,10 +181,10 @@ def test_mcfnodes_rename_rejected_leaves_index_intact():
     node and the lookup index exactly as they were (assignment happens before
     `_pos` is mutated)."""
     nodes = MCFNodes()
-    nodes.add(MCFNode(Node="dcid:n1", typeOf="dcid:T1"))
+    nodes.add(MCFNode(dcid="dcid:n1", typeOf="dcid:T1"))
 
     with pytest.raises(ValidationError):
         nodes.rename("dcid:n1", "not-a-dcid")
 
-    assert nodes.nodes[0].Node == "dcid:n1"
+    assert nodes.nodes[0].dcid == "dcid:n1"
     assert nodes._pos == {"dcid:n1": 0}

--- a/tests/test_models_schema_nodes.py
+++ b/tests/test_models_schema_nodes.py
@@ -2,24 +2,24 @@ import pytest
 from pydantic import ValidationError
 
 from dcp_tools.custom_data.models.schema_nodes import (
-    EntityTypeMCFNode,
-    EventTypeMCFNode,
-    MeasurementMethodMCFNode,
-    PropertyMCFNode,
-    UnitOfMeasureMCFNode,
+    EntityTypeNode,
+    EventTypeNode,
+    MeasurementMethodNode,
+    PropertyNode,
+    UnitOfMeasureNode,
 )
 
-# --- EntityTypeMCFNode ---
+# --- EntityTypeNode ---
 
 
 def test_entity_type_default_typeof():
-    node = EntityTypeMCFNode(dcid="dcid:MyClass", name="My Class")
+    node = EntityTypeNode(dcid="dcid:MyClass", name="My Class")
     assert node.typeOf == "dcid:Class"
     assert "typeOf: dcid:Class" in node.mcf
 
 
 def test_entity_type_accepts_included_in_list():
-    node = EntityTypeMCFNode(
+    node = EntityTypeNode(
         dcid="dcid:MyClass",
         name="My Class",
         includedIn=["dcid:provenance/p", "dcid:source/s"],
@@ -30,26 +30,26 @@ def test_entity_type_accepts_included_in_list():
 def test_entity_type_rejects_malformed_node():
     """Node field enforces dcid: prefix; builder normalizes before construction."""
     with pytest.raises(ValidationError):
-        EntityTypeMCFNode(dcid="MyClass", name="My Class")
+        EntityTypeNode(dcid="MyClass", name="My Class")
 
 
 def test_entity_type_included_in_normalizes_bare_token():
     """includedIn is DcidOrListDcid; a bare token is minted (regression for #126)."""
-    node = EntityTypeMCFNode(dcid="dcid:MyClass", name="My Class", includedIn="p")
+    node = EntityTypeNode(dcid="dcid:MyClass", name="My Class", includedIn="p")
     assert node.includedIn == "dcid:p"
 
 
-# --- EventTypeMCFNode ---
+# --- EventTypeNode ---
 
 
 def test_event_type_default_typeof_and_subclassof():
-    node = EventTypeMCFNode(dcid="dcid:MyEvent", name="My Event")
+    node = EventTypeNode(dcid="dcid:MyEvent", name="My Event")
     assert node.typeOf == "dcid:Class"
     assert node.subClassOf == "dcid:Event"
 
 
 def test_event_type_subclassof_override():
-    node = EventTypeMCFNode(
+    node = EventTypeNode(
         dcid="dcid:MyEvent", name="My Event", subClassOf="dcid:DisasterEvent"
     )
     assert node.subClassOf == "dcid:DisasterEvent"
@@ -58,22 +58,22 @@ def test_event_type_subclassof_override():
 
 def test_event_type_subclassof_normalizes_bare_token():
     """subClassOf is DcidOrListDcid; a bare token is minted (regression for #126)."""
-    node = EventTypeMCFNode(
+    node = EventTypeNode(
         dcid="dcid:MyEvent", name="My Event", subClassOf="DisasterEvent"
     )
     assert node.subClassOf == "dcid:DisasterEvent"
 
 
-# --- PropertyMCFNode ---
+# --- PropertyNode ---
 
 
 def test_property_default_typeof():
-    node = PropertyMCFNode(dcid="dcid:myProp", name="My Prop")
+    node = PropertyNode(dcid="dcid:myProp", name="My Prop")
     assert node.typeOf == "dcid:Property"
 
 
 def test_property_optional_refs_serialize():
-    node = PropertyMCFNode(
+    node = PropertyNode(
         dcid="dcid:myProp",
         name="My Prop",
         domainIncludes="dcid:Person",
@@ -89,17 +89,17 @@ def test_property_model_normalizes_bare_ref():
     """DcidOrListDcid now runs ensure_dcid via a BeforeValidator (regression for #126), so
     domainIncludes/rangeIncludes/subPropertyOf are normalized at the model layer too, not
     just by the builder (add_property). A bare token is minted to dcid:<token>."""
-    node = PropertyMCFNode(dcid="dcid:myProp", domainIncludes="Person")
+    node = PropertyNode(dcid="dcid:myProp", domainIncludes="Person")
     assert node.domainIncludes == "dcid:Person"
 
 
 def test_property_model_rejects_whitespace_bearing_ref():
     with pytest.raises(ValidationError):
-        PropertyMCFNode(dcid="dcid:myProp", domainIncludes="has space")
+        PropertyNode(dcid="dcid:myProp", domainIncludes="has space")
 
 
 def test_property_model_normalizes_bare_ref_list():
-    node = PropertyMCFNode(
+    node = PropertyNode(
         dcid="dcid:myProp",
         domainIncludes=["Person", "Household"],
         rangeIncludes=["Number"],
@@ -110,16 +110,16 @@ def test_property_model_normalizes_bare_ref_list():
     assert node.subPropertyOf == ["dcid:baseProp"]
 
 
-# --- UnitOfMeasureMCFNode ---
+# --- UnitOfMeasureNode ---
 
 
 def test_unit_default_typeof():
-    node = UnitOfMeasureMCFNode(dcid="dcid:MyUnit", name="My Unit")
+    node = UnitOfMeasureNode(dcid="dcid:MyUnit", name="My Unit")
     assert node.typeOf == "dcid:UnitOfMeasure"
 
 
 def test_unit_typeof_override_validates():
-    node = UnitOfMeasureMCFNode(
+    node = UnitOfMeasureNode(
         dcid="dcid:USD", name="US Dollar", typeOf="dcid:CurrencyUnitOfMeasure"
     )
     assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
@@ -127,26 +127,24 @@ def test_unit_typeof_override_validates():
 
 
 def test_unit_inherits_short_display_name():
-    node = UnitOfMeasureMCFNode(dcid="dcid:USD", name="US Dollar", shortDisplayName="$")
+    node = UnitOfMeasureNode(dcid="dcid:USD", name="US Dollar", shortDisplayName="$")
     assert 'shortDisplayName: "$"' in node.mcf
 
 
-# --- MeasurementMethodMCFNode ---
+# --- MeasurementMethodNode ---
 
 
 def test_measurement_method_default_typeof():
-    node = MeasurementMethodMCFNode(dcid="dcid:MyMethod")
+    node = MeasurementMethodNode(dcid="dcid:MyMethod")
     assert node.typeOf == "dcid:MeasurementMethodEnum"
 
 
 def test_measurement_method_typeof_override_validates():
-    node = MeasurementMethodMCFNode(
-        dcid="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum"
-    )
+    node = MeasurementMethodNode(dcid="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum")
     assert node.typeOf == "dcid:CensusSurveyEnum"
     assert "typeOf: dcid:CensusSurveyEnum" in node.mcf
 
 
 def test_measurement_method_allows_missing_name():
-    node = MeasurementMethodMCFNode(dcid="dcid:MyMethod")
+    node = MeasurementMethodNode(dcid="dcid:MyMethod")
     assert "name:" not in node.mcf

--- a/tests/test_models_schema_nodes.py
+++ b/tests/test_models_schema_nodes.py
@@ -13,14 +13,14 @@ from dcp_tools.custom_data.models.schema_nodes import (
 
 
 def test_entity_type_default_typeof():
-    node = EntityTypeMCFNode(Node="dcid:MyClass", name="My Class")
+    node = EntityTypeMCFNode(dcid="dcid:MyClass", name="My Class")
     assert node.typeOf == "dcid:Class"
     assert "typeOf: dcid:Class" in node.mcf
 
 
 def test_entity_type_accepts_included_in_list():
     node = EntityTypeMCFNode(
-        Node="dcid:MyClass",
+        dcid="dcid:MyClass",
         name="My Class",
         includedIn=["dcid:provenance/p", "dcid:source/s"],
     )
@@ -30,12 +30,12 @@ def test_entity_type_accepts_included_in_list():
 def test_entity_type_rejects_malformed_node():
     """Node field enforces dcid: prefix; builder normalizes before construction."""
     with pytest.raises(ValidationError):
-        EntityTypeMCFNode(Node="MyClass", name="My Class")
+        EntityTypeMCFNode(dcid="MyClass", name="My Class")
 
 
 def test_entity_type_included_in_normalizes_bare_token():
     """includedIn is DcidOrListDcid; a bare token is minted (regression for #126)."""
-    node = EntityTypeMCFNode(Node="dcid:MyClass", name="My Class", includedIn="p")
+    node = EntityTypeMCFNode(dcid="dcid:MyClass", name="My Class", includedIn="p")
     assert node.includedIn == "dcid:p"
 
 
@@ -43,14 +43,14 @@ def test_entity_type_included_in_normalizes_bare_token():
 
 
 def test_event_type_default_typeof_and_subclassof():
-    node = EventTypeMCFNode(Node="dcid:MyEvent", name="My Event")
+    node = EventTypeMCFNode(dcid="dcid:MyEvent", name="My Event")
     assert node.typeOf == "dcid:Class"
     assert node.subClassOf == "dcid:Event"
 
 
 def test_event_type_subclassof_override():
     node = EventTypeMCFNode(
-        Node="dcid:MyEvent", name="My Event", subClassOf="dcid:DisasterEvent"
+        dcid="dcid:MyEvent", name="My Event", subClassOf="dcid:DisasterEvent"
     )
     assert node.subClassOf == "dcid:DisasterEvent"
     assert "subClassOf: dcid:DisasterEvent" in node.mcf
@@ -59,7 +59,7 @@ def test_event_type_subclassof_override():
 def test_event_type_subclassof_normalizes_bare_token():
     """subClassOf is DcidOrListDcid; a bare token is minted (regression for #126)."""
     node = EventTypeMCFNode(
-        Node="dcid:MyEvent", name="My Event", subClassOf="DisasterEvent"
+        dcid="dcid:MyEvent", name="My Event", subClassOf="DisasterEvent"
     )
     assert node.subClassOf == "dcid:DisasterEvent"
 
@@ -68,13 +68,13 @@ def test_event_type_subclassof_normalizes_bare_token():
 
 
 def test_property_default_typeof():
-    node = PropertyMCFNode(Node="dcid:myProp", name="My Prop")
+    node = PropertyMCFNode(dcid="dcid:myProp", name="My Prop")
     assert node.typeOf == "dcid:Property"
 
 
 def test_property_optional_refs_serialize():
     node = PropertyMCFNode(
-        Node="dcid:myProp",
+        dcid="dcid:myProp",
         name="My Prop",
         domainIncludes="dcid:Person",
         rangeIncludes="dcid:Number",
@@ -89,18 +89,18 @@ def test_property_model_normalizes_bare_ref():
     """DcidOrListDcid now runs ensure_dcid via a BeforeValidator (regression for #126), so
     domainIncludes/rangeIncludes/subPropertyOf are normalized at the model layer too, not
     just by the builder (add_property). A bare token is minted to dcid:<token>."""
-    node = PropertyMCFNode(Node="dcid:myProp", domainIncludes="Person")
+    node = PropertyMCFNode(dcid="dcid:myProp", domainIncludes="Person")
     assert node.domainIncludes == "dcid:Person"
 
 
 def test_property_model_rejects_whitespace_bearing_ref():
     with pytest.raises(ValidationError):
-        PropertyMCFNode(Node="dcid:myProp", domainIncludes="has space")
+        PropertyMCFNode(dcid="dcid:myProp", domainIncludes="has space")
 
 
 def test_property_model_normalizes_bare_ref_list():
     node = PropertyMCFNode(
-        Node="dcid:myProp",
+        dcid="dcid:myProp",
         domainIncludes=["Person", "Household"],
         rangeIncludes=["Number"],
         subPropertyOf=["baseProp"],
@@ -114,20 +114,20 @@ def test_property_model_normalizes_bare_ref_list():
 
 
 def test_unit_default_typeof():
-    node = UnitOfMeasureMCFNode(Node="dcid:MyUnit", name="My Unit")
+    node = UnitOfMeasureMCFNode(dcid="dcid:MyUnit", name="My Unit")
     assert node.typeOf == "dcid:UnitOfMeasure"
 
 
 def test_unit_typeof_override_validates():
     node = UnitOfMeasureMCFNode(
-        Node="dcid:USD", name="US Dollar", typeOf="dcid:CurrencyUnitOfMeasure"
+        dcid="dcid:USD", name="US Dollar", typeOf="dcid:CurrencyUnitOfMeasure"
     )
     assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
     assert "typeOf: dcid:CurrencyUnitOfMeasure" in node.mcf
 
 
 def test_unit_inherits_short_display_name():
-    node = UnitOfMeasureMCFNode(Node="dcid:USD", name="US Dollar", shortDisplayName="$")
+    node = UnitOfMeasureMCFNode(dcid="dcid:USD", name="US Dollar", shortDisplayName="$")
     assert 'shortDisplayName: "$"' in node.mcf
 
 
@@ -135,18 +135,18 @@ def test_unit_inherits_short_display_name():
 
 
 def test_measurement_method_default_typeof():
-    node = MeasurementMethodMCFNode(Node="dcid:MyMethod")
+    node = MeasurementMethodMCFNode(dcid="dcid:MyMethod")
     assert node.typeOf == "dcid:MeasurementMethodEnum"
 
 
 def test_measurement_method_typeof_override_validates():
     node = MeasurementMethodMCFNode(
-        Node="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum"
+        dcid="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum"
     )
     assert node.typeOf == "dcid:CensusSurveyEnum"
     assert "typeOf: dcid:CensusSurveyEnum" in node.mcf
 
 
 def test_measurement_method_allows_missing_name():
-    node = MeasurementMethodMCFNode(Node="dcid:MyMethod")
+    node = MeasurementMethodMCFNode(dcid="dcid:MyMethod")
     assert "name:" not in node.mcf

--- a/tests/test_models_schema_nodes.py
+++ b/tests/test_models_schema_nodes.py
@@ -15,7 +15,7 @@ from dcp_tools.custom_data.models.schema_nodes import (
 def test_entity_type_default_typeof():
     node = EntityTypeNode(dcid="dcid:MyClass", name="My Class")
     assert node.typeOf == "dcid:Class"
-    assert "typeOf: dcid:Class" in node.mcf
+    assert "typeOf: dcid:Class" in node.to_mcf()
 
 
 def test_entity_type_accepts_included_in_list():
@@ -24,7 +24,7 @@ def test_entity_type_accepts_included_in_list():
         name="My Class",
         includedIn=["dcid:provenance/p", "dcid:source/s"],
     )
-    assert "includedIn: dcid:provenance/p, dcid:source/s" in node.mcf
+    assert "includedIn: dcid:provenance/p, dcid:source/s" in node.to_mcf()
 
 
 def test_entity_type_rejects_malformed_node():
@@ -53,7 +53,7 @@ def test_event_type_subclassof_override():
         dcid="dcid:MyEvent", name="My Event", subClassOf="dcid:DisasterEvent"
     )
     assert node.subClassOf == "dcid:DisasterEvent"
-    assert "subClassOf: dcid:DisasterEvent" in node.mcf
+    assert "subClassOf: dcid:DisasterEvent" in node.to_mcf()
 
 
 def test_event_type_subclassof_normalizes_bare_token():
@@ -80,9 +80,9 @@ def test_property_optional_refs_serialize():
         rangeIncludes="dcid:Number",
         subPropertyOf="dcid:baseProp",
     )
-    assert "domainIncludes: dcid:Person" in node.mcf
-    assert "rangeIncludes: dcid:Number" in node.mcf
-    assert "subPropertyOf: dcid:baseProp" in node.mcf
+    assert "domainIncludes: dcid:Person" in node.to_mcf()
+    assert "rangeIncludes: dcid:Number" in node.to_mcf()
+    assert "subPropertyOf: dcid:baseProp" in node.to_mcf()
 
 
 def test_property_model_normalizes_bare_ref():
@@ -123,12 +123,12 @@ def test_unit_typeof_override_validates():
         dcid="dcid:USD", name="US Dollar", typeOf="dcid:CurrencyUnitOfMeasure"
     )
     assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
-    assert "typeOf: dcid:CurrencyUnitOfMeasure" in node.mcf
+    assert "typeOf: dcid:CurrencyUnitOfMeasure" in node.to_mcf()
 
 
 def test_unit_inherits_short_display_name():
     node = UnitOfMeasureNode(dcid="dcid:USD", name="US Dollar", shortDisplayName="$")
-    assert 'shortDisplayName: "$"' in node.mcf
+    assert 'shortDisplayName: "$"' in node.to_mcf()
 
 
 # --- MeasurementMethodNode ---
@@ -142,9 +142,9 @@ def test_measurement_method_default_typeof():
 def test_measurement_method_typeof_override_validates():
     node = MeasurementMethodNode(dcid="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum")
     assert node.typeOf == "dcid:CensusSurveyEnum"
-    assert "typeOf: dcid:CensusSurveyEnum" in node.mcf
+    assert "typeOf: dcid:CensusSurveyEnum" in node.to_mcf()
 
 
 def test_measurement_method_allows_missing_name():
     node = MeasurementMethodNode(dcid="dcid:MyMethod")
-    assert "name:" not in node.mcf
+    assert "name:" not in node.to_mcf()

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -3,29 +3,29 @@ import pytest
 from pydantic import ValidationError
 
 from dcp_tools.custom_data.models.stat_vars import (
-    StatVarMCFNode,
-    StatVarPeerGroupMCFNode,
+    StatVarNode,
+    StatVarPeerGroupNode,
 )
 from dcp_tools.custom_data.schema_tools import _rows_to_stat_var_nodes
 
 
 def test_search_description_serialization_str_and_list():
-    sv_str = StatVarMCFNode(dcid="dcid:n1", name="Var", searchDescription="A")
+    sv_str = StatVarNode(dcid="dcid:n1", name="Var", searchDescription="A")
     assert 'searchDescription: "A"' in sv_str.mcf
 
-    sv_str = StatVarMCFNode(
+    sv_str = StatVarNode(
         dcid="dcid:n1",
         name="Var",
         searchDescription=["A string, or not", "B string, other"],
     )
     assert 'searchDescription: "A string, or not","B string, other"' in sv_str.mcf
 
-    sv_list = StatVarMCFNode(dcid="dcid:n2", name="Var", searchDescription=["A", "B"])
+    sv_list = StatVarNode(dcid="dcid:n2", name="Var", searchDescription=["A", "B"])
     assert 'searchDescription: "A","B"' in sv_list.mcf
 
 
 def test_statvarnode_strips_whitespace_and_linebreaks():
-    sv = StatVarMCFNode(
+    sv = StatVarNode(
         dcid="dcid:n1\n",
         name="Var \n",
         searchDescription=["First line\n", "Second line "],
@@ -36,7 +36,7 @@ def test_statvarnode_strips_whitespace_and_linebreaks():
 
 
 def test_statvarnode_omits_observation_properties_by_default():
-    sv = StatVarMCFNode(
+    sv = StatVarNode(
         dcid="dcid:n1",
         name="Var",
     )
@@ -44,7 +44,7 @@ def test_statvarnode_omits_observation_properties_by_default():
 
 
 def test_statvarnode_serializes_observation_properties_multi_entity():
-    sv = StatVarMCFNode(
+    sv = StatVarNode(
         dcid="dcid:n1",
         name="Var",
         observationProperties=["dcid:source", "dcid:destination"],
@@ -94,12 +94,10 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
 
 
 def test_observation_properties_normalizes_bare_scalar_and_list():
-    sv = StatVarMCFNode(
-        dcid="dcid:n1", name="Var", observationProperties="originCountry"
-    )
+    sv = StatVarNode(dcid="dcid:n1", name="Var", observationProperties="originCountry")
     assert sv.observationProperties == "dcid:originCountry"
 
-    sv_list = StatVarMCFNode(
+    sv_list = StatVarNode(
         dcid="dcid:n1",
         name="Var",
         observationProperties=["originCountry", "destinationCountry"],
@@ -116,29 +114,27 @@ def test_observation_properties_normalizes_bare_scalar_and_list():
 
 def test_observation_properties_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarMCFNode(dcid="dcid:n1", name="Var", observationProperties="has space")
+        StatVarNode(dcid="dcid:n1", name="Var", observationProperties="has space")
 
 
 def test_relevant_variable_normalizes_bare_scalar_and_list():
-    sv = StatVarMCFNode(dcid="dcid:n1", name="Var", relevantVariable="otherVar")
+    sv = StatVarNode(dcid="dcid:n1", name="Var", relevantVariable="otherVar")
     assert sv.relevantVariable == "dcid:otherVar"
 
-    sv_list = StatVarMCFNode(
-        dcid="dcid:n1", name="Var", relevantVariable=["one", "two"]
-    )
+    sv_list = StatVarNode(dcid="dcid:n1", name="Var", relevantVariable=["one", "two"])
     assert sv_list.relevantVariable == ["dcid:one", "dcid:two"]
 
 
 def test_relevant_variable_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarMCFNode(dcid="dcid:n1", name="Var", relevantVariable="has space")
+        StatVarNode(dcid="dcid:n1", name="Var", relevantVariable="has space")
 
 
-# --- member on StatVarPeerGroupMCFNode is DcidOrListDcid, same normalization ---
+# --- member on StatVarPeerGroupNode is DcidOrListDcid, same normalization ---
 
 
 def test_peer_group_member_normalizes_bare_scalar_and_list():
-    node = StatVarPeerGroupMCFNode(
+    node = StatVarPeerGroupNode(
         dcid="dcid:svpg/x", name="Peers", member=["varOne", "varTwo"]
     )
     assert node.member == ["dcid:varOne", "dcid:varTwo"]
@@ -147,4 +143,4 @@ def test_peer_group_member_normalizes_bare_scalar_and_list():
 
 def test_peer_group_member_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarPeerGroupMCFNode(dcid="dcid:svpg/x", name="Peers", member="has space")
+        StatVarPeerGroupNode(dcid="dcid:svpg/x", name="Peers", member="has space")

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -10,34 +10,34 @@ from dcp_tools.custom_data.schema_tools import _rows_to_stat_var_nodes
 
 
 def test_search_description_serialization_str_and_list():
-    sv_str = StatVarMCFNode(Node="dcid:n1", name="Var", searchDescription="A")
+    sv_str = StatVarMCFNode(dcid="dcid:n1", name="Var", searchDescription="A")
     assert 'searchDescription: "A"' in sv_str.mcf
 
     sv_str = StatVarMCFNode(
-        Node="dcid:n1",
+        dcid="dcid:n1",
         name="Var",
         searchDescription=["A string, or not", "B string, other"],
     )
     assert 'searchDescription: "A string, or not","B string, other"' in sv_str.mcf
 
-    sv_list = StatVarMCFNode(Node="dcid:n2", name="Var", searchDescription=["A", "B"])
+    sv_list = StatVarMCFNode(dcid="dcid:n2", name="Var", searchDescription=["A", "B"])
     assert 'searchDescription: "A","B"' in sv_list.mcf
 
 
 def test_statvarnode_strips_whitespace_and_linebreaks():
     sv = StatVarMCFNode(
-        Node="dcid:n1\n",
+        dcid="dcid:n1\n",
         name="Var \n",
         searchDescription=["First line\n", "Second line "],
     )
-    assert sv.Node == "dcid:n1"
+    assert sv.dcid == "dcid:n1"
     assert sv.name == "Var"
     assert sv.searchDescription == ["First line", "Second line"]
 
 
 def test_statvarnode_omits_observation_properties_by_default():
     sv = StatVarMCFNode(
-        Node="dcid:n1",
+        dcid="dcid:n1",
         name="Var",
     )
     assert "observationProperties" not in sv.mcf
@@ -45,7 +45,7 @@ def test_statvarnode_omits_observation_properties_by_default():
 
 def test_statvarnode_serializes_observation_properties_multi_entity():
     sv = StatVarMCFNode(
-        Node="dcid:n1",
+        dcid="dcid:n1",
         name="Var",
         observationProperties=["dcid:source", "dcid:destination"],
     )
@@ -95,12 +95,12 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
 
 def test_observation_properties_normalizes_bare_scalar_and_list():
     sv = StatVarMCFNode(
-        Node="dcid:n1", name="Var", observationProperties="originCountry"
+        dcid="dcid:n1", name="Var", observationProperties="originCountry"
     )
     assert sv.observationProperties == "dcid:originCountry"
 
     sv_list = StatVarMCFNode(
-        Node="dcid:n1",
+        dcid="dcid:n1",
         name="Var",
         observationProperties=["originCountry", "destinationCountry"],
     )
@@ -116,22 +116,22 @@ def test_observation_properties_normalizes_bare_scalar_and_list():
 
 def test_observation_properties_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarMCFNode(Node="dcid:n1", name="Var", observationProperties="has space")
+        StatVarMCFNode(dcid="dcid:n1", name="Var", observationProperties="has space")
 
 
 def test_relevant_variable_normalizes_bare_scalar_and_list():
-    sv = StatVarMCFNode(Node="dcid:n1", name="Var", relevantVariable="otherVar")
+    sv = StatVarMCFNode(dcid="dcid:n1", name="Var", relevantVariable="otherVar")
     assert sv.relevantVariable == "dcid:otherVar"
 
     sv_list = StatVarMCFNode(
-        Node="dcid:n1", name="Var", relevantVariable=["one", "two"]
+        dcid="dcid:n1", name="Var", relevantVariable=["one", "two"]
     )
     assert sv_list.relevantVariable == ["dcid:one", "dcid:two"]
 
 
 def test_relevant_variable_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarMCFNode(Node="dcid:n1", name="Var", relevantVariable="has space")
+        StatVarMCFNode(dcid="dcid:n1", name="Var", relevantVariable="has space")
 
 
 # --- member on StatVarPeerGroupMCFNode is DcidOrListDcid, same normalization ---
@@ -139,7 +139,7 @@ def test_relevant_variable_rejects_whitespace_bearing_token():
 
 def test_peer_group_member_normalizes_bare_scalar_and_list():
     node = StatVarPeerGroupMCFNode(
-        Node="dcid:svpg/x", name="Peers", member=["varOne", "varTwo"]
+        dcid="dcid:svpg/x", name="Peers", member=["varOne", "varTwo"]
     )
     assert node.member == ["dcid:varOne", "dcid:varTwo"]
     assert "member: dcid:varOne, dcid:varTwo" in node.mcf
@@ -147,4 +147,4 @@ def test_peer_group_member_normalizes_bare_scalar_and_list():
 
 def test_peer_group_member_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarPeerGroupMCFNode(Node="dcid:svpg/x", name="Peers", member="has space")
+        StatVarPeerGroupMCFNode(dcid="dcid:svpg/x", name="Peers", member="has space")

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -11,17 +11,17 @@ from dcp_tools.custom_data.schema_tools import _rows_to_stat_var_nodes
 
 def test_search_description_serialization_str_and_list():
     sv_str = StatVarNode(dcid="dcid:n1", name="Var", searchDescription="A")
-    assert 'searchDescription: "A"' in sv_str.mcf
+    assert 'searchDescription: "A"' in sv_str.to_mcf()
 
     sv_str = StatVarNode(
         dcid="dcid:n1",
         name="Var",
         searchDescription=["A string, or not", "B string, other"],
     )
-    assert 'searchDescription: "A string, or not","B string, other"' in sv_str.mcf
+    assert 'searchDescription: "A string, or not","B string, other"' in sv_str.to_mcf()
 
     sv_list = StatVarNode(dcid="dcid:n2", name="Var", searchDescription=["A", "B"])
-    assert 'searchDescription: "A","B"' in sv_list.mcf
+    assert 'searchDescription: "A","B"' in sv_list.to_mcf()
 
 
 def test_statvarnode_strips_whitespace_and_linebreaks():
@@ -40,7 +40,7 @@ def test_statvarnode_omits_observation_properties_by_default():
         dcid="dcid:n1",
         name="Var",
     )
-    assert "observationProperties" not in sv.mcf
+    assert "observationProperties" not in sv.to_mcf()
 
 
 def test_statvarnode_serializes_observation_properties_multi_entity():
@@ -49,7 +49,7 @@ def test_statvarnode_serializes_observation_properties_multi_entity():
         name="Var",
         observationProperties=["dcid:source", "dcid:destination"],
     )
-    assert "observationProperties: dcid:source, dcid:destination" in sv.mcf
+    assert "observationProperties: dcid:source, dcid:destination" in sv.to_mcf()
 
 
 def test_rows_to_stat_var_nodes_parses_comma_separated():
@@ -57,7 +57,7 @@ def test_rows_to_stat_var_nodes_parses_comma_separated():
         {"Node": ["dcid:n3"], "name": ["Var"], "searchDescription": ["A, B"]}
     )
     nodes = _rows_to_stat_var_nodes(df)
-    mcf = nodes.nodes[0].mcf
+    mcf = nodes.nodes[0].to_mcf()
     assert 'searchDescription: "A","B"' in mcf
 
 
@@ -70,7 +70,7 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists():
         }
     )
     nodes = _rows_to_stat_var_nodes(df)
-    mcf = nodes.nodes[0].mcf
+    mcf = nodes.nodes[0].to_mcf()
     assert 'searchDescription: "A list, comma","second element"' in mcf
 
 
@@ -83,7 +83,7 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
         }
     )
     nodes = _rows_to_stat_var_nodes(df)
-    mcf = nodes.nodes[0].mcf
+    mcf = nodes.nodes[0].to_mcf()
     assert "memberOf: dcid:g/oneId, dcid:g/twoId" in mcf
 
 
@@ -108,7 +108,7 @@ def test_observation_properties_normalizes_bare_scalar_and_list():
     ]
     assert (
         "observationProperties: dcid:originCountry, dcid:destinationCountry"
-        in sv_list.mcf
+        in sv_list.to_mcf()
     )
 
 
@@ -138,7 +138,7 @@ def test_peer_group_member_normalizes_bare_scalar_and_list():
         dcid="dcid:svpg/x", name="Peers", member=["varOne", "varTwo"]
     )
     assert node.member == ["dcid:varOne", "dcid:varTwo"]
-    assert "member: dcid:varOne, dcid:varTwo" in node.mcf
+    assert "member: dcid:varOne, dcid:varTwo" in node.to_mcf()
 
 
 def test_peer_group_member_rejects_whitespace_bearing_token():

--- a/tests/test_models_topics.py
+++ b/tests/test_models_topics.py
@@ -16,26 +16,26 @@ def test_topic_relevant_variable_accepts_bare_statvar_dcid():
     """A bare token matches the plain-Dcid branch and is minted to a plain dcid
     (regression for #126: this used to pass through unvalidated)."""
     node = TopicMCFNode(
-        Node="dcid:topic/T", name="Topic", relevantVariable="myVariable"
+        dcid="dcid:topic/T", name="Topic", relevantVariable="myVariable"
     )
     assert node.relevantVariable == "dcid:myVariable"
 
 
 def test_topic_relevant_variable_accepts_group_dcid():
-    node = TopicMCFNode(Node="dcid:topic/T", name="Topic", relevantVariable="g/MyGroup")
+    node = TopicMCFNode(dcid="dcid:topic/T", name="Topic", relevantVariable="g/MyGroup")
     assert node.relevantVariable == "dcid:g/MyGroup"
 
 
 def test_topic_relevant_variable_accepts_topic_dcid():
     node = TopicMCFNode(
-        Node="dcid:topic/T", name="Topic", relevantVariable="topic/OtherTopic"
+        dcid="dcid:topic/T", name="Topic", relevantVariable="topic/OtherTopic"
     )
     assert node.relevantVariable == "dcid:topic/OtherTopic"
 
 
 def test_topic_relevant_variable_accepts_list():
     node = TopicMCFNode(
-        Node="dcid:topic/T",
+        dcid="dcid:topic/T",
         name="Topic",
         relevantVariable=["varOne", "varTwo"],
     )
@@ -45,7 +45,7 @@ def test_topic_relevant_variable_accepts_list():
 
 def test_topic_node_rejects_missing_slug():
     with pytest.raises(ValidationError):
-        TopicMCFNode(Node="dcid:NotATopic", name="Topic", relevantVariable="var")
+        TopicMCFNode(dcid="dcid:NotATopic", name="Topic", relevantVariable="var")
 
 
 def test_topic_node_rejects_missing_dcid_prefix():
@@ -53,17 +53,17 @@ def test_topic_node_rejects_missing_dcid_prefix():
     unprefixed, since the old hand-rolled pattern checked for the 'topic/' segment
     but never required the 'dcid:' prefix."""
     with pytest.raises(ValidationError):
-        TopicMCFNode(Node="topic/x", name="Topic", relevantVariable="var")
+        TopicMCFNode(dcid="topic/x", name="Topic", relevantVariable="var")
 
 
 def test_topic_node_accepts_dcid_prefixed_slug():
-    node = TopicMCFNode(Node="dcid:topic/x", name="Topic", relevantVariable="var")
-    assert node.Node == "dcid:topic/x"
+    node = TopicMCFNode(dcid="dcid:topic/x", name="Topic", relevantVariable="var")
+    assert node.dcid == "dcid:topic/x"
 
 
 def test_topic_node_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        TopicMCFNode(Node="dcid:topic/ x", name="Topic", relevantVariable="var")
+        TopicMCFNode(dcid="dcid:topic/ x", name="Topic", relevantVariable="var")
 
 
 def test_topic_csv_conversion_rejects_bare_node(tmp_path):
@@ -82,7 +82,7 @@ def test_topic_csv_conversion_rejects_bare_node(tmp_path):
     csv_path.write_text("Node,name,relevantVariable\ndcid:topic/x,T,dcid:v\n")
     nodes = csv_metadata_to_nodes(str(csv_path), node_type="Topic")
 
-    assert nodes.nodes[0].Node == "dcid:topic/x"
+    assert nodes.nodes[0].dcid == "dcid:topic/x"
     assert "Node: dcid:topic/x\n" in nodes.nodes[0].mcf
 
 
@@ -91,4 +91,4 @@ def test_topic_relevant_variable_rejects_whitespace_bearing_token():
     value DcidOrListDcid rejected could still validate via the more-permissive
     Group/Topic branches (which used PlainValidator and never enforced a pattern)."""
     with pytest.raises(ValidationError):
-        TopicMCFNode(Node="dcid:topic/T", name="Topic", relevantVariable="has space")
+        TopicMCFNode(dcid="dcid:topic/T", name="Topic", relevantVariable="has space")

--- a/tests/test_models_topics.py
+++ b/tests/test_models_topics.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from dcp_tools.custom_data.models.topics import TopicMCFNode
+from dcp_tools.custom_data.models.topics import TopicNode
 from dcp_tools.custom_data.schema_tools import csv_metadata_to_nodes
 
 # relevantVariable collapsed to plain DcidOrListDcid in #131. The group and topic members of
@@ -15,26 +15,24 @@ from dcp_tools.custom_data.schema_tools import csv_metadata_to_nodes
 def test_topic_relevant_variable_accepts_bare_statvar_dcid():
     """A bare token matches the plain-Dcid branch and is minted to a plain dcid
     (regression for #126: this used to pass through unvalidated)."""
-    node = TopicMCFNode(
-        dcid="dcid:topic/T", name="Topic", relevantVariable="myVariable"
-    )
+    node = TopicNode(dcid="dcid:topic/T", name="Topic", relevantVariable="myVariable")
     assert node.relevantVariable == "dcid:myVariable"
 
 
 def test_topic_relevant_variable_accepts_group_dcid():
-    node = TopicMCFNode(dcid="dcid:topic/T", name="Topic", relevantVariable="g/MyGroup")
+    node = TopicNode(dcid="dcid:topic/T", name="Topic", relevantVariable="g/MyGroup")
     assert node.relevantVariable == "dcid:g/MyGroup"
 
 
 def test_topic_relevant_variable_accepts_topic_dcid():
-    node = TopicMCFNode(
+    node = TopicNode(
         dcid="dcid:topic/T", name="Topic", relevantVariable="topic/OtherTopic"
     )
     assert node.relevantVariable == "dcid:topic/OtherTopic"
 
 
 def test_topic_relevant_variable_accepts_list():
-    node = TopicMCFNode(
+    node = TopicNode(
         dcid="dcid:topic/T",
         name="Topic",
         relevantVariable=["varOne", "varTwo"],
@@ -45,7 +43,7 @@ def test_topic_relevant_variable_accepts_list():
 
 def test_topic_node_rejects_missing_slug():
     with pytest.raises(ValidationError):
-        TopicMCFNode(dcid="dcid:NotATopic", name="Topic", relevantVariable="var")
+        TopicNode(dcid="dcid:NotATopic", name="Topic", relevantVariable="var")
 
 
 def test_topic_node_rejects_missing_dcid_prefix():
@@ -53,17 +51,17 @@ def test_topic_node_rejects_missing_dcid_prefix():
     unprefixed, since the old hand-rolled pattern checked for the 'topic/' segment
     but never required the 'dcid:' prefix."""
     with pytest.raises(ValidationError):
-        TopicMCFNode(dcid="topic/x", name="Topic", relevantVariable="var")
+        TopicNode(dcid="topic/x", name="Topic", relevantVariable="var")
 
 
 def test_topic_node_accepts_dcid_prefixed_slug():
-    node = TopicMCFNode(dcid="dcid:topic/x", name="Topic", relevantVariable="var")
+    node = TopicNode(dcid="dcid:topic/x", name="Topic", relevantVariable="var")
     assert node.dcid == "dcid:topic/x"
 
 
 def test_topic_node_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        TopicMCFNode(dcid="dcid:topic/ x", name="Topic", relevantVariable="var")
+        TopicNode(dcid="dcid:topic/ x", name="Topic", relevantVariable="var")
 
 
 def test_topic_csv_conversion_rejects_bare_node(tmp_path):
@@ -91,4 +89,4 @@ def test_topic_relevant_variable_rejects_whitespace_bearing_token():
     value DcidOrListDcid rejected could still validate via the more-permissive
     Group/Topic branches (which used PlainValidator and never enforced a pattern)."""
     with pytest.raises(ValidationError):
-        TopicMCFNode(dcid="dcid:topic/T", name="Topic", relevantVariable="has space")
+        TopicNode(dcid="dcid:topic/T", name="Topic", relevantVariable="has space")

--- a/tests/test_models_topics.py
+++ b/tests/test_models_topics.py
@@ -38,7 +38,7 @@ def test_topic_relevant_variable_accepts_list():
         relevantVariable=["varOne", "varTwo"],
     )
     assert node.relevantVariable == ["dcid:varOne", "dcid:varTwo"]
-    assert "relevantVariable: dcid:varOne, dcid:varTwo" in node.mcf
+    assert "relevantVariable: dcid:varOne, dcid:varTwo" in node.to_mcf()
 
 
 def test_topic_node_rejects_missing_slug():
@@ -81,7 +81,7 @@ def test_topic_csv_conversion_rejects_bare_node(tmp_path):
     nodes = csv_metadata_to_nodes(str(csv_path), node_type="Topic")
 
     assert nodes.nodes[0].dcid == "dcid:topic/x"
-    assert "Node: dcid:topic/x\n" in nodes.nodes[0].mcf
+    assert "Node: dcid:topic/x\n" in nodes.nodes[0].to_mcf()
 
 
 def test_topic_relevant_variable_rejects_whitespace_bearing_token():

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -54,18 +54,18 @@ def test_single_level_group():
         "Should create exactly one group node for single-level path"
     )
     group = groups[0]
-    assert group.Node == "dcid:example.org/g/category"
+    assert group.dcid == "dcid:example.org/g/category"
     assert group.name == "Category"
     assert group.specializationOf == "dcid:dc/g/Root"
 
-    assert resolved["Category"] == group.Node
+    assert resolved["Category"] == group.dcid
 
 
 def test_multi_level_group():
     resolved, groups = resolve_group_paths(["A/B/C"], group_namespace="ns")
 
     assert len(groups) == 3
-    slug_map = {g.Node.split("/")[-1]: g for g in groups}
+    slug_map = {g.dcid.split("/")[-1]: g for g in groups}
 
     # Check each group's parent linkage
     assert slug_map["A"].specializationOf == "dcid:dc/g/Root"
@@ -81,7 +81,7 @@ def test_duplicate_paths_do_not_create_duplicates():
 
     # Expect three unique group nodes: X, Y, Z
     assert len(groups) == 3
-    slugs = sorted(g.Node for g in groups)
+    slugs = sorted(g.dcid for g in groups)
     assert "dcid:ns2/g/X" in slugs
     assert "dcid:ns2/g/Y" in slugs
     assert "dcid:ns2/g/Z" in slugs
@@ -108,7 +108,7 @@ def test_csv_metadata_to_nodes_parse_groups(tmp_path):
         str(csv_path), parse_groups=True, group_namespace="ns"
     )
 
-    assert [n.Node for n in nodes.nodes] == [
+    assert [n.dcid for n in nodes.nodes] == [
         "dcid:n1",
         "dcid:n2",
         "dcid:ns/g/economic",
@@ -130,7 +130,7 @@ def test_resolve_group_paths_cleans_raw_path():
     )
 
     assert len(groups) == 2
-    slugs = [g.Node for g in groups]
+    slugs = [g.dcid for g in groups]
     assert slugs == ["dcid:ns/g/economic", "dcid:ns/g/employment"]
     assert resolved["-Economic// Employment / "] == "dcid:ns/g/employment"
 
@@ -155,7 +155,7 @@ def test_resolve_group_paths_drops_whitespace_only_segments(raw, expected):
     """
     resolved, groups = resolve_group_paths([raw], group_namespace="ns")
 
-    assert [g.Node for g in groups] == expected
+    assert [g.dcid for g in groups] == expected
     assert resolved[raw] == expected[-1]
 
 
@@ -229,7 +229,7 @@ def test_csv_metadata_to_nodes_parse_groups_remove_works_on_group_node(tmp_path)
     looks the node up via `_pos`) on a group node from a parse_groups=True result must
     work — the same class of index bug #126 fixed in `rename_variable`."""
     content = (
-        "Node,name,typeOf,memberOf\n"
+        "dcid,name,typeOf,memberOf\n"
         "dcid:n1,Name1,dcid:StatisticalVariable,Economic/Employment\n"
     )
     csv_path = tmp_path / "test.csv"
@@ -240,7 +240,7 @@ def test_csv_metadata_to_nodes_parse_groups_remove_works_on_group_node(tmp_path)
     )
 
     nodes.remove("dcid:ns/g/employment")
-    assert [n.Node for n in nodes.nodes] == ["dcid:n1", "dcid:ns/g/economic"]
+    assert [n.dcid for n in nodes.nodes] == ["dcid:n1", "dcid:ns/g/economic"]
     # The index was kept consistent, not merely the list.
     assert nodes._expect_present("dcid:ns/g/economic") == 1
 

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -1,9 +1,9 @@
 import pytest
 
-from dcp_tools.custom_data.models.mcf import MCFNodes
+from dcp_tools.custom_data.models.mcf import Nodes
 from dcp_tools.custom_data.models.stat_vars import (
-    StatVarGroupMCFNode,
-    StatVarMCFNode,
+    StatVarGroupNode,
+    StatVarNode,
 )
 from dcp_tools.custom_data.schema_tools import (
     csv_metadata_to_nodes,
@@ -37,14 +37,14 @@ def test_csv_metadata_to_nodes(tmp_path):
         assert hasattr(node, "searchDescription")
 
 
-def get_group_nodes(nodes: MCFNodes) -> list[StatVarGroupMCFNode]:
-    """Extract all StatVarGroupMCFNode instances from MCFNodes."""
-    return [n for n in nodes.nodes if isinstance(n, StatVarGroupMCFNode)]
+def get_group_nodes(nodes: Nodes) -> list[StatVarGroupNode]:
+    """Extract all StatVarGroupNode instances from Nodes."""
+    return [n for n in nodes.nodes if isinstance(n, StatVarGroupNode)]
 
 
-def get_statvar_nodes(nodes: MCFNodes) -> list[StatVarMCFNode]:
-    """Extract all StatVarMCFNode instances from MCFNodes."""
-    return [n for n in nodes.nodes if isinstance(n, StatVarMCFNode)]
+def get_statvar_nodes(nodes: Nodes) -> list[StatVarNode]:
+    """Extract all StatVarNode instances from Nodes."""
+    return [n for n in nodes.nodes if isinstance(n, StatVarNode)]
 
 
 def test_single_level_group():
@@ -150,7 +150,7 @@ def test_resolve_group_paths_drops_whitespace_only_segments(raw, expected):
     `.strip("/ ")` does not remove a tab or newline, so such a segment used to
     survive and `to_camelCase` reduced it to an empty slug, minting a group whose
     dcid ends in a bare "g/". These paths reached the resolver through
-    `StatVarMCFNode(memberOf=...)` before groups were resolved ahead of node
+    `StatVarNode(memberOf=...)` before groups were resolved ahead of node
     construction, and were cleaned on the way in.
     """
     resolved, groups = resolve_group_paths([raw], group_namespace="ns")
@@ -225,7 +225,7 @@ def test_csv_metadata_to_nodes_parse_groups_leaves_segmentless_memberof_unset(tm
 
 def test_csv_metadata_to_nodes_parse_groups_remove_works_on_group_node(tmp_path):
     """Regression test: csv_metadata_to_nodes used to append group nodes directly to
-    `nodes.nodes`, bypassing `MCFNodes.add` and leaving `_pos` stale. `.remove()` (which
+    `nodes.nodes`, bypassing `Nodes.add` and leaving `_pos` stale. `.remove()` (which
     looks the node up via `_pos`) on a group node from a parse_groups=True result must
     work — the same class of index bug #126 fixed in `rename_variable`."""
     content = (

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -568,4 +568,4 @@ def test_get_bucket_files_multiple_types():
     expected_df = pd.DataFrame({"a": [1], "b": [2]})
     pd.testing.assert_frame_equal(result["a.csv"], expected_df)
     assert result["b.json"] == {"x": 1}
-    assert result["c.mcf"].nodes[0].Node == "dcid:n"
+    assert result["c.mcf"].nodes[0].dcid == "dcid:n"


### PR DESCRIPTION
Part of https://github.com/ONEcampaign/dcp-tools/issues/137

I'm splitting into two PRs due to the amount of renaming/refactoring to make review easier. This PR addresses:
- Rename `MCFNode` -> `Node`
- Combine the duplicate `Node` and `dcid` properties
- Rename `mcf()` to `to_mcf()`
- Update CustomDataManager builders (done for the fields changed so far)

A follow-up PR will address:
- Convert fields to snake_case
- Update CustomDataManager builders (to be completed)
