### PR TITLE
Refactor to use snake_case across the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,20 @@
   is unchanged.
 - `rename_variable` normalizes a bare `old_name`/`new_name` to `dcid:<token>`, the same rule
   `add_variable_to_mcf` applies to `Node`.
+- **Renamed the node model classes to drop the `MCF` qualifier**, treating MCF as one
+  serialization of a Data Commons graph node rather than the model's identity: `MCFNode` →
+  `Node`, `MCFNodes` → `Nodes`, and every subclass.
+- **Collapsed a node's duplicate `Node`/`dcid` properties into a single `dcid`.** A node's
+  identifier is now `node.dcid`, which still serializes to the mandatory `Node:` line in MCF;
+  the separate optional `dcid` property is removed.
+- **`Node.mcf` is now the `Node.to_mcf()` method** (and `Nodes.to_mcf()`), matching the
+  `to_dict()`/`to_json()` convention and leaving room for a future `to_jsonld()`.
+- **The Python API is now snake_case throughout.** Node and `Config` attributes,
+  `CustomDataManager` builder keyword arguments, and the `set_*` methods use snake_case
+  (`node.type_of`, `add_variable_to_mcf(measured_property=...)`, `set_import_name(...)`). The
+  serialized `config.json` and MCF wire format are unchanged: camelCase keys are preserved via
+  pydantic aliases (`alias_generator=to_camel`). CSV column headers (e.g. `memberOf`) keep the
+  Data Commons camelCase convention.
 
 ### Fixed
 - `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
@@ -142,6 +156,13 @@
   the MCF as-is.
 - Replace direct calls to `build_stat_var_groups_from_strings` with either
   `csv_metadata_to_nodes(..., parse_groups=True, group_namespace=...)` or `resolve_group_paths`.
+- Drop the `MCF` infix from node model class names (`MCFNode` → `Node`, `StatVarMCFNode` →
+  `StatVarNode`, and so on) and the `MCFNodes` container → `Nodes`.
+- Read a node's id via `.dcid` (not `.Node`); the separate `dcid` property is gone.
+- Call `node.to_mcf()` instead of `node.mcf`.
+- Convert builder keyword arguments, node/`Config` attributes and `set_*` methods to
+  snake_case (`measuredProperty` → `measured_property`, `typeOf` → `type_of`, `set_importName`
+  → `set_import_name`, and so on). The exported `config.json` and MCF are unchanged.
 
 ## [0.1.1] - 2026-02-19
 

--- a/README.md
+++ b/README.md
@@ -55,20 +55,20 @@ manager.add_input_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
     provenance="ONEClimateFinance",
     data=data,
-    columnMappings={
+    column_mappings={
         "observationAbout": "country",
         "date": "year",
         "variable": "variable",
         "value": "value",
     },
-    observationProperties={"unit": "USDollar"},
+    observation_properties={"unit": "USDollar"},
 )
 
 manager.add_variable_to_mcf(
     dcid="climateFinanceProvidedCommitments",
     name="Climate finance commitments (bilateral)",
     description="Funding committed for climate adaptation and mitigation projects",
-    statType="dcid:measuredValue",
+    stat_type="dcid:measuredValue",
 )
 
 out_dir = Path("export/climate_finance")

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -92,6 +92,16 @@
   `CLOUD_SERVICE_REGION`, `CLOUD_RUN_SERVICE_NAME`, and `DATACOMMONS_SERVICE_IMAGE`.
 - Added an `imports` argument on `run_data_load` and a matching `--imports` flag on the
   `dataload` CLI command, to trigger a load of specific imports rather than all imports.
+- **Breaking:** renamed the node model classes to drop the `MCF` qualifier — `MCFNode` →
+  `Node`, `MCFNodes` → `Nodes`, and every subclass. MCF is now treated as one serialization
+  of a Data Commons graph node.
+- **Breaking:** a node's identifier is now a single `dcid` property — the duplicate
+  `Node`/`dcid` pair is collapsed. Access it via `node.dcid`; it still serializes to the
+  `Node:` line in MCF.
+- **Breaking:** `Node.mcf` is now the `Node.to_mcf()` method.
+- **Breaking:** the Python API is snake_case throughout — node/`Config` attributes, builder
+  keyword arguments and the `set_*` methods. Serialisation still uses camelCase using
+  pydantic's `alias_generator=to_camel`.
 
 ## v0.1.0 (in development)
 - Initial release of the `dcp-tools` package for external preview and testing

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -65,11 +65,11 @@ manager.add_input_file(
     "climate-finance/commitments.csv",
     provenance="ONEClimateFinance",
     data=commitments,
-    columnMappings={
-        "observationAbout": "country",
-        "date": "year",
-        "variable": "variable",
-        "value": "value",
+    column_mappings={
+      "observationAbout": "country",
+      "date": "year",
+      "variable": "variable",
+      "value": "value",
     },
 )
 ```
@@ -126,20 +126,20 @@ flows = pd.DataFrame({
 manager.add_variable_to_mcf(
     dcid="climateFinanceProvidedFlows",
     name="Climate finance provided (bilateral flow)",
-    statType="dcid:measuredValue",
-    observationProperties=["dcid:providerCountry", "dcid:recipientCountry"],
+    stat_type="dcid:measuredValue",
+    observation_properties=["dcid:providerCountry", "dcid:recipientCountry"],
 )
 
 manager.add_input_file(
     "climate-finance/flows.csv",
     provenance="ONEClimateFinance",
     data=flows,
-    columnMappings={
-        "variable": "variable",
-        "date": "year",
-        "value": "value",
-        "custom:providerCountry": "provider",
-        "custom:recipientCountry": "recipient",
+    column_mappings={
+      "variable": "variable",
+      "date": "year",
+      "value": "value",
+      "custom:providerCountry": "provider",
+      "custom:recipientCountry": "recipient",
     },
 )
 ```

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -111,7 +111,7 @@ manager.add_input_file(
     file_name="climate_finance/one_cf_provider_commitments.csv",
     provenance="ONEClimateFinance",
     data=data,
-    columnMappings={
+    column_mappings={
         "observationAbout": "country",
         "date": "year",
         "variable": "variable",
@@ -156,8 +156,8 @@ manager.add_variable_to_mcf(
     name="Climate finance provided (commitments)",
     description="Bilateral climate finance commitments reported by the provider country.",
     provenance="ONEClimateFinance",
-    populationType="Thing",
-    measuredProperty="amount",
+    population_type="Thing",
+    measured_property="amount",
 )
 ```
 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -100,13 +100,13 @@ manager.add_input_file(
     file_name="climate_finance_commitments.csv",
     provenance="ONEClimateFinance",
     data=df,
-    columnMappings={
+    column_mappings={
         "observationAbout": "country",
         "date": "year",
         "variable": "variable",
         "value": "value",
     },
-    observationProperties={"unit": "USDollar"},
+    observation_properties={"unit": "USDollar"},
 )
 ```
 
@@ -126,7 +126,7 @@ Data is optional at registration:
 manager.add_input_file(
     file_name="climate_finance_disbursements.csv",
     provenance="ONEClimateFinance",
-    columnMappings={
+    column_mappings={
         "observationAbout": "country",
         "date": "year",
         "variable": "variable",
@@ -161,7 +161,7 @@ manager.add_input_file(
     file_name="bilateral_climate_finance_flows.csv",
     provenance="ONEClimateFinance",
     data=flows,
-    columnMappings={
+    column_mappings={
         "variable": "variable",
         "date": "year",
         "value": "value",
@@ -174,8 +174,8 @@ manager.add_variable_to_mcf(
     dcid="climateFinanceBilateralFlow",
     name="Climate finance bilateral flow",
     description="Bilateral climate finance commitments between a provider and a recipient country.",
-    statType="dcid:measuredValue",
-    observationProperties=["dcid:providerCountry", "dcid:recipientCountry"],
+    stat_type="dcid:measuredValue",
+    observation_properties=["dcid:providerCountry", "dcid:recipientCountry"],
 )
 ```
 
@@ -219,9 +219,9 @@ manager.add_variable_to_mcf(
     dcid="climateFinanceProvidedCommitments",
     name="Climate finance committed",
     description="Bilateral climate finance commitments provided by a country.",
-    statType="dcid:measuredValue",
-    populationType="Country",
-    measuredProperty="amount",
+    stat_type="dcid:measuredValue",
+    population_type="Country",
+    measured_property="amount",
 )
 ```
 
@@ -236,15 +236,15 @@ manager.add_property(
     dcid="providerCountry",
     name="provider country",
     description="The country providing climate finance in a bilateral flow.",
-    domainIncludes="StatisticalVariable",
-    rangeIncludes="Country",
+    domain_includes="StatisticalVariable",
+    range_includes="Country",
 )
 manager.add_property(
     dcid="recipientCountry",
     name="recipient country",
     description="The country receiving climate finance in a bilateral flow.",
-    domainIncludes="StatisticalVariable",
-    rangeIncludes="Country",
+    domain_includes="StatisticalVariable",
+    range_includes="Country",
 )
 ```
 
@@ -259,7 +259,7 @@ manager.add_entity_type(
     dcid="ClimateFinanceProgram",
     name="Climate finance program",
     description="A named climate finance program or initiative tracked by ONE.",
-    includedIn="ONEClimateFinance",
+    included_in="ONEClimateFinance",
 )
 ```
 
@@ -275,7 +275,7 @@ Add a top-level StatVarGroup for all of an organization's custom variables:
 manager.add_variable_group_to_mcf(
     dcid="dcid:one/g/ONEData",
     name="ONE Data",
-    specializationOf="dcid:dc/g/Root",
+    specialization_of="dcid:dc/g/Root",
 )
 ```
 
@@ -377,7 +377,7 @@ Vertical specs tell the importer which top-level groups to file matching StatVar
 `groupStatVarsByProperty` is set. Skip this unless you're using that setting.
 
 ```python
-manager.set_groupStatVarsByProperty(True)
+manager.set_group_stat_vars_by_property(True)
 manager.add_vertical_spec(
     verticals=["ClimateFinanceVertical"],
     population_type="Country",

--- a/src/dcp_tools/custom_data/config_utils.py
+++ b/src/dcp_tools/custom_data/config_utils.py
@@ -25,27 +25,27 @@ def iter_config_files(directory: Path, pattern: str = "config.json") -> Iterator
 def _merge_simple_attrs(existing: Config, new: Config, policy: DuplicatePolicy) -> None:
     """Merge simple attributes that are booleans, strings, or None."""
     for attr in (
-        "importName",
-        "includeInputSubdirs",
-        "groupStatVarsByProperty",
-        "defaultCustomRootStatVarGroupName",
-        "customIdNamespace",
-        "customSvgPrefix",
-        "verticalSpecsFile",
+        "import_name",
+        "include_input_subdirs",
+        "group_stat_vars_by_property",
+        "default_custom_root_stat_var_group_name",
+        "custom_id_namespace",
+        "custom_svg_prefix",
+        "vertical_specs_file",
     ):
         _merge_attribute(existing, new, attr, policy)
 
     _merge_sequence_attribute(
         existing=existing,
         new=new,
-        attribute="svHierarchyPropsBlocklist",
+        attribute="sv_hierarchy_props_blocklist",
         policy=policy,
     )
 
     _merge_sequence_attribute(
         existing=existing,
         new=new,
-        attribute="dataDownloadUrl",
+        attribute="data_download_url",
         policy=policy,
     )
 
@@ -70,24 +70,24 @@ def _merge_input_files(existing: Config, new: Config, policy: DuplicatePolicy) -
     replaces, ``"ignore"`` and equal entries are skipped.
     """
     existing_by_key: dict[str, int] = {}
-    for i, e in enumerate(existing.inputFiles):
+    for i, e in enumerate(existing.input_files):
         k = e.filename or e.pattern
         if k is not None:
             existing_by_key[k] = i
 
-    for entry in new.inputFiles:
+    for entry in new.input_files:
         key = entry.filename or entry.pattern
         if key is None:
             # Should not happen: InputFile enforces filename XOR pattern.
             continue
         if key not in existing_by_key:
             logger.info(f"Added input file '{key}'")
-            existing.inputFiles.append(entry)
-            existing_by_key[key] = len(existing.inputFiles) - 1
+            existing.input_files.append(entry)
+            existing_by_key[key] = len(existing.input_files) - 1
             continue
 
         idx = existing_by_key[key]
-        tgt = existing.inputFiles[idx]
+        tgt = existing.input_files[idx]
         if tgt == entry:
             continue
 
@@ -98,7 +98,7 @@ def _merge_input_files(existing: Config, new: Config, policy: DuplicatePolicy) -
             policy=policy,
         )
         if policy == "override":
-            existing.inputFiles[idx] = entry
+            existing.input_files[idx] = entry
 
 
 def _merge_attribute(
@@ -180,7 +180,7 @@ def merge_configs_from_directory(
             values are encountered.
 
     """
-    base = Config(inputFiles=[])
+    base = Config(input_files=[])
     for path in iter_config_files(Path(directory)):
         logger.info(f"Merging config file {path}")
         config = Config.from_json(str(path))

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -113,10 +113,10 @@ class CustomDataManager:
     >>> dc_manager.add_property(
     >>>     dcid="myProp",
     >>>     name="My Property",
-    >>>     domainIncludes="Person",
-    >>>     rangeIncludes="Number",
+    >>>     domain_includes="Person",
+    >>>     range_includes="Number",
     >>> )
-    >>> dc_manager.add_unit(dcid="USD", name="US Dollar", shortDisplayName="$")
+    >>> dc_manager.add_unit(dcid="USD", name="US Dollar", short_display_name="$")
     >>> dc_manager.add_measurement_method(dcid="MyCensus")
 
     You can also add variables for export to an MCF file using a CSV file. The CSV file should
@@ -128,7 +128,7 @@ class CustomDataManager:
     >>>    file_name="input_file.csv",
     >>>    provenance="Provenance Name",
     >>>    data=df,
-    >>>    columnMappings={"observationAbout": "Country", "date": "Year", "value": "Value"}
+    >>>    column_mappings={"observationAbout": "Country", "date": "Year", "value": "Value"}
     >>>    )
 
     For multi-entity observations, map each dimension with a ``custom:<name>`` key, and declare the
@@ -137,7 +137,7 @@ class CustomDataManager:
     >>>    file_name="input_file.csv",
     >>>    provenance="Provenance Name",
     >>>    data=df,
-    >>>    columnMappings={
+    >>>    column_mappings={
     >>>        "variable": "Var",
     >>>        "date": "Year",
     >>>        "value": "Value",
@@ -148,7 +148,7 @@ class CustomDataManager:
     >>> dc_manager.add_variable_to_mcf(
     >>>    dcid="dcid:var/StatVar",
     >>>    name="Variable Name",
-    >>>    observationProperties=["dcid:originCountry", "dcid:destinationCountry"],
+    >>>    observation_properties=["dcid:originCountry", "dcid:destinationCountry"],
     >>> )
 
     It isn't a requirement to add the data at the same time as the input file. You can add the data
@@ -162,8 +162,8 @@ class CustomDataManager:
 
     To set the includeInputSubdirs and the groupStatVarsByProperty fields of the config, use
     the set_includeInputSubdirs and set_groupStatVarsByProperty methods
-    >>> dc_manager.set_includeInputSubdirs(True)
-    >>> dc_manager.set_groupStatVarsByProperty(True)
+    >>> dc_manager.set_include_input_subdirs(True)
+    >>> dc_manager.set_group_stat_vars_by_property(True)
 
     Once you are ready to export the config and the data, use the exporter methods.
     Note that while the config is being edited (provenances, variables, input files being added)
@@ -199,7 +199,7 @@ class CustomDataManager:
         """
 
         self._config = (
-            Config.from_json(config_file) if config_file else Config(inputFiles=[])
+            Config.from_json(config_file) if config_file else Config(input_files=[])
         )
 
         if mcf_files:
@@ -219,25 +219,25 @@ class CustomDataManager:
         self._vertical_specs: list[VerticalSpec] = []
 
     def __repr__(self) -> str:
-        input_files_count = len(self._config.inputFiles)
+        input_files_count = len(self._config.input_files)
 
         all_nodes = [n for nodes in self._mcf_nodes.values() for n in nodes.nodes]
-        sources_count = sum(1 for n in all_nodes if n.typeOf == "dcid:Source")
-        provenances_count = sum(1 for n in all_nodes if n.typeOf == "dcid:Provenance")
+        sources_count = sum(1 for n in all_nodes if n.type_of == "dcid:Source")
+        provenances_count = sum(1 for n in all_nodes if n.type_of == "dcid:Provenance")
         variables_count = len(all_nodes) - sources_count - provenances_count
 
         dataframes_count = len(self._data)
         vertical_specs_count = len(self._vertical_specs)
 
-        import_name = self._config.importName
-        include_input_subdirs = self._config.includeInputSubdirs
-        group_statvars = self._config.groupStatVarsByProperty
-        root_group_name = self._config.defaultCustomRootStatVarGroupName
-        namespace = self._config.customIdNamespace
-        svg_prefix = self._config.customSvgPrefix
-        blocklist = self._config.svHierarchyPropsBlocklist
-        data_download_url = self._config.dataDownloadUrl
-        vertical_specs_file = self._config.verticalSpecsFile
+        import_name = self._config.import_name
+        include_input_subdirs = self._config.include_input_subdirs
+        group_statvars = self._config.group_stat_vars_by_property
+        root_group_name = self._config.default_custom_root_stat_var_group_name
+        namespace = self._config.custom_id_namespace
+        svg_prefix = self._config.custom_svg_prefix
+        blocklist = self._config.sv_hierarchy_props_blocklist
+        data_download_url = self._config.data_download_url
+        vertical_specs_file = self._config.vertical_specs_file
 
         return (
             f"<CustomDataManager config: "
@@ -256,35 +256,35 @@ class CustomDataManager:
             f"verticalSpecsFile={vertical_specs_file}>"
         )
 
-    def set_importName(self, name: str | None) -> CustomDataManager:
+    def set_import_name(self, name: str | None) -> CustomDataManager:
         """Set the import name in the config.
 
         The import name is used by the platform prep job to name the JSON-LD output
         directory. Pass ``None`` to unset it; ``export_config`` then defaults it to the
         export directory name.
         """
-        self._config.importName = name
+        self._config.import_name = name
         return self
 
-    def set_includeInputSubdirs(self, set_value: bool) -> CustomDataManager:
+    def set_include_input_subdirs(self, set_value: bool) -> CustomDataManager:
         """Set the includeInputSubdirs attribute of the config"""
-        self._config.includeInputSubdirs = set_value
+        self._config.include_input_subdirs = set_value
         return self
 
-    def set_groupStatVarsByProperty(self, set_value: bool) -> CustomDataManager:
+    def set_group_stat_vars_by_property(self, set_value: bool) -> CustomDataManager:
         """Set the groupStatVarsByProperty attribute of the config"""
-        self._config.groupStatVarsByProperty = set_value
+        self._config.group_stat_vars_by_property = set_value
         return self
 
-    def set_defaultCustomRootStatVarGroupName(
+    def set_default_custom_root_stat_var_group_name(
         self, name: str | None
     ) -> CustomDataManager:
         """Set the default custom root StatVarGroup display name in the config."""
 
-        self._config.defaultCustomRootStatVarGroupName = name
+        self._config.default_custom_root_stat_var_group_name = name
         return self
 
-    def set_customIdNamespace(
+    def set_custom_id_namespace(
         self, namespace: str | None, *, update_svg_prefix: bool = True
     ) -> CustomDataManager:
         """Set the namespace for generated custom Statistical Variables and groups.
@@ -296,20 +296,20 @@ class CustomDataManager:
                 Defaults to ``True``.
         """
 
-        self._config.customIdNamespace = namespace
+        self._config.custom_id_namespace = namespace
 
-        if update_svg_prefix and namespace and not self._config.customSvgPrefix:
-            self._config.customSvgPrefix = f"{namespace}/g/"
+        if update_svg_prefix and namespace and not self._config.custom_svg_prefix:
+            self._config.custom_svg_prefix = f"{namespace}/g/"
 
         return self
 
-    def set_customSvgPrefix(self, prefix: str | None) -> CustomDataManager:
+    def set_custom_svg_prefix(self, prefix: str | None) -> CustomDataManager:
         """Set the prefix used for generated custom StatVarGroup IDs."""
 
-        self._config.customSvgPrefix = prefix
+        self._config.custom_svg_prefix = prefix
         return self
 
-    def set_svHierarchyPropsBlocklist(
+    def set_sv_hierarchy_props_blocklist(
         self, blocklist: list[str] | None
     ) -> CustomDataManager:
         """Set the StatVar hierarchy property blocklist.
@@ -319,7 +319,7 @@ class CustomDataManager:
         """
 
         if blocklist is None:
-            self._config.svHierarchyPropsBlocklist = None
+            self._config.sv_hierarchy_props_blocklist = None
         else:
             seen: set[str] = set()
             deduped: list[str] = []
@@ -327,33 +327,33 @@ class CustomDataManager:
                 if prop not in seen:
                     seen.add(prop)
                     deduped.append(prop)
-            self._config.svHierarchyPropsBlocklist = deduped
+            self._config.sv_hierarchy_props_blocklist = deduped
         return self
 
-    def set_dataDownloadUrl(self, urls: list[str] | None) -> CustomDataManager:
+    def set_data_download_url(self, urls: list[str] | None) -> CustomDataManager:
         """Set the data download URLs in the config.
 
         Replaces any existing list. Pass ``None`` to unset the field (absent from the
         exported ``config.json``).
         """
-        self._config.dataDownloadUrl = urls
+        self._config.data_download_url = urls
         return self
 
-    def add_dataDownloadUrl(self, url: str) -> CustomDataManager:
+    def add_data_download_url(self, url: str) -> CustomDataManager:
         """Append a single data download URL to the config.
 
         Initializes the list to ``[url]`` when the field is unset.
         """
-        existing = self._config.dataDownloadUrl or []
-        self._config.dataDownloadUrl = [*existing, url]
+        existing = self._config.data_download_url or []
+        self._config.data_download_url = [*existing, url]
         return self
 
-    def set_verticalSpecsFile(self, file_name: str | None) -> CustomDataManager:
+    def set_vertical_specs_file(self, file_name: str | None) -> CustomDataManager:
         """Set the vertical-specs filename in the config.
 
         Plain filename string (no ``.json``-suffix enforcement). Pass ``None`` to unset.
         """
-        self._config.verticalSpecsFile = file_name
+        self._config.vertical_specs_file = file_name
         return self
 
     def add_vertical_spec(
@@ -383,15 +383,15 @@ class CustomDataManager:
         """
         self._vertical_specs.append(
             VerticalSpec(
-                populationType=population_type,
-                measuredProperties=measured_properties or [],
+                population_type=population_type,
+                measured_properties=measured_properties or [],
                 verticals=verticals,
             )
         )
         if file_name is not None:
-            self._config.verticalSpecsFile = file_name
-        elif self._config.verticalSpecsFile is None:
-            self._config.verticalSpecsFile = DEFAULT_VERTICAL_SPECS_NAME
+            self._config.vertical_specs_file = file_name
+        elif self._config.vertical_specs_file is None:
+            self._config.vertical_specs_file = DEFAULT_VERTICAL_SPECS_NAME
         return self
 
     def add_source(
@@ -401,7 +401,7 @@ class CustomDataManager:
         url: str,
         description: str | None = None,
         license: str | None = None,
-        isPartOf: str | None = None,
+        is_part_of: str | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_PROVENANCE_MCF_NAME,
@@ -418,7 +418,7 @@ class CustomDataManager:
             url: URL of the data source.
             description: Optional human-readable description. (Optional)
             license: Optional license information. (Optional)
-            isPartOf: Optional DCID of a parent source. (Optional)
+            is_part_of: Optional DCID of a parent source. (Optional)
             additional_properties: Additional MCF properties, passed as a dictionary
                 with the target property as key. (Optional)
             override: If True, overwrite the existing node if it exists. Defaults to False.
@@ -451,15 +451,15 @@ class CustomDataManager:
         source: str,
         description: str | None = None,
         license: str | None = None,
-        licenseType: str | None = None,
-        lastDataRefreshDate: str | None = None,
-        nextDataRefreshDate: str | None = None,
-        nextSourceReleaseDate: str | None = None,
-        sourceReleaseFrequency: str | None = None,
-        earliestObservationDate: str | None = None,
-        latestObservationDate: str | None = None,
+        license_type: str | None = None,
+        last_data_refresh_date: str | None = None,
+        next_data_refresh_date: str | None = None,
+        next_source_release_date: str | None = None,
+        source_release_frequency: str | None = None,
+        earliest_observation_date: str | None = None,
+        latest_observation_date: str | None = None,
         curator: str | None = None,
-        isPartOf: str | None = None,
+        is_part_of: str | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_PROVENANCE_MCF_NAME,
@@ -479,15 +479,15 @@ class CustomDataManager:
                 ``dcid:source/<source>``; ``dcid:``-prefixed → verbatim.
             description: Optional human-readable description. (Optional)
             license: Optional license information. (Optional)
-            licenseType: Optional license type. (Optional)
-            lastDataRefreshDate: Optional date of last data refresh. (Optional)
-            nextDataRefreshDate: Optional date of next expected data refresh. (Optional)
-            nextSourceReleaseDate: Optional date of next source release. (Optional)
-            sourceReleaseFrequency: Optional frequency of source releases. (Optional)
-            earliestObservationDate: Optional earliest observation date. (Optional)
-            latestObservationDate: Optional latest observation date. (Optional)
+            license_type: Optional license type. (Optional)
+            last_data_refresh_date: Optional date of last data refresh. (Optional)
+            next_data_refresh_date: Optional date of next expected data refresh. (Optional)
+            next_source_release_date: Optional date of next source release. (Optional)
+            source_release_frequency: Optional frequency of source releases. (Optional)
+            earliest_observation_date: Optional earliest observation date. (Optional)
+            latest_observation_date: Optional latest observation date. (Optional)
             curator: Optional curator of the dataset. (Optional)
-            isPartOf: Optional DCID of a parent provenance. (Optional)
+            is_part_of: Optional DCID of a parent provenance. (Optional)
             additional_properties: Additional MCF properties, passed as a dictionary
                 with the target property as key. (Optional)
             override: If True, overwrite the existing node if it exists. Defaults to False.
@@ -505,8 +505,8 @@ class CustomDataManager:
 
         dcid = mint_dcid(prefix="provenance", name=name)
         url = str(url)
-        sourceLink = mint_dcid(prefix="source", name=source)
-        self._require_source_exists(source, sourceLink)
+        source_link = mint_dcid(prefix="source", name=source)
+        self._require_source_exists(source, source_link)
         props = _parse_kwargs_into_properties(
             locals(), extra_exclude={"name", "source"}
         )
@@ -522,17 +522,17 @@ class CustomDataManager:
         *,
         dcid: str,
         name: str,
-        memberOf: list[str] | str | None = None,
-        statType: str | StatType | None = None,
-        shortDisplayName: str | None = None,
+        member_of: list[str] | str | None = None,
+        stat_type: str | StatType | None = None,
+        short_display_name: str | None = None,
         description: str | None = None,
-        searchDescription: list[str] | str | None = None,
+        search_description: list[str] | str | None = None,
         provenance: str | None = None,
-        populationType: str | None = None,
-        measuredProperty: str | None = None,
-        measurementQualifier: str | None = None,
-        measurementDenominator: str | None = None,
-        observationProperties: list[str] | None = None,
+        population_type: str | None = None,
+        measured_property: str | None = None,
+        measurement_qualifier: str | None = None,
+        measurement_denominator: str | None = None,
+        observation_properties: list[str] | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
@@ -546,17 +546,17 @@ class CustomDataManager:
                 applies to ``populationType``, ``measuredProperty``,
                 ``measurementQualifier`` and ``measurementDenominator``.
             name: Name of the variable (Optional)
-            memberOf: Member of group for the variable (Optional)
-            statType: Type of the statistical variable (Optional)
-            shortDisplayName: Short display name of the variable (Optional)
+            member_of: Member of group for the variable (Optional)
+            stat_type: Type of the statistical variable (Optional)
+            short_display_name: Short display name of the variable (Optional)
             description: Description of the variable (Optional)
-            searchDescription: Search description of the variable (Optional)
+            search_description: Search description of the variable (Optional)
             provenance: Provenance of the variable (Optional)
-            populationType: Population type of the variable (Optional)
-            measuredProperty: Measured property of the variable (Optional)
-            measurementQualifier: Measurement qualifier of the variable (Optional)
-            measurementDenominator: Measurement denominator of the variable (Optional)
-            observationProperties: For multi-entity data, the list of dcid:-prefixed properties
+            population_type: Population type of the variable (Optional)
+            measured_property: Measured property of the variable (Optional)
+            measurement_qualifier: Measurement qualifier of the variable (Optional)
+            measurement_denominator: Measurement denominator of the variable (Optional)
+            observation_properties: For multi-entity data, the list of dcid:-prefixed properties
                 that apply to observations, one per custom dimension (Optional)
             additional_properties: Additional properties for the variable,
                 passed as a dictionary with the target property as key.(Optional)
@@ -568,14 +568,14 @@ class CustomDataManager:
         """
 
         dcid = ensure_dcid(dcid)
-        if populationType is not None:
-            populationType = ensure_dcid(populationType)
-        if measuredProperty is not None:
-            measuredProperty = ensure_dcid(measuredProperty)
-        if measurementQualifier is not None:
-            measurementQualifier = ensure_dcid(measurementQualifier)
-        if measurementDenominator is not None:
-            measurementDenominator = ensure_dcid(measurementDenominator)
+        if population_type is not None:
+            population_type = ensure_dcid(population_type)
+        if measured_property is not None:
+            measured_property = ensure_dcid(measured_property)
+        if measurement_qualifier is not None:
+            measurement_qualifier = ensure_dcid(measurement_qualifier)
+        if measurement_denominator is not None:
+            measurement_denominator = ensure_dcid(measurement_denominator)
 
         props = _parse_kwargs_into_properties(locals())
         node = StatVarNode(**props)
@@ -590,10 +590,10 @@ class CustomDataManager:
         *,
         dcid: str,
         name: str,
-        specializationOf: str,
+        specialization_of: str,
         description: str | None = None,
         provenance: str | None = None,
-        shortDisplayName: str | None = None,
+        short_display_name: str | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_GROUP_NAME,
@@ -604,13 +604,13 @@ class CustomDataManager:
             dcid: DCID of the group you are defining. It must be prefixed by g/ and may include
                 an additional prefix before the g.
             name: This is the name of the heading that will appear in the Statistical Variable Explorer.
-            specializationOf: Specialization of the variable group. For a top-level group,
+            specialization_of: Specialization of the variable group. For a top-level group,
                 this must be dcid:dc/g/Root, which is the root group in the statistical
                 variable hierarchy in the Knowledge Graph.To create a sub-group, specify the
                 DCID of another node you have already defined.
             description: Description of the variable group (Optional)
             provenance: Provenance of the variable group (Optional)
-            shortDisplayName: Short display name of the variable group (Optional)
+            short_display_name: Short display name of the variable group (Optional)
             additional_properties: Additional properties for the variable group,
                 passed as a dictionary with the target property as key.(Optional)
             override: If True, overwrite the existing node if it exists. Defaults to False.
@@ -633,7 +633,7 @@ class CustomDataManager:
         dcid: str,
         name: str,
         description: str | None = None,
-        includedIn: str | list[str] | None = None,
+        included_in: str | list[str] | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
@@ -649,7 +649,7 @@ class CustomDataManager:
                 valid dcid tokens (no whitespace).
             name: Human-readable name for the entity type.
             description: Optional human-readable description. (Optional)
-            includedIn: Bare provenance name (or list of names) the entity type is
+            included_in: Bare provenance name (or list of names) the entity type is
                 defined in. **Important:** this takes the bare provenance name (not a
                 dcid, unlike the other ref params). The provenance must already be
                 registered via ``add_provenance``. The builder emits ``includedIn`` for
@@ -670,8 +670,8 @@ class CustomDataManager:
                 provenance referenced by ``includedIn`` has not been registered.
         """
         dcid = ensure_dcid(dcid)
-        if includedIn is not None:
-            includedIn = self._expand_included_in(includedIn)
+        if included_in is not None:
+            included_in = self._expand_included_in(included_in)
         props = _parse_kwargs_into_properties(locals())
         node = EntityTypeNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -684,8 +684,8 @@ class CustomDataManager:
         dcid: str,
         name: str,
         description: str | None = None,
-        subClassOf: str = "dcid:Event",
-        includedIn: str | list[str] | None = None,
+        sub_class_of: str = "dcid:Event",
+        included_in: str | list[str] | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
@@ -701,9 +701,9 @@ class CustomDataManager:
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Human-readable name for the event type.
             description: Optional human-readable description. (Optional)
-            subClassOf: Parent class DCID. Bare tokens are normalized to ``dcid:<token>``.
+            sub_class_of: Parent class DCID. Bare tokens are normalized to ``dcid:<token>``.
                 Defaults to ``"dcid:Event"``. (Optional)
-            includedIn: Bare provenance name (or list of names) the event type is
+            included_in: Bare provenance name (or list of names) the event type is
                 defined in. **Important:** this takes the bare provenance name (not a
                 dcid, unlike the other ref params). The provenance must already be
                 registered via ``add_provenance``. The builder emits ``includedIn`` for
@@ -724,9 +724,9 @@ class CustomDataManager:
                 provenance referenced by ``includedIn`` has not been registered.
         """
         dcid = ensure_dcid(dcid)
-        subClassOf = ensure_dcid(subClassOf)
-        if includedIn is not None:
-            includedIn = self._expand_included_in(includedIn)
+        sub_class_of = ensure_dcid(sub_class_of)
+        if included_in is not None:
+            included_in = self._expand_included_in(included_in)
         props = _parse_kwargs_into_properties(locals())
         node = EventTypeNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -738,9 +738,9 @@ class CustomDataManager:
         *,
         dcid: str,
         name: str,
-        domainIncludes: str | list[str] | None = None,
-        rangeIncludes: str | list[str] | None = None,
-        subPropertyOf: str | list[str] | None = None,
+        domain_includes: str | list[str] | None = None,
+        range_includes: str | list[str] | None = None,
+        sub_property_of: str | list[str] | None = None,
         description: str | None = None,
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
@@ -755,13 +755,13 @@ class CustomDataManager:
                 ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Human-readable name for the property.
-            domainIncludes: DCID(s) of classes the property applies to. Bare tokens or
+            domain_includes: DCID(s) of classes the property applies to. Bare tokens or
                 lists are normalized to ``dcid:`` (same as ``Node``); already
                 ``dcid:``-prefixed values are passed through verbatim. (Optional)
-            rangeIncludes: DCID(s) of classes that are the value type. Bare tokens or
+            range_includes: DCID(s) of classes that are the value type. Bare tokens or
                 lists are normalized to ``dcid:`` (same as ``Node``); already
                 ``dcid:``-prefixed values are passed through verbatim. (Optional)
-            subPropertyOf: DCID(s) of parent properties. Bare tokens or lists are
+            sub_property_of: DCID(s) of parent properties. Bare tokens or lists are
                 normalized to ``dcid:`` (same as ``Node``); already ``dcid:``-prefixed
                 values are passed through verbatim. (Optional)
             description: Optional human-readable description. (Optional)
@@ -779,12 +779,12 @@ class CustomDataManager:
                 exists and ``override`` is False, or if the file name is invalid.
         """
         dcid = ensure_dcid(dcid)
-        if domainIncludes is not None:
-            domainIncludes = ensure_dcid(domainIncludes)
-        if rangeIncludes is not None:
-            rangeIncludes = ensure_dcid(rangeIncludes)
-        if subPropertyOf is not None:
-            subPropertyOf = ensure_dcid(subPropertyOf)
+        if domain_includes is not None:
+            domain_includes = ensure_dcid(domain_includes)
+        if range_includes is not None:
+            range_includes = ensure_dcid(range_includes)
+        if sub_property_of is not None:
+            sub_property_of = ensure_dcid(sub_property_of)
         props = _parse_kwargs_into_properties(locals())
         node = PropertyNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -796,9 +796,9 @@ class CustomDataManager:
         *,
         dcid: str,
         name: str,
-        shortDisplayName: str | None = None,
+        short_display_name: str | None = None,
         description: str | None = None,
-        typeOf: str = "dcid:UnitOfMeasure",
+        type_of: str = "dcid:UnitOfMeasure",
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
@@ -813,9 +813,9 @@ class CustomDataManager:
                 ``dcid:<token>``; already ``dcid:``-prefixed values are passed through
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Human-readable name for the unit.
-            shortDisplayName: Optional short display name (e.g. ``"$"``). (Optional)
+            short_display_name: Optional short display name (e.g. ``"$"``). (Optional)
             description: Optional human-readable description. (Optional)
-            typeOf: Type DCID. Bare tokens are normalized to ``dcid:<token>``. Defaults to
+            type_of: Type DCID. Bare tokens are normalized to ``dcid:<token>``. Defaults to
                 ``"dcid:UnitOfMeasure"``; override for sub-types such as
                 ``"dcid:CurrencyUnitOfMeasure"``. (Optional)
             additional_properties: Additional MCF properties, passed as a dictionary
@@ -832,7 +832,7 @@ class CustomDataManager:
                 exists and ``override`` is False, or if the file name is invalid.
         """
         dcid = ensure_dcid(dcid)
-        typeOf = ensure_dcid(typeOf)
+        type_of = ensure_dcid(type_of)
         props = _parse_kwargs_into_properties(locals())
         node = UnitOfMeasureNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -845,7 +845,7 @@ class CustomDataManager:
         dcid: str,
         name: str | None = None,
         description: str | None = None,
-        typeOf: str = "dcid:MeasurementMethodEnum",
+        type_of: str = "dcid:MeasurementMethodEnum",
         additional_properties: dict[str, str] | None = None,
         override: bool = False,
         mcf_file_name: MCFFileName | str = DEFAULT_STATVAR_MCF_NAME,
@@ -862,7 +862,7 @@ class CustomDataManager:
                 verbatim. Names must be valid dcid tokens (no whitespace).
             name: Optional human-readable name. (Optional)
             description: Optional human-readable description. (Optional)
-            typeOf: Measurement-method enum type DCID. Bare tokens are normalized to
+            type_of: Measurement-method enum type DCID. Bare tokens are normalized to
                 ``dcid:<token>``. Defaults to ``"dcid:MeasurementMethodEnum"``; override
                 for sub-types such as ``"dcid:CensusSurveyEnum"``. (Optional)
             additional_properties: Additional MCF properties, passed as a dictionary
@@ -879,7 +879,7 @@ class CustomDataManager:
                 exists and ``override`` is False, or if the file name is invalid.
         """
         dcid = ensure_dcid(dcid)
-        typeOf = ensure_dcid(typeOf)
+        type_of = ensure_dcid(type_of)
         props = _parse_kwargs_into_properties(locals())
         node = MeasurementMethodNode(**props)
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -958,9 +958,9 @@ class CustomDataManager:
         *,
         provenance: str,
         data: pd.DataFrame | None = None,
-        columnMappings: dict[str, str] | None = None,
-        observationProperties: dict[str, str] | None = None,
-        ignoreColumns: list[str] | None = None,
+        column_mappings: dict[str, str] | None = None,
+        observation_properties: dict[str, str] | None = None,
+        ignore_columns: list[str] | None = None,
         pattern: str | None = None,
         override: bool = False,
     ) -> CustomDataManager:
@@ -985,15 +985,15 @@ class CustomDataManager:
                 ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
                 use it verbatim. Names must be valid dcid tokens (no whitespace).
             data: Data to register (optional; only valid with ``file_name``).
-            columnMappings: Column mappings. Match the headings in the CSV file to the
+            column_mappings: Column mappings. Match the headings in the CSV file to the
                 allowed properties. Allowed keys are [variable, observationAbout, date, value, unit,
                 scalingFactor, measurementMethod, observationPeriod, custom:<name>].
                 Use custom:<name> keys to map each entity dimension for multi-entity observations.
-            observationProperties: Optional file-level constant observation properties applied
+            observation_properties: Optional file-level constant observation properties applied
                 to every observation (e.g. ``{"unit": "USDollar"}``). Standard keys are
                 ``unit``/``scalingFactor``/``measurementMethod``/``observationPeriod``; custom
                 keys are preserved verbatim.
-            ignoreColumns: List of columns to ignore (optional).
+            ignore_columns: List of columns to ignore (optional).
             pattern: Glob pattern matching one or more input files. Mutually exclusive
                 with ``file_name``. Pattern entries carry no local data.
             override: If True, overwrite the existing entry if it exists. Defaults to False.
@@ -1015,18 +1015,18 @@ class CustomDataManager:
             filename=file_name,
             pattern=pattern,
             provenance=provenance,
-            columnMappings=ColumnMappings.model_validate(columnMappings or {}),
-            observationProperties=(
-                ObservationProperties(**observationProperties)
-                if observationProperties is not None
+            column_mappings=ColumnMappings.model_validate(column_mappings or {}),
+            observation_properties=(
+                ObservationProperties(**observation_properties)
+                if observation_properties is not None
                 else None
             ),
-            ignoreColumns=ignoreColumns,
+            ignore_columns=ignore_columns,
         )
 
         # Upsert into the list keyed by filename or pattern
         existing_idx: int | None = None
-        for i, e in enumerate(self._config.inputFiles):
+        for i, e in enumerate(self._config.input_files):
             if file_name is not None and e.filename == file_name:
                 existing_idx = i
                 break
@@ -1041,9 +1041,9 @@ class CustomDataManager:
                     f"Input file '{key}' already registered. "
                     "Use override=True to replace it."
                 )
-            self._config.inputFiles[existing_idx] = entry
+            self._config.input_files[existing_idx] = entry
         else:
-            self._config.inputFiles.append(entry)
+            self._config.input_files.append(entry)
 
         # Register data if provided (filename path only).
         # file_name is non-None here: the pattern+data guard and XOR check above ensure it.
@@ -1066,7 +1066,7 @@ class CustomDataManager:
             override: If True, overwrite the existing data if it exists.
         """
 
-        if not any(e.filename == file_name for e in self._config.inputFiles):
+        if not any(e.filename == file_name for e in self._config.input_files):
             raise ValueError(
                 f"File '{file_name}' not found in the config file. Please register the "
                 "file in the config file before adding data, using the "
@@ -1186,7 +1186,7 @@ class CustomDataManager:
         """
         for nodes in self._mcf_nodes.values():
             for n in nodes.nodes:
-                if n.typeOf == "dcid:Provenance" and n.dcid == provenance_link:
+                if n.type_of == "dcid:Provenance" and n.dcid == provenance_link:
                     return n
         raise ValueError(
             f"Provenance '{provenance}' not found. "
@@ -1219,7 +1219,7 @@ class CustomDataManager:
         for ref in refs:
             prov_link = mint_dcid(prefix="provenance", name=ref)
             prov_node = self._require_provenance_exists(ref, prov_link)
-            for dcid in (prov_link, getattr(prov_node, "sourceLink", None)):
+            for dcid in (prov_link, getattr(prov_node, "source_link", None)):
                 if dcid is not None and dcid not in seen:
                     seen.add(dcid)
                     expanded.append(dcid)
@@ -1233,7 +1233,7 @@ class CustomDataManager:
             source_link: The minted dcid for the source (used for the lookup).
         """
         if not any(
-            n.typeOf == "dcid:Source" and n.dcid == source_link
+            n.type_of == "dcid:Source" and n.dcid == source_link
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
         ):
@@ -1252,9 +1252,9 @@ class CustomDataManager:
             n.dcid
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
-            if n.typeOf == "dcid:Provenance"
+            if n.type_of == "dcid:Provenance"
         }
-        for entry in self._config.inputFiles:
+        for entry in self._config.input_files:
             if entry.provenance and entry.provenance not in known:
                 bare = entry.provenance.removeprefix("dcid:provenance/")
                 raise ValueError(
@@ -1280,15 +1280,15 @@ class CustomDataManager:
         source_file: dict[str, str] = {}
         for fname, nodes in self._mcf_nodes.items():
             for n in nodes.nodes:
-                node_type = n.typeOf
+                node_type = n.type_of
                 if node_type == "dcid:Provenance":
                     prov_file[n.dcid] = fname
-                    prov_source[n.dcid] = getattr(n, "sourceLink", None)
+                    prov_source[n.dcid] = getattr(n, "source_link", None)
                 elif node_type == "dcid:Source":
                     source_file[n.dcid] = fname
 
         missing: dict[str, str] = {}
-        for entry in self._config.inputFiles:
+        for entry in self._config.input_files:
             ref = entry.provenance
             owning = prov_file.get(ref)
             if owning is None:
@@ -1331,8 +1331,8 @@ class CustomDataManager:
         # fallback) for this export only, without mutating manager state, so
         # re-exporting to another directory picks up that directory's name.
         config = self._config
-        if config.importName is None:
-            config = config.model_copy(update={"importName": Path(dir_path).name})
+        if config.import_name is None:
+            config = config.model_copy(update={"import_name": Path(dir_path).name})
 
         output_path = Path(dir_path) / "config.json"
         with output_path.open("w") as f:
@@ -1414,7 +1414,7 @@ class CustomDataManager:
         if not self._vertical_specs:
             raise ValueError("No vertical specs to export")
 
-        file_name = self._config.verticalSpecsFile or DEFAULT_VERTICAL_SPECS_NAME
+        file_name = self._config.vertical_specs_file or DEFAULT_VERTICAL_SPECS_NAME
         payload = {
             "specs": [spec.model_dump(mode="json") for spec in self._vertical_specs]
         }
@@ -1436,7 +1436,7 @@ class CustomDataManager:
 
         missing = [
             entry.filename
-            for entry in self._config.inputFiles
+            for entry in self._config.input_files
             if entry.filename is not None and entry.filename not in self._data
         ]
         if missing:

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -222,12 +222,8 @@ class CustomDataManager:
         input_files_count = len(self._config.inputFiles)
 
         all_nodes = [n for nodes in self._mcf_nodes.values() for n in nodes.nodes]
-        sources_count = sum(
-            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcid:Source"
-        )
-        provenances_count = sum(
-            1 for n in all_nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
-        )
+        sources_count = sum(1 for n in all_nodes if n.typeOf == "dcid:Source")
+        provenances_count = sum(1 for n in all_nodes if n.typeOf == "dcid:Provenance")
         variables_count = len(all_nodes) - sources_count - provenances_count
 
         dataframes_count = len(self._data)
@@ -1190,10 +1186,7 @@ class CustomDataManager:
         """
         for nodes in self._mcf_nodes.values():
             for n in nodes.nodes:
-                if (
-                    getattr(n, "typeOf", None) == "dcid:Provenance"
-                    and n.dcid == provenance_link
-                ):
+                if n.typeOf == "dcid:Provenance" and n.dcid == provenance_link:
                     return n
         raise ValueError(
             f"Provenance '{provenance}' not found. "
@@ -1240,7 +1233,7 @@ class CustomDataManager:
             source_link: The minted dcid for the source (used for the lookup).
         """
         if not any(
-            getattr(n, "typeOf", None) == "dcid:Source" and n.dcid == source_link
+            n.typeOf == "dcid:Source" and n.dcid == source_link
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
         ):
@@ -1259,7 +1252,7 @@ class CustomDataManager:
             n.dcid
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
-            if getattr(n, "typeOf", None) == "dcid:Provenance"
+            if n.typeOf == "dcid:Provenance"
         }
         for entry in self._config.inputFiles:
             if entry.provenance and entry.provenance not in known:
@@ -1287,7 +1280,7 @@ class CustomDataManager:
         source_file: dict[str, str] = {}
         for fname, nodes in self._mcf_nodes.items():
             for n in nodes.nodes:
-                node_type = getattr(n, "typeOf", None)
+                node_type = n.typeOf
                 if node_type == "dcid:Provenance":
                     prov_file[n.dcid] = fname
                     prov_source[n.dcid] = getattr(n, "sourceLink", None)

--- a/src/dcp_tools/custom_data/models/config_file.py
+++ b/src/dcp_tools/custom_data/models/config_file.py
@@ -2,6 +2,7 @@ from os import PathLike
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic.alias_generators import to_camel
 
 from dcp_tools.custom_data.models.data_files import InputFile
 
@@ -10,44 +11,46 @@ class Config(BaseModel):
     """Representation of the config file
 
     Attributes:
-        importName: Name of the import. Used by the platform prep job to name the
+        import_name: Name of the import. Used by the platform prep job to name the
             JSON-LD output directory. Optional; defaults to the export directory name
             on export when unset.
-        includeInputSubdirs: Include input subdirectories.
-        groupStatVarsByProperty: Group stat vars by property.
-        defaultCustomRootStatVarGroupName: Display name for the custom root StatVarGroup.
+        include_input_subdirs: Include input subdirectories.
+        group_stat_vars_by_property: Group stat vars by property.
+        default_custom_root_stat_var_group_name: Display name for the custom root StatVarGroup.
             Default: `"Custom Variables"`
-        customIdNamespace: Namespace token for generated ids for SVs and manual groups.
+        custom_id_namespace: Namespace token for generated ids for SVs and manual groups.
             Default: `"custom"`.
-        customSvgPrefix: String prefix for generated custom StatVarGroup ids. If not set,
+        custom_svg_prefix: String prefix for generated custom StatVarGroup ids. If not set,
             and `customIdNamespace` is provided, it defaults to `<customIdNamespace>/g/`.
-        inputFiles: List of input file entries. Each entry specifies exactly one of
+        input_files: List of input file entries. Each entry specifies exactly one of
             ``filename`` (exact CSV name) or ``pattern`` (glob), plus ``provenance``
             and column mapping information.
-        svHierarchyPropsBlocklist: Array of additional property dcids to exclude from hierarchy generation.
+        sv_hierarchy_props_blocklist: Array of additional property dcids to exclude from hierarchy generation.
             These are added to the internal blocklist used by Data Commons.
-        dataDownloadUrl: Optional list of URLs the importer fetches input data from.
+        data_download_url: Optional list of URLs the importer fetches input data from.
             Serialized as a JSON list; passthrough config value (no fetching/validation here).
-        verticalSpecsFile: Optional filename of the vertical-specs JSON file the importer reads
+        vertical_specs_file: Optional filename of the vertical-specs JSON file the importer reads
             when grouping stat vars. Plain filename string; the file itself is not managed here.
     """
 
-    importName: str | None = None
-    includeInputSubdirs: bool | None = None
-    groupStatVarsByProperty: bool | None = None
-    defaultCustomRootStatVarGroupName: str | None = None
-    customIdNamespace: str | None = None
-    customSvgPrefix: str | None = None
-    svHierarchyPropsBlocklist: list[str] | None = None
-    dataDownloadUrl: list[str] | None = None
-    verticalSpecsFile: str | None = None
-    inputFiles: list[InputFile]
+    import_name: str | None = None
+    include_input_subdirs: bool | None = None
+    group_stat_vars_by_property: bool | None = None
+    default_custom_root_stat_var_group_name: str | None = None
+    custom_id_namespace: str | None = None
+    custom_svg_prefix: str | None = None
+    sv_hierarchy_props_blocklist: list[str] | None = None
+    data_download_url: list[str] | None = None
+    vertical_specs_file: str | None = None
+    input_files: list[InputFile]
 
     # model configuration - populate by name (for the "format" field alias)
     # and forbid extra fields
     model_config = ConfigDict(
-        populate_by_name=True,
+        alias_generator=to_camel,
         extra="forbid",
+        populate_by_name=True,
+        serialize_by_alias=True,
         str_strip_whitespace=True,
         validate_assignment=True,
     )

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -11,6 +11,7 @@ from pydantic import (
     model_serializer,
     model_validator,
 )
+from pydantic.alias_generators import to_camel
 
 from dcp_tools.custom_data.models.common import CustomDimensionName, mint_dcid
 
@@ -34,11 +35,11 @@ class ColumnMappings(BaseModel):
         date: Date of the observation.
         value: Value of the observation.
         unit: Unit of the observation.
-        scalingFactor: Scaling factor for the data.
-        measurementMethod: Measurement method used for the data.
-        observationPeriod: Observation period of the data.
-        observationAbout: Entity column for single-entity data.
-        customDimensions: Entity columns for multi-entity data.
+        scaling_factor: Scaling factor for the data.
+        measurement_method: Measurement method used for the data.
+        observation_period: Observation period of the data.
+        observation_about: Entity column for single-entity data.
+        custom_dimensions: Entity columns for multi-entity data.
     """
 
     variable: str | None = Field(
@@ -61,27 +62,32 @@ class ColumnMappings(BaseModel):
         validation_alias=AliasChoices("unit", "dcid:unit"),
         serialization_alias="dcid:unit",
     )
-    scalingFactor: str | None = None
-    measurementMethod: str | None = Field(
+    scaling_factor: str | None = None
+    measurement_method: str | None = Field(
         default=None,
         validation_alias=AliasChoices("measurementMethod", "dcid:measurementMethod"),
         serialization_alias="dcid:measurementMethod",
     )
-    observationPeriod: str | None = Field(
+    observation_period: str | None = Field(
         default=None,
         validation_alias=AliasChoices("observationPeriod", "dcid:observationPeriod"),
         serialization_alias="dcid:observationPeriod",
     )
-    observationAbout: str | None = Field(
+    observation_about: str | None = Field(
         default=None,
         validation_alias=AliasChoices("observationAbout", "dcid:observationAbout"),
         serialization_alias="dcid:observationAbout",
     )
-    customDimensions: dict[CustomDimensionName, str] = Field(
+    custom_dimensions: dict[CustomDimensionName, str] = Field(
         default_factory=dict,
     )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, str]:
@@ -119,15 +125,15 @@ class ObservationProperties(BaseModel):
 
     Attributes:
         unit: Unit applied to every observation.
-        scalingFactor: Scaling factor applied to every observation.
-        measurementMethod: Measurement method applied to every observation.
-        observationPeriod: Observation period applied to every observation.
+        scaling_factor: Scaling factor applied to every observation.
+        measurement_method: Measurement method applied to every observation.
+        observation_period: Observation period applied to every observation.
     """
 
     unit: str | None = None
-    scalingFactor: str | None = None
-    measurementMethod: str | None = None
-    observationPeriod: str | None = None
+    scaling_factor: str | None = None
+    measurement_method: str | None = None
+    observation_period: str | None = None
 
     model_config = ConfigDict(extra="allow")
 
@@ -146,10 +152,10 @@ class InputFile(BaseModel):
         provenance: Provenance name for the data. Bare name is minted as
             ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
             use it verbatim. Names must be valid dcid tokens (no whitespace).
-        ignoreColumns: List of columns to ignore.
-        columnMappings: If headings in the CSV file do not use the default names,
+        ignore_columns: List of columns to ignore.
+        column_mappings: If headings in the CSV file do not use the default names,
             the equivalent names for each column.
-        observationProperties: File-level constant observation properties applied to every
+        observation_properties: File-level constant observation properties applied to every
             observation (constants such as unit or measurementMethod). Optional.
         data_format: Format of the data (variable per row, one observation per row).
             This attribute is represented as "format" in the JSON.
@@ -158,14 +164,18 @@ class InputFile(BaseModel):
     filename: str | None = None
     pattern: str | None = None
     provenance: str
-    ignoreColumns: list[str] | None = None
-    columnMappings: ColumnMappings
-    observationProperties: ObservationProperties | None = None
+    ignore_columns: list[str] | None = None
+    column_mappings: ColumnMappings
+    observation_properties: ObservationProperties | None = None
     data_format: Literal["variablePerRow"] = Field(
         default="variablePerRow", alias="format"
     )
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+    )
 
     @field_validator("provenance", mode="after")
     @classmethod

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
+from pydantic.alias_generators import to_camel
 
 from dcp_tools.custom_data.models.common import (
     Dcid,
@@ -21,27 +22,33 @@ class Node(BaseModel):
     Attributes:
         dcid: Unique identifier for the Node.
         name: The human-readable name for the Node.
-        typeOf: The DCID representing the typeOf this Node. It can be a single DCID
+        type_of: The DCID representing the typeOf this Node. It can be a single DCID
             or a list of DCIDs if the Node belongs to multiple types.
         description: Optional human-readable description.
         provenance: Optional provenance information.
-        shortDisplayName: Optional human-readable short name for display.
-        subClassOf: Optional DCID indicating the 'parent' Node class.
+        short_display_name: Optional human-readable short name for display.
+        sub_class_of: Optional DCID indicating the 'parent' Node class.
     """
 
     dcid: Dcid
     name: QuotedStr | None = None
-    typeOf: DcidOrListDcid
+    type_of: DcidOrListDcid
     description: QuotedStr | None = None
     provenance: QuotedStr | None = None
-    shortDisplayName: QuotedStr | None = None
-    subClassOf: StrOrListStr | None = None
+    short_display_name: QuotedStr | None = None
+    sub_class_of: StrOrListStr | None = None
 
     # Allow extra fields since nodes can have arbitrary properties and this
     # class is not comprehensive of all possible node properties. Assignments are
     # validated too, so patterns like Dcid/GroupDcid are enforced on `Nodes.rename`
     # (which assigns `.dcid`), not just on construction.
-    model_config = ConfigDict(extra="allow", validate_assignment=True)
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="allow",
+        populate_by_name=True,
+        serialize_by_alias=True,
+        validate_assignment=True,
+    )
 
     @staticmethod
     def _clean_str(value: str) -> str:

--- a/src/dcp_tools/custom_data/models/schema_nodes.py
+++ b/src/dcp_tools/custom_data/models/schema_nodes.py
@@ -17,12 +17,12 @@ class EntityTypeNode(Node):
         description: Optional human-readable description.
 
         # EntityType-specific
-        typeOf: Fixed type indicating this is a Class (``dcid:Class``).
-        includedIn: Optional provenance/source DCID(s) the entity type is defined in.
+        type_of: Fixed type indicating this is a Class (``dcid:Class``).
+        included_in: Optional provenance/source DCID(s) the entity type is defined in.
     """
 
-    typeOf: Literal["dcid:Class"] = "dcid:Class"
-    includedIn: DcidOrListDcid | None = None
+    type_of: Literal["dcid:Class"] = "dcid:Class"
+    included_in: DcidOrListDcid | None = None
 
 
 class EventTypeNode(Node):
@@ -38,14 +38,14 @@ class EventTypeNode(Node):
         description: Optional human-readable description.
 
         # EventType-specific
-        typeOf: Fixed type indicating this is a Class (``dcid:Class``).
-        subClassOf: Parent class; defaults to ``dcid:Event`` (overridable).
-        includedIn: Optional provenance/source DCID(s) the event type is defined in.
+        type_of: Fixed type indicating this is a Class (``dcid:Class``).
+        sub_class_of: Parent class; defaults to ``dcid:Event`` (overridable).
+        included_in: Optional provenance/source DCID(s) the event type is defined in.
     """
 
-    typeOf: Literal["dcid:Class"] = "dcid:Class"
-    subClassOf: DcidOrListDcid = "dcid:Event"
-    includedIn: DcidOrListDcid | None = None
+    type_of: Literal["dcid:Class"] = "dcid:Class"
+    sub_class_of: DcidOrListDcid = "dcid:Event"
+    included_in: DcidOrListDcid | None = None
 
 
 class PropertyNode(Node):
@@ -61,16 +61,16 @@ class PropertyNode(Node):
         description: Optional human-readable description.
 
         # Property-specific
-        typeOf: Fixed type indicating this is a Property (``dcid:Property``).
-        domainIncludes: Optional DCID(s) of classes the property applies to.
-        rangeIncludes: Optional DCID(s) of classes that are the value type.
-        subPropertyOf: Optional DCID(s) of parent properties.
+        type_of: Fixed type indicating this is a Property (``dcid:Property``).
+        domain_includes: Optional DCID(s) of classes the property applies to.
+        range_includes: Optional DCID(s) of classes that are the value type.
+        sub_property_of: Optional DCID(s) of parent properties.
     """
 
-    typeOf: Literal["dcid:Property"] = "dcid:Property"
-    domainIncludes: DcidOrListDcid | None = None
-    rangeIncludes: DcidOrListDcid | None = None
-    subPropertyOf: DcidOrListDcid | None = None
+    type_of: Literal["dcid:Property"] = "dcid:Property"
+    domain_includes: DcidOrListDcid | None = None
+    range_includes: DcidOrListDcid | None = None
+    sub_property_of: DcidOrListDcid | None = None
 
 
 class UnitOfMeasureNode(Node):
@@ -84,14 +84,14 @@ class UnitOfMeasureNode(Node):
         # Inherited from Node
         dcid: Identifier for the Node (e.g. ``dcid:MyUnit``).
         name: The human-readable name for the Node.
-        shortDisplayName: Optional short display name (e.g. ``"$"``).
+        short_display_name: Optional short display name (e.g. ``"$"``).
         description: Optional human-readable description.
 
         # UnitOfMeasure-specific
-        typeOf: Type of unit; defaults to ``dcid:UnitOfMeasure`` (overridable).
+        type_of: Type of unit; defaults to ``dcid:UnitOfMeasure`` (overridable).
     """
 
-    typeOf: DcidOrListDcid = "dcid:UnitOfMeasure"
+    type_of: DcidOrListDcid = "dcid:UnitOfMeasure"
 
 
 class MeasurementMethodNode(Node):
@@ -107,8 +107,8 @@ class MeasurementMethodNode(Node):
         description: Optional human-readable description.
 
         # MeasurementMethod-specific
-        typeOf: Measurement method enum type; defaults to ``dcid:MeasurementMethodEnum``
+        type_of: Measurement method enum type; defaults to ``dcid:MeasurementMethodEnum``
             (overridable).
     """
 
-    typeOf: DcidOrListDcid = "dcid:MeasurementMethodEnum"
+    type_of: DcidOrListDcid = "dcid:MeasurementMethodEnum"

--- a/src/dcp_tools/custom_data/models/sources.py
+++ b/src/dcp_tools/custom_data/models/sources.py
@@ -14,16 +14,16 @@ class SourceNode(Node):
         description: Optional human-readable description.
 
         # Source-specific
-        typeOf: Fixed type indicating this is a Source (``dcid:Source``).
+        type_of: Fixed type indicating this is a Source (``dcid:Source``).
         url: URL of the data source.
         license: Optional license information.
-        isPartOf: Optional DCID of a parent source.
+        is_part_of: Optional DCID of a parent source.
     """
 
-    typeOf: Literal["dcid:Source"] = "dcid:Source"
+    type_of: Literal["dcid:Source"] = "dcid:Source"
     url: QuotedStr | None = None
     license: QuotedStr | None = None
-    isPartOf: Dcid | None = None
+    is_part_of: Dcid | None = None
 
 
 class ProvenanceNode(Node):
@@ -36,31 +36,31 @@ class ProvenanceNode(Node):
         description: Optional human-readable description.
 
         # Provenance-specific
-        typeOf: Fixed type indicating this is a Provenance (``dcid:Provenance``).
+        type_of: Fixed type indicating this is a Provenance (``dcid:Provenance``).
         url: URL of the provenance dataset.
-        sourceLink: DCID of the parent Source node.
+        source_link: DCID of the parent Source node.
         license: Optional license information.
-        licenseType: Optional license type.
-        lastDataRefreshDate: Optional date of last data refresh.
-        nextDataRefreshDate: Optional date of next expected data refresh.
-        nextSourceReleaseDate: Optional date of next source release.
-        sourceReleaseFrequency: Optional frequency of source releases.
-        earliestObservationDate: Optional earliest observation date in the dataset.
-        latestObservationDate: Optional latest observation date in the dataset.
+        license_type: Optional license type.
+        last_data_refresh_date: Optional date of last data refresh.
+        next_data_refresh_date: Optional date of next expected data refresh.
+        next_source_release_date: Optional date of next source release.
+        source_release_frequency: Optional frequency of source releases.
+        earliest_observation_date: Optional earliest observation date in the dataset.
+        latest_observation_date: Optional latest observation date in the dataset.
         curator: Optional curator of the dataset.
-        isPartOf: Optional DCID of a parent provenance.
+        is_part_of: Optional DCID of a parent provenance.
     """
 
-    typeOf: Literal["dcid:Provenance"] = "dcid:Provenance"
+    type_of: Literal["dcid:Provenance"] = "dcid:Provenance"
     url: QuotedStr | None = None
-    sourceLink: Dcid | None = None
+    source_link: Dcid | None = None
     license: QuotedStr | None = None
-    licenseType: QuotedStr | None = None
-    lastDataRefreshDate: QuotedStr | None = None
-    nextDataRefreshDate: QuotedStr | None = None
-    nextSourceReleaseDate: QuotedStr | None = None
-    sourceReleaseFrequency: QuotedStr | None = None
-    earliestObservationDate: QuotedStr | None = None
-    latestObservationDate: QuotedStr | None = None
+    license_type: QuotedStr | None = None
+    last_data_refresh_date: QuotedStr | None = None
+    next_data_refresh_date: QuotedStr | None = None
+    next_source_release_date: QuotedStr | None = None
+    source_release_frequency: QuotedStr | None = None
+    earliest_observation_date: QuotedStr | None = None
+    latest_observation_date: QuotedStr | None = None
     curator: QuotedStr | None = None
-    isPartOf: Dcid | None = None
+    is_part_of: Dcid | None = None

--- a/src/dcp_tools/custom_data/models/stat_vars.py
+++ b/src/dcp_tools/custom_data/models/stat_vars.py
@@ -35,34 +35,34 @@ class StatVarNode(Node):
         name: The human-readable name for the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.
-        shortDisplayName: Optional human-readable short name for display.
-        subClassOf: Optional DCID indicating the 'parent' Node class.
+        short_display_name: Optional human-readable short name for display.
+        sub_class_of: Optional DCID indicating the 'parent' Node class.
 
         # Additional Attributes specific to StatisticalVariable
-        statType: Type of statistical measurement represented by the variable.
-        typeOf: Fixed type indicating this is a StatisticalVariable.
-        memberOf: Optional DCID indicating group membership.
-        relevantVariable: Optional DCID of a related variable.
-        searchDescription: Optional descriptions enhancing NL search capabilities.
-        populationType: Optional DCID of the population entity type being measured.
-        measuredProperty: Optional DCID of the property being measured.
-        measurementQualifier: Optional qualifier describing measurement specifics.
-        measurementDenominator: Optional denominator for ratio-type statistical measures.
+        stat_type: Type of statistical measurement represented by the variable.
+        type_of: Fixed type indicating this is a StatisticalVariable.
+        member_of: Optional DCID indicating group membership.
+        relevant_variable: Optional DCID of a related variable.
+        search_description: Optional descriptions enhancing NL search capabilities.
+        population_type: Optional DCID of the population entity type being measured.
+        measured_property: Optional DCID of the property being measured.
+        measurement_qualifier: Optional qualifier describing measurement specifics.
+        measurement_denominator: Optional denominator for ratio-type statistical measures.
         footnote: Optional footnotes providing additional context or information.
-        observationProperties: Optional observation properties for multi-entity data.
+        observation_properties: Optional observation properties for multi-entity data.
     """
 
-    statType: StatType | None = StatType.MEASURED_VALUE
-    typeOf: Literal["dcid:StatisticalVariable"] = "dcid:StatisticalVariable"
-    memberOf: GroupDcidOrListGroupDcid | None = None
-    relevantVariable: DcidOrListDcid | None = None
-    searchDescription: QuotedStrListOrStr | None = None
-    populationType: Dcid | None = None
-    measuredProperty: Dcid | None = None
-    measurementQualifier: Dcid | None = None
-    measurementDenominator: Dcid | None = None
+    stat_type: StatType | None = StatType.MEASURED_VALUE
+    type_of: Literal["dcid:StatisticalVariable"] = "dcid:StatisticalVariable"
+    member_of: GroupDcidOrListGroupDcid | None = None
+    relevant_variable: DcidOrListDcid | None = None
+    search_description: QuotedStrListOrStr | None = None
+    population_type: Dcid | None = None
+    measured_property: Dcid | None = None
+    measurement_qualifier: Dcid | None = None
+    measurement_denominator: Dcid | None = None
     footnote: QuotedStrListOrStr | None = None
-    observationProperties: DcidOrListDcid | None = None
+    observation_properties: DcidOrListDcid | None = None
 
 
 class StatVarGroupNode(Node):
@@ -71,21 +71,21 @@ class StatVarGroupNode(Node):
     Attributes:
         # Additional Attributes specific to StatVarGroup
         dcid: Node identifier, must contain '/g'.
-        typeOf: Fixed type indicating this is a StatVarGroup.
-        specializationOf: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
+        type_of: Fixed type indicating this is a StatVarGroup.
+        specialization_of: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
 
          # Inherits from Node
         name: The human-readable name for the Node.
         dcid: Optional DCID for uniquely identifying the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.
-        shortDisplayName: Optional human-readable short name for display.
-        subClassOf: Optional DCID indicating the 'parent' Node class.
+        short_display_name: Optional human-readable short name for display.
+        sub_class_of: Optional DCID indicating the 'parent' Node class.
     """
 
     dcid: GroupDcid
-    typeOf: Literal["dcid:StatVarGroup"] = "dcid:StatVarGroup"
-    specializationOf: GroupDcid
+    type_of: Literal["dcid:StatVarGroup"] = "dcid:StatVarGroup"
+    specialization_of: GroupDcid
 
 
 class StatVarPeerGroupNode(Node):
@@ -95,17 +95,17 @@ class StatVarPeerGroupNode(Node):
     Attributes:
         # Additional Attributes specific to StatVarPeerGroup
         dcid: Node identifier, must contain '/svpg'.
-        typeOf: Fixed type indicating this is a StatVarPeerGroup.
+        type_of: Fixed type indicating this is a StatVarPeerGroup.
         member: DCID of the parent group, must start with 'dcid:' and contain 'g/'.
 
          # Inherits from Node
         name: The human-readable name for the Node.
         description: Optional human-readable description.
         provenance: Optional provenance information.
-        shortDisplayName: Optional human-readable short name for display.
-        subClassOf: Optional DCID indicating the 'parent' Node class.
+        short_display_name: Optional human-readable short name for display.
+        sub_class_of: Optional DCID indicating the 'parent' Node class.
     """
 
     dcid: PeerGroupDcid
-    typeOf: Literal["dcid:StatVarPeerGroup"] = "dcid:StatVarPeerGroup"
+    type_of: Literal["dcid:StatVarPeerGroup"] = "dcid:StatVarPeerGroup"
     member: DcidOrListDcid

--- a/src/dcp_tools/custom_data/models/topics.py
+++ b/src/dcp_tools/custom_data/models/topics.py
@@ -12,8 +12,8 @@ class TopicNode(Node):
 
     Attributes:
         dcid: Node identifier, must start with 'dcid:' and contain 'topic/'.
-        typeOf: Fixed type indicating this is a Topic.
-        relevantVariable: Variable or list of variables relevant to a topic.
+        type_of: Fixed type indicating this is a Topic.
+        relevant_variable: Variable or list of variables relevant to a topic.
             Contains a list of ordered values. Must start with 'dcid:'. Accepts
             plain StatVar dcids as well as group (``.../g/...``) and topic
             (``.../topic/...``) dcids: both are already valid ``dcid:\\S+`` tokens,
@@ -24,10 +24,10 @@ class TopicNode(Node):
             dcid: Optional DCID for uniquely identifying the Node.
             description: Optional human-readable description.
             provenance: Optional provenance information.
-            shortDisplayName: Optional human-readable short name for display.
-            subClassOf: Optional DCID indicating the 'parent' Node class.
+            short_display_name: Optional human-readable short name for display.
+            sub_class_of: Optional DCID indicating the 'parent' Node class.
     """
 
     dcid: TopicDcid
-    typeOf: Literal["dcid:Topic"] = "dcid:Topic"
-    relevantVariable: DcidOrListDcid
+    type_of: Literal["dcid:Topic"] = "dcid:Topic"
+    relevant_variable: DcidOrListDcid

--- a/src/dcp_tools/custom_data/models/vertical_specs.py
+++ b/src/dcp_tools/custom_data/models/vertical_specs.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, ConfigDict, Field
+from pydantic.alias_generators import to_camel
 
 
 class VerticalSpec(BaseModel):
@@ -11,14 +12,19 @@ class VerticalSpec(BaseModel):
     the field names match the keys the importer expects (``data.py:VerticalSpec``).
 
     Attributes:
-        populationType: Population type the spec applies to. Defaults to ``"Thing"``,
+        population_type: Population type the spec applies to. Defaults to ``"Thing"``,
             matching the importer's own default.
-        measuredProperties: Measured properties the spec applies to.
+        measured_properties: Measured properties the spec applies to.
         verticals: Vertical (top-level group) names to file matching stat vars under.
     """
 
-    populationType: str = "Thing"
-    measuredProperties: list[str] = Field(default_factory=list)
+    population_type: str = "Thing"
+    measured_properties: list[str] = Field(default_factory=list)
     verticals: list[str] = Field(default_factory=list)
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        extra="forbid",
+        populate_by_name=True,
+        serialize_by_alias=True,
+    )

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -90,7 +90,7 @@ def _rows_to_stat_var_nodes(
     return Nodes(nodes=nodes)
 
 
-def to_camelCase(segment: str) -> str:
+def to_camel_case(segment: str) -> str:
     """
     Turn a segment like 'Official Development Assistance' into 'officialDevelopmentAssistance'.
     Keep all-upper or already-camel segments (e.g. DAC1, ODA) unchanged.
@@ -157,7 +157,7 @@ def resolve_group_paths(
         parts = [p for p in cleaned.split("/") if p.strip()]
         if not parts:
             continue
-        slug_parts = [to_camelCase(part) for part in parts]
+        slug_parts = [to_camel_case(part) for part in parts]
 
         for idx, part in enumerate(parts):
             group_dcid = root + slug_parts[idx]
@@ -167,7 +167,7 @@ def resolve_group_paths(
                 parent = "dcid:dc/g/Root" if idx == 0 else root + slug_parts[idx - 1]
                 group_nodes.append(
                     StatVarGroupNode(
-                        dcid=group_dcid, name=part, specializationOf=parent
+                        dcid=group_dcid, name=part, specialization_of=parent
                     )
                 )
 

--- a/src/dcp_tools/gcp_utilities/storage.py
+++ b/src/dcp_tools/gcp_utilities/storage.py
@@ -291,8 +291,8 @@ def get_unregistered_csv_files(
     if isinstance(config, dict):
         config = Config.model_validate(config)
 
-    registered = {e.filename for e in config.inputFiles if e.filename}
-    patterns = [e.pattern for e in config.inputFiles if e.pattern]
+    registered = {e.filename for e in config.input_files if e.filename}
+    patterns = [e.pattern for e in config.input_files if e.pattern]
     return [
         name
         for name in csv_files
@@ -338,7 +338,7 @@ def get_missing_csv_files(
         config = Config.model_validate(config)
 
     missing: list[str] = []
-    for entry in config.inputFiles:
+    for entry in config.input_files:
         name = entry.filename
         if name is None:
             # Pattern entries are globs, not single files — skip them.

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -16,7 +16,9 @@ from dcp_tools.custom_data.models.data_files import (
     ColumnMappings,
     InputFile,
 )
-from dcp_tools.custom_data.models.schema_nodes import PropertyNode
+from dcp_tools.custom_data.models.schema_nodes import EntityTypeNode, PropertyNode
+from dcp_tools.custom_data.models.sources import ProvenanceNode, SourceNode
+from dcp_tools.custom_data.models.stat_vars import StatVarGroupNode, StatVarNode
 
 
 def test_custom_data_manager_add_provenance_and_override():
@@ -34,11 +36,13 @@ def test_custom_data_manager_add_provenance_and_override():
     manager.add_provenance(name="pA", url="http://prov", source="new_source")
 
     prov_nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    source_node = next(n for n in prov_nodes if n.typeOf == "dcid:Source")
-    prov_node = next(n for n in prov_nodes if n.typeOf == "dcid:Provenance")
+    source_node = next(n for n in prov_nodes if n.type_of == "dcid:Source")
+    assert isinstance(source_node, SourceNode)
+    prov_node = next(n for n in prov_nodes if n.type_of == "dcid:Provenance")
+    assert isinstance(prov_node, ProvenanceNode)
     assert source_node.dcid == "dcid:source/new_source"
     assert prov_node.dcid == "dcid:provenance/pA"
-    assert prov_node.sourceLink == "dcid:source/new_source"
+    assert prov_node.source_link == "dcid:source/new_source"
 
     # duplicate provenance without override raises
     with pytest.raises(ValueError):
@@ -51,7 +55,7 @@ def test_custom_data_manager_add_provenance_and_override():
     updated_prov = next(
         n
         for n in manager._mcf_nodes["provenance.mcf"].nodes
-        if n.typeOf == "dcid:Provenance"
+        if n.type_of == "dcid:Provenance"
     )
     # url is stored raw; QuotedStr serialization wraps it in quotes at dump time
     assert updated_prov.url == "http://prov2"
@@ -68,7 +72,7 @@ def test_add_source_metadata_lands_on_node():
         license="CC-BY-4.0",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    node = next(n for n in nodes if n.typeOf == "dcid:Source")
+    node = next(n for n in nodes if n.type_of == "dcid:Source")
     assert node.dcid == "dcid:source/MySource"
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert node.description == "A test source"
@@ -84,24 +88,25 @@ def test_add_provenance_metadata_lands_on_node():
         url="http://provx.org",
         source="SrcX",
         description="Prov desc",
-        lastDataRefreshDate="2024-01-01",
+        last_data_refresh_date="2024-01-01",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    prov_node = next(n for n in nodes if n.typeOf == "dcid:Provenance")
+    prov_node = next(n for n in nodes if n.type_of == "dcid:Provenance")
+    assert isinstance(prov_node, ProvenanceNode)
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert prov_node.description == "Prov desc"
-    assert prov_node.lastDataRefreshDate == "2024-01-01"
+    assert prov_node.last_data_refresh_date == "2024-01-01"
 
 
 def test_validate_provenances_raises_for_unknown_provenance(tmp_path):
     """An inputFile referencing a provenance with no matching node raises at export."""
     manager = CustomDataManager()
     # Register a file with a provenance that has no corresponding MCF node
-    manager._config.inputFiles.append(
+    manager._config.input_files.append(
         InputFile(
             filename="x.csv",
             provenance="dcid:provenance/ghost",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
     )
     with pytest.raises(ValueError, match="ghost"):
@@ -111,13 +116,13 @@ def test_validate_provenances_raises_for_unknown_provenance(tmp_path):
 def test_set_additional_config_fields():
     manager = CustomDataManager()
 
-    manager.set_defaultCustomRootStatVarGroupName("My Root Group")
-    manager.set_customIdNamespace("test_ns")
+    manager.set_default_custom_root_stat_var_group_name("My Root Group")
+    manager.set_custom_id_namespace("test_ns")
     # Default prefix should be auto-populated when namespace is set
-    assert manager._config.customSvgPrefix == "test_ns/g/"
+    assert manager._config.custom_svg_prefix == "test_ns/g/"
 
-    manager.set_customSvgPrefix("test_ns/groups/")
-    manager.set_svHierarchyPropsBlocklist(
+    manager.set_custom_svg_prefix("test_ns/groups/")
+    manager.set_sv_hierarchy_props_blocklist(
         [
             "statType",
             "measurementQualifier",
@@ -125,10 +130,10 @@ def test_set_additional_config_fields():
         ]
     )
 
-    assert manager._config.defaultCustomRootStatVarGroupName == "My Root Group"
-    assert manager._config.customIdNamespace == "test_ns"
-    assert manager._config.customSvgPrefix == "test_ns/groups/"
-    assert manager._config.svHierarchyPropsBlocklist == [
+    assert manager._config.default_custom_root_stat_var_group_name == "My Root Group"
+    assert manager._config.custom_id_namespace == "test_ns"
+    assert manager._config.custom_svg_prefix == "test_ns/groups/"
+    assert manager._config.sv_hierarchy_props_blocklist == [
         "statType",
         "measurementQualifier",
     ]
@@ -138,12 +143,12 @@ def test_import_name_set_and_export_default(tmp_path):
     """set_importName stores the value; export_config defaults it to the dir name."""
     # explicit importName survives export unchanged
     manager = CustomDataManager()
-    manager.set_importName("MyImport")
-    assert manager._config.importName == "MyImport"
+    manager.set_import_name("MyImport")
+    assert manager._config.import_name == "MyImport"
     out = tmp_path / "OECD_wage_data"
     out.mkdir()
     manager.export_config(out)
-    assert Config.from_json(str(out / "config.json")).importName == "MyImport"
+    assert Config.from_json(str(out / "config.json")).import_name == "MyImport"
 
     # unset importName defaults to each export directory name without mutating state,
     # so re-exporting the same manager elsewhere picks up the new directory's name.
@@ -151,13 +156,13 @@ def test_import_name_set_and_export_default(tmp_path):
     out2 = tmp_path / "frog_data"
     out2.mkdir()
     manager2.export_config(out2)
-    assert Config.from_json(str(out2 / "config.json")).importName == "frog_data"
-    assert manager2._config.importName is None
+    assert Config.from_json(str(out2 / "config.json")).import_name == "frog_data"
+    assert manager2._config.import_name is None
 
     out3 = tmp_path / "toad_data"
     out3.mkdir()
     manager2.export_config(out3)
-    assert Config.from_json(str(out3 / "config.json")).importName == "toad_data"
+    assert Config.from_json(str(out3 / "config.json")).import_name == "toad_data"
 
 
 def test_add_input_file_registration_and_override(tmp_path):
@@ -174,9 +179,13 @@ def test_add_input_file_registration_and_override(tmp_path):
         file_name="input.csv",
         provenance="p1",
         data=df3,
-        columnMappings={"observationAbout": "entity", "date": "Year", "value": "Value"},
+        column_mappings={
+            "observationAbout": "entity",
+            "date": "Year",
+            "value": "Value",
+        },
     )
-    assert any(e.filename == "input.csv" for e in manager._config.inputFiles)
+    assert any(e.filename == "input.csv" for e in manager._config.input_files)
     assert "input.csv" in manager._data
 
     with pytest.raises(ValueError):
@@ -208,8 +217,9 @@ def test_add_input_file_without_column_mappings():
     df = pd.DataFrame({"A": [1]})
     manager.add_input_file(file_name="input.csv", provenance="p1", data=df)
 
-    entry = next(e for e in manager._config.inputFiles if e.filename == "input.csv")
-    mappings = entry.columnMappings
+    entry = next(e for e in manager._config.input_files if e.filename == "input.csv")
+    assert isinstance(entry, InputFile)
+    mappings = entry.column_mappings
     assert mappings.model_dump(exclude_none=True) == {}
 
 
@@ -238,7 +248,7 @@ def test_export_methods(tmp_path):
         file_name="data.csv",
         provenance="p1",
         data=df,
-        columnMappings={"observationAbout": "A"},
+        column_mappings={"observationAbout": "A"},
     )
     manager.add_variable_to_mcf(dcid="dcid:vX", name="VX")
 
@@ -263,12 +273,12 @@ def test_export_data_creates_missing_subdirectory(tmp_path):
     manager = CustomDataManager()
     manager.add_source(name="S", url="http://s")
     manager.add_provenance(name="P", url="http://p", source="S")
-    manager.set_includeInputSubdirs(True)
+    manager.set_include_input_subdirs(True)
     manager.add_input_file(
         file_name="sub/gdp.csv",
         provenance="P",
         data=pd.DataFrame({"a": [1]}),
-        columnMappings={"value": "a"},
+        column_mappings={"value": "a"},
     )
 
     manager.export_data(tmp_path)
@@ -303,14 +313,14 @@ def test_export_vertical_specs_creates_missing_subdirectory(tmp_path):
 def test_export_all_writes_full_bundle_for_subdirectory_input_file(tmp_path):
     """export_all writes the complete bundle when a file_name nests in a subdirectory."""
     manager = CustomDataManager()
-    manager.set_includeInputSubdirs(True)
+    manager.set_include_input_subdirs(True)
     manager.add_source(name="S", url="http://s")
     manager.add_provenance(name="P", url="http://p", source="S")
     manager.add_input_file(
         file_name="sub/gdp.csv",
         provenance="P",
         data=pd.DataFrame({"a": [1]}),
-        columnMappings={"value": "a"},
+        column_mappings={"value": "a"},
     )
 
     manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
@@ -326,18 +336,20 @@ def test_add_variable_group_to_mcf_and_override():
     """
     manager = CustomDataManager()
     manager.add_variable_group_to_mcf(
-        dcid="dcid:test/g/1", name="Group1", specializationOf="dcid:dc/g/Root"
+        dcid="dcid:test/g/1", name="Group1", specialization_of="dcid:dc/g/Root"
     )
     groups = manager._mcf_nodes[DEFAULT_GROUP_NAME].nodes
     assert any(
-        n.dcid == "dcid:test/g/1" and n.specializationOf == "dcid:dc/g/Root"
+        isinstance(n, StatVarGroupNode)
+        and n.dcid == "dcid:test/g/1"
+        and n.specialization_of == "dcid:dc/g/Root"
         for n in groups
     )
 
     manager.add_variable_group_to_mcf(
         dcid="dcid:test/g/1",
         name="Group2",
-        specializationOf="dcid:dc/g/Root",
+        specialization_of="dcid:dc/g/Root",
         override=True,
     )
     updated = manager._mcf_nodes[DEFAULT_GROUP_NAME].nodes
@@ -365,7 +377,8 @@ def test_add_variables_to_mcf_from_csv_parse_groups(tmp_path):
     assert node_ids == ["dcid:n1", "dcid:ns/g/economic", "dcid:ns/g/employment"]
 
     statvar = next(n for n in nodes if n.dcid == "dcid:n1")
-    assert statvar.memberOf == "dcid:ns/g/employment"
+    assert isinstance(statvar, StatVarNode)
+    assert statvar.member_of == "dcid:ns/g/employment"
 
 
 def test_add_variables_to_mcf_from_csv_rejects_namespace_without_parse_groups(
@@ -386,7 +399,7 @@ def test_config_round_trip(tmp_path):
     """
     Ensures a Config can be dumped to JSON and loaded back identically.
     """
-    cfg = Config(inputFiles=[])
+    cfg = Config(input_files=[])
     path = tmp_path / "cfg.json"
     path.write_text(cfg.model_dump_json())
     loaded = Config.from_json(str(path))
@@ -405,7 +418,7 @@ def test_custom_data_manager_repr():
         file_name="f.csv",
         provenance="p1",
         data=df,
-        columnMappings={"observationAbout": "A"},
+        column_mappings={"observationAbout": "A"},
     )
     manager.add_variable_to_mcf(dcid="dcid:vX", name="VX")
     r = repr(manager)
@@ -426,7 +439,7 @@ def test_remove_indicator():
         file_name="a.csv",
         provenance="p1",
         data=df,
-        columnMappings={"observationAbout": "A"},
+        column_mappings={"observationAbout": "A"},
     )
     manager.add_variable_to_mcf(dcid="dcid:sv1", name="Var", provenance="p1")
 
@@ -455,55 +468,55 @@ def _make_cfg(
         InputFile(
             filename=key,
             provenance=prov,
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
     ]
     return Config(
-        inputFiles=input_files,
-        includeInputSubdirs=include_subdirs,
-        groupStatVarsByProperty=group_by_property,
-        defaultCustomRootStatVarGroupName=root_group_name,
-        customIdNamespace=custom_namespace,
-        customSvgPrefix=custom_svg_prefix,
-        svHierarchyPropsBlocklist=sv_blocklist,
-        dataDownloadUrl=data_download_url,
-        verticalSpecsFile=vertical_specs_file,
+        input_files=input_files,
+        include_input_subdirs=include_subdirs,
+        group_stat_vars_by_property=group_by_property,
+        default_custom_root_stat_var_group_name=root_group_name,
+        custom_id_namespace=custom_namespace,
+        custom_svg_prefix=custom_svg_prefix,
+        sv_hierarchy_props_blocklist=sv_blocklist,
+        data_download_url=data_download_url,
+        vertical_specs_file=vertical_specs_file,
     )
 
 
 def test_set_data_download_url():
     manager = CustomDataManager()
-    manager.set_dataDownloadUrl(["u1", "u2"])
-    assert manager._config.dataDownloadUrl == ["u1", "u2"]
+    manager.set_data_download_url(["u1", "u2"])
+    assert manager._config.data_download_url == ["u1", "u2"]
 
-    manager.set_dataDownloadUrl(None)
-    assert manager._config.dataDownloadUrl is None
+    manager.set_data_download_url(None)
+    assert manager._config.data_download_url is None
 
 
 def test_add_data_download_url_initializes_and_appends():
     manager = CustomDataManager()
 
     # Initializes from unset
-    manager.add_dataDownloadUrl("u1")
-    assert manager._config.dataDownloadUrl == ["u1"]
+    manager.add_data_download_url("u1")
+    assert manager._config.data_download_url == ["u1"]
 
     # Appends to existing list
-    manager.add_dataDownloadUrl("u2")
-    assert manager._config.dataDownloadUrl == ["u1", "u2"]
+    manager.add_data_download_url("u2")
+    assert manager._config.data_download_url == ["u1", "u2"]
 
     # Unset then re-initialize
-    manager.set_dataDownloadUrl(None)
-    manager.add_dataDownloadUrl("u3")
-    assert manager._config.dataDownloadUrl == ["u3"]
+    manager.set_data_download_url(None)
+    manager.add_data_download_url("u3")
+    assert manager._config.data_download_url == ["u3"]
 
 
 def test_set_vertical_specs_file():
     manager = CustomDataManager()
-    manager.set_verticalSpecsFile("vs.json")
-    assert manager._config.verticalSpecsFile == "vs.json"
+    manager.set_vertical_specs_file("vs.json")
+    assert manager._config.vertical_specs_file == "vs.json"
 
-    manager.set_verticalSpecsFile(None)
-    assert manager._config.verticalSpecsFile is None
+    manager.set_vertical_specs_file(None)
+    assert manager._config.vertical_specs_file is None
 
 
 def test_add_vertical_spec_appends_and_wires_config():
@@ -515,24 +528,24 @@ def test_add_vertical_spec_appends_and_wires_config():
     )
 
     # Auto-wires verticalSpecsFile to the default name on first use
-    assert manager._config.verticalSpecsFile == DEFAULT_VERTICAL_SPECS_NAME
+    assert manager._config.vertical_specs_file == DEFAULT_VERTICAL_SPECS_NAME
     assert len(manager._vertical_specs) == 1
     spec = manager._vertical_specs[0]
-    assert spec.populationType == "Person"
-    assert spec.measuredProperties == ["count"]
+    assert spec.population_type == "Person"
+    assert spec.measured_properties == ["count"]
     assert spec.verticals == ["PersonCountVertical"]
 
 
 def test_add_vertical_spec_respects_existing_and_explicit_filename():
     # A filename set beforehand is left untouched by the default path
     manager = CustomDataManager()
-    manager.set_verticalSpecsFile("custom.json")
+    manager.set_vertical_specs_file("custom.json")
     manager.add_vertical_spec(verticals=["v"])
-    assert manager._config.verticalSpecsFile == "custom.json"
+    assert manager._config.vertical_specs_file == "custom.json"
 
     # An explicit file_name overrides
     manager.add_vertical_spec(verticals=["v2"], file_name="other.json")
-    assert manager._config.verticalSpecsFile == "other.json"
+    assert manager._config.vertical_specs_file == "other.json"
 
 
 def test_export_vertical_specs_writes_specs_json(tmp_path):
@@ -579,24 +592,25 @@ def test_add_input_file_observation_properties():
     manager.add_input_file(
         "data.csv",
         provenance="prov1",
-        columnMappings={"observationAbout": "Country", "date": "Year"},
-        observationProperties={"unit": "USDollar", "customProp": "x"},
+        column_mappings={"observationAbout": "Country", "date": "Year"},
+        observation_properties={"unit": "USDollar", "customProp": "x"},
     )
 
-    entry = manager._config.inputFiles[0]
-    assert entry.observationProperties is not None
-    assert entry.observationProperties.unit == "USDollar"
-    assert entry.observationProperties.__pydantic_extra__["customProp"] == "x"
+    entry = manager._config.input_files[0]
+    assert isinstance(entry, InputFile)
+    assert entry.observation_properties is not None
+    assert entry.observation_properties.unit == "USDollar"
+    assert entry.observation_properties.__pydantic_extra__["customProp"] == "x"
     # columnMappings coexists
-    assert entry.columnMappings is not None
+    assert entry.column_mappings is not None
 
     # Omitting the kwarg leaves observationProperties absent (None)
     manager.add_input_file(
         "other.csv",
         provenance="prov1",
     )
-    other_entry = manager._config.inputFiles[1]
-    assert other_entry.observationProperties is None
+    other_entry = manager._config.input_files[1]
+    assert other_entry.observation_properties is None
 
 
 def test_merge_data_download_url(tmp_path):
@@ -615,7 +629,7 @@ def test_merge_data_download_url(tmp_path):
     )
 
     manager = CustomDataManager.from_config_files_in_directory(tmp_path)
-    assert manager._config.dataDownloadUrl == ["u1"]
+    assert manager._config.data_download_url == ["u1"]
 
     # Override policy: second config has different urls → takes the new list
     d3 = tmp_path / "three"
@@ -628,7 +642,7 @@ def test_merge_data_download_url(tmp_path):
     manager2 = CustomDataManager.from_config_files_in_directory(
         tmp_path, policy="override"
     )
-    assert manager2._config.dataDownloadUrl == ["u2"]
+    assert manager2._config.data_download_url == ["u2"]
 
 
 def test_merge_vertical_specs_file(tmp_path):
@@ -647,7 +661,7 @@ def test_merge_vertical_specs_file(tmp_path):
     )
 
     manager = CustomDataManager.from_config_files_in_directory(tmp_path)
-    assert manager._config.verticalSpecsFile == "vs.json"
+    assert manager._config.vertical_specs_file == "vs.json"
 
 
 def test_merge_configs_from_directory(tmp_path):
@@ -659,7 +673,7 @@ def test_merge_configs_from_directory(tmp_path):
         custom_namespace="ns",
         sv_blocklist=["measurementDenominator"],
     )
-    cfg1.includeInputSubdirs = True
+    cfg1.include_input_subdirs = True
     (d1 / "config.json").write_text(
         cfg1.model_dump_json(indent=2, exclude_none=True, by_alias=True)
     )
@@ -677,12 +691,12 @@ def test_merge_configs_from_directory(tmp_path):
 
     manager = CustomDataManager.from_config_files_in_directory(tmp_path)
 
-    filenames = {e.filename for e in manager._config.inputFiles}
+    filenames = {e.filename for e in manager._config.input_files}
     assert filenames == {"a.csv", "b.csv"}
-    assert manager._config.includeInputSubdirs is True
-    assert manager._config.customIdNamespace == "ns"
+    assert manager._config.include_input_subdirs is True
+    assert manager._config.custom_id_namespace == "ns"
     # Blocklist remains the one provided explicitly (none defined in the second config).
-    assert manager._config.svHierarchyPropsBlocklist == ["measurementDenominator"]
+    assert manager._config.sv_hierarchy_props_blocklist == ["measurementDenominator"]
 
 
 def test_merge_configs_duplicate_error(tmp_path):
@@ -724,7 +738,7 @@ def test_merge_configs_blocklist_override(tmp_path):
     )
 
     # When overriding, we take the latest list but still remove duplicates.
-    assert manager._config.svHierarchyPropsBlocklist == ["statType", "unit"]
+    assert manager._config.sv_hierarchy_props_blocklist == ["statType", "unit"]
 
 
 def test_rename_variable_mcf_only():
@@ -902,10 +916,10 @@ def test_column_mappings_emit_dcid_keys():
         date="Year",
         value="Val",
         unit="Unit_column",
-        scalingFactor="Scale_column",
-        measurementMethod="Method_column",
-        observationPeriod="Period_column",
-        customDimensions={
+        scaling_factor="Scale_column",
+        measurement_method="Method_column",
+        observation_period="Period_column",
+        custom_dimensions={
             "sourceCountry": "Source",
             "destinationCountry": "Destination",
         },
@@ -927,15 +941,15 @@ def test_column_mappings_emit_dcid_keys():
 
 
 def test_column_mappings_dump_respects_exclude_none_flag():
-    cm = ColumnMappings(variable="Var", customDimensions={"sourceCountry": "Source"})
+    cm = ColumnMappings(variable="Var", custom_dimensions={"sourceCountry": "Source"})
     assert cm.model_dump(exclude_none=True) == {
-        "variable": "Var",
+        "dcid:variableMeasured": "Var",
         "custom:sourceCountry": "Source",
     }
 
     full_dump = cm.model_dump()
-    assert "date" in full_dump
-    assert full_dump["date"] is None
+    assert "dcid:observationDate" in full_dump
+    assert full_dump["dcid:observationDate"] is None
 
 
 def test_column_mappings_accepts_dcid_keys_on_input():
@@ -947,13 +961,13 @@ def test_column_mappings_accepts_dcid_keys_on_input():
             "dcid:value": "Val",
         }
     )
-    assert cm.observationAbout == "Country"
+    assert cm.observation_about == "Country"
     assert cm.date == "Year"
     assert cm.value == "Val"
 
     # Short-key input must also still work
     cm2 = ColumnMappings.model_validate({"observationAbout": "Country"})
-    assert cm2.observationAbout == "Country"
+    assert cm2.observation_about == "Country"
 
 
 def test_column_mappings_round_trip_preserves_custom_prefix():
@@ -979,7 +993,7 @@ def test_column_mappings_rejects_malformed_custom_dimension_names(dimension_name
             variable="Var",
             date="Year",
             value="Val",
-            customDimensions={dimension_name: "Source"},
+            custom_dimensions={dimension_name: "Source"},
         )
 
 
@@ -1000,16 +1014,17 @@ def test_add_variable_to_mcf_normalizes_bare_reference_fields():
     manager.add_variable_to_mcf(
         dcid="StatVar",
         name="Variable Name",
-        populationType="Person",
-        measuredProperty="count",
-        measurementQualifier="Commitment",
-        measurementDenominator="Area",
+        population_type="Person",
+        measured_property="count",
+        measurement_qualifier="Commitment",
+        measurement_denominator="Area",
     )
     node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
-    assert node.populationType == "dcid:Person"
-    assert node.measuredProperty == "dcid:count"
-    assert node.measurementQualifier == "dcid:Commitment"
-    assert node.measurementDenominator == "dcid:Area"
+    assert isinstance(node, StatVarNode)
+    assert node.population_type == "dcid:Person"
+    assert node.measured_property == "dcid:count"
+    assert node.measurement_qualifier == "dcid:Commitment"
+    assert node.measurement_denominator == "dcid:Area"
 
 
 def test_add_variable_to_mcf_passes_prefixed_reference_fields_through():
@@ -1018,13 +1033,14 @@ def test_add_variable_to_mcf_passes_prefixed_reference_fields_through():
     manager.add_variable_to_mcf(
         dcid="dcid:StatVar",
         name="Variable Name",
-        populationType="dcid:Person",
-        measuredProperty="dcid:count",
+        population_type="dcid:Person",
+        measured_property="dcid:count",
     )
     node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
+    assert isinstance(node, StatVarNode)
     assert node.dcid == "dcid:StatVar"
-    assert node.populationType == "dcid:Person"
-    assert node.measuredProperty == "dcid:count"
+    assert node.population_type == "dcid:Person"
+    assert node.measured_property == "dcid:count"
 
 
 def test_add_entity_type_lands_node():
@@ -1032,9 +1048,9 @@ def test_add_entity_type_lands_node():
     manager = CustomDataManager()
     manager.add_entity_type(dcid="MyClass", name="My Class")
     nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
-    node = next(n for n in nodes if n.typeOf == "dcid:Class")
+    node = next(n for n in nodes if n.type_of == "dcid:Class")
     assert node.dcid == "dcid:MyClass"
-    assert node.typeOf == "dcid:Class"
+    assert node.type_of == "dcid:Class"
 
 
 def test_add_entity_type_dcid_prefixed_node_verbatim():
@@ -1052,16 +1068,16 @@ def test_add_event_type_default_subclassof():
     manager.add_event_type(dcid="Quake", name="Q")
     nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
     node = nodes[0]
-    assert node.typeOf == "dcid:Class"
-    assert node.subClassOf == "dcid:Event"
+    assert node.type_of == "dcid:Class"
+    assert node.sub_class_of == "dcid:Event"
 
 
 def test_add_event_type_subclassof_override():
     """A bare subClassOf override is normalized to dcid:."""
     manager = CustomDataManager()
-    manager.add_event_type(dcid="Quake", name="Q", subClassOf="DisasterEvent")
+    manager.add_event_type(dcid="Quake", name="Q", sub_class_of="DisasterEvent")
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert node.subClassOf == "dcid:DisasterEvent"
+    assert node.sub_class_of == "dcid:DisasterEvent"
 
 
 def test_add_property_lands_node():
@@ -1070,15 +1086,15 @@ def test_add_property_lands_node():
     manager.add_property(
         dcid="myProp",
         name="My Prop",
-        domainIncludes="dcid:Person",
-        rangeIncludes="dcid:Number",
+        domain_includes="dcid:Person",
+        range_includes="dcid:Number",
     )
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
     assert node.dcid == "dcid:myProp"
-    assert node.typeOf == "dcid:Property"
+    assert node.type_of == "dcid:Property"
     assert isinstance(node, PropertyNode)
-    assert node.domainIncludes == "dcid:Person"
-    assert node.rangeIncludes == "dcid:Number"
+    assert node.domain_includes == "dcid:Person"
+    assert node.range_includes == "dcid:Number"
 
 
 def test_add_property_normalizes_bare_refs():
@@ -1087,14 +1103,15 @@ def test_add_property_normalizes_bare_refs():
     manager.add_property(
         dcid="myProp",
         name="x",
-        domainIncludes="Person",
-        rangeIncludes=["Number", "dcid:Already"],
-        subPropertyOf="baseProp",
+        domain_includes="Person",
+        range_includes=["Number", "dcid:Already"],
+        sub_property_of="baseProp",
     )
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert node.domainIncludes == "dcid:Person"
-    assert node.rangeIncludes == ["dcid:Number", "dcid:Already"]
-    assert node.subPropertyOf == "dcid:baseProp"
+    assert isinstance(node, PropertyNode)
+    assert node.domain_includes == "dcid:Person"
+    assert node.range_includes == ["dcid:Number", "dcid:Already"]
+    assert node.sub_property_of == "dcid:baseProp"
 
 
 def test_add_unit_lands_node_and_typeof_override():
@@ -1103,20 +1120,20 @@ def test_add_unit_lands_node_and_typeof_override():
     manager.add_unit(
         dcid="USD",
         name="US Dollar",
-        shortDisplayName="$",
-        typeOf="CurrencyUnitOfMeasure",
+        short_display_name="$",
+        type_of="CurrencyUnitOfMeasure",
     )
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
-    assert node.shortDisplayName == "$"
+    assert node.type_of == "dcid:CurrencyUnitOfMeasure"
+    assert node.short_display_name == "$"
 
 
 def test_add_measurement_method_lands_node_and_typeof_override():
     """add_measurement_method normalizes bare typeOf and allows absent name."""
     manager = CustomDataManager()
-    manager.add_measurement_method(dcid="MyCensus", typeOf="CensusSurveyEnum")
+    manager.add_measurement_method(dcid="MyCensus", type_of="CensusSurveyEnum")
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert node.typeOf == "dcid:CensusSurveyEnum"
+    assert node.type_of == "dcid:CensusSurveyEnum"
     assert node.name is None
 
 
@@ -1125,10 +1142,11 @@ def test_included_in_expands_to_provenance_and_source():
     manager = CustomDataManager()
     manager.add_source(name="src", url="http://s")
     manager.add_provenance(name="prov", url="http://p", source="src")
-    manager.add_entity_type(dcid="T", name="T", includedIn="prov")
+    manager.add_entity_type(dcid="T", name="T", included_in="prov")
 
     entity_node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert entity_node.includedIn == ["dcid:provenance/prov", "dcid:source/src"]
+    assert isinstance(entity_node, EntityTypeNode)
+    assert entity_node.included_in == ["dcid:provenance/prov", "dcid:source/src"]
     assert (
         entity_node.model_dump()["includedIn"]
         == "dcid:provenance/prov, dcid:source/src"
@@ -1142,10 +1160,11 @@ def test_included_in_accepts_list_of_provenances():
     manager.add_source(name="srcB", url="http://b")
     manager.add_provenance(name="provA", url="http://pa", source="srcA")
     manager.add_provenance(name="provB", url="http://pb", source="srcB")
-    manager.add_entity_type(dcid="T", name="T", includedIn=["provA", "provB"])
+    manager.add_entity_type(dcid="T", name="T", included_in=["provA", "provB"])
 
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
-    assert node.includedIn == [
+    assert isinstance(node, EntityTypeNode)
+    assert node.included_in == [
         "dcid:provenance/provA",
         "dcid:source/srcA",
         "dcid:provenance/provB",
@@ -1159,12 +1178,13 @@ def test_included_in_dedups_shared_source():
     manager.add_source(name="src", url="http://s")
     manager.add_provenance(name="provA", url="http://pa", source="src")
     manager.add_provenance(name="provB", url="http://pb", source="src")
-    manager.add_entity_type(dcid="T", name="T", includedIn=["provA", "provB"])
+    manager.add_entity_type(dcid="T", name="T", included_in=["provA", "provB"])
 
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
+    assert isinstance(node, EntityTypeNode)
     # provA is processed first: emits provenance/provA then source/src.
     # provB is processed second: emits provenance/provB; source/src already seen → skipped.
-    assert node.includedIn == [
+    assert node.included_in == [
         "dcid:provenance/provA",
         "dcid:source/src",
         "dcid:provenance/provB",
@@ -1175,7 +1195,7 @@ def test_included_in_raises_for_missing_provenance():
     """includedIn referencing an unregistered provenance raises ValueError."""
     manager = CustomDataManager()
     with pytest.raises(ValueError, match="ghost"):
-        manager.add_event_type(dcid="E", name="E", includedIn="ghost")
+        manager.add_event_type(dcid="E", name="E", included_in="ghost")
 
 
 def test_add_entity_type_override():

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -34,12 +34,8 @@ def test_custom_data_manager_add_provenance_and_override():
     manager.add_provenance(name="pA", url="http://prov", source="new_source")
 
     prov_nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    source_node = next(
-        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcid:Source"
-    )
-    prov_node = next(
-        n for n in prov_nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
-    )
+    source_node = next(n for n in prov_nodes if n.typeOf == "dcid:Source")
+    prov_node = next(n for n in prov_nodes if n.typeOf == "dcid:Provenance")
     assert source_node.dcid == "dcid:source/new_source"
     assert prov_node.dcid == "dcid:provenance/pA"
     assert prov_node.sourceLink == "dcid:source/new_source"
@@ -55,7 +51,7 @@ def test_custom_data_manager_add_provenance_and_override():
     updated_prov = next(
         n
         for n in manager._mcf_nodes["provenance.mcf"].nodes
-        if getattr(n, "typeOf", None) == "dcid:Provenance"
+        if n.typeOf == "dcid:Provenance"
     )
     # url is stored raw; QuotedStr serialization wraps it in quotes at dump time
     assert updated_prov.url == "http://prov2"
@@ -72,7 +68,7 @@ def test_add_source_metadata_lands_on_node():
         license="CC-BY-4.0",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcid:Source")
+    node = next(n for n in nodes if n.typeOf == "dcid:Source")
     assert node.dcid == "dcid:source/MySource"
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert node.description == "A test source"
@@ -91,9 +87,7 @@ def test_add_provenance_metadata_lands_on_node():
         lastDataRefreshDate="2024-01-01",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
-    prov_node = next(
-        n for n in nodes if getattr(n, "typeOf", None) == "dcid:Provenance"
-    )
+    prov_node = next(n for n in nodes if n.typeOf == "dcid:Provenance")
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert prov_node.description == "Prov desc"
     assert prov_node.lastDataRefreshDate == "2024-01-01"
@@ -1038,7 +1032,7 @@ def test_add_entity_type_lands_node():
     manager = CustomDataManager()
     manager.add_entity_type(dcid="MyClass", name="My Class")
     nodes = manager._mcf_nodes["custom_nodes.mcf"].nodes
-    node = next(n for n in nodes if getattr(n, "typeOf", None) == "dcid:Class")
+    node = next(n for n in nodes if n.typeOf == "dcid:Class")
     assert node.dcid == "dcid:MyClass"
     assert node.typeOf == "dcid:Class"
 

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -17,19 +17,19 @@ def test_node_snapshot():
     node = Node(
         dcid="dcid:X/foo",
         name='"Some Name"',
-        typeOf="dcid:StatisticalVariable",
+        type_of="dcid:StatisticalVariable",
         description='"Foo description',
         provenance='"Some foo provenance"',
-        shortDisplayName='"F"',
-        subClassOf="dcid:Parent",
+        short_display_name='"F"',
+        sub_class_of="dcid:Parent",
     )
     assert node.to_mcf().strip() == got
 
 
 def test_config_json_snapshot(tmp_path):
     manager = CustomDataManager()
-    manager.set_importName("test_import")
-    manager.set_includeInputSubdirs(True).set_groupStatVarsByProperty(False)
+    manager.set_import_name("test_import")
+    manager.set_include_input_subdirs(True).set_group_stat_vars_by_property(False)
 
     manager.add_source(name="S1", url="http://source1")
     manager.add_provenance(name="provA", url="http://prova", source="S1")
@@ -38,12 +38,12 @@ def test_config_json_snapshot(tmp_path):
     manager.add_input_file(
         "a.csv",
         provenance="provA",
-        columnMappings={"observationAbout": "Country", "date": "Year", "value": "Val"},
+        column_mappings={"observationAbout": "Country", "date": "Year", "value": "Val"},
     )
     manager.add_input_file(
         "b.csv",
         provenance="provB",
-        columnMappings={"observationAbout": "Country", "date": "Year", "value": "Val"},
+        column_mappings={"observationAbout": "Country", "date": "Year", "value": "Val"},
     )
 
     # export
@@ -56,13 +56,13 @@ def test_config_json_snapshot(tmp_path):
 
 def test_config_json_snapshot_multi_entity(tmp_path):
     manager = CustomDataManager()
-    manager.set_importName("test_import_multi_entity")
+    manager.set_import_name("test_import_multi_entity")
     manager.add_source(name="S1", url="http://source1")
     manager.add_provenance(name="provC", url="http://provc", source="S1")
     manager.add_input_file(
         "c.csv",
         provenance="provC",
-        columnMappings={
+        column_mappings={
             "dcid:observationDate": "Year",
             "dcid:value": "Val",
             "dcid:variableMeasured": "Var",
@@ -92,13 +92,13 @@ def test_provenance_mcf_snapshot(tmp_path):
 def test_full_mcf_export(tmp_path):
     mgr = CustomDataManager()
     mgr.add_variable_group_to_mcf(
-        dcid="dcid:one/g/group1", name="Group One", specializationOf="dcid:dc/g/Root"
+        dcid="dcid:one/g/group1", name="Group One", specialization_of="dcid:dc/g/Root"
     )
     mgr.add_variable_to_mcf(
         dcid="dcid:var/one",
         name="Test Var",
         description="Test var",
-        memberOf="dcid:one/g/group1",
+        member_of="dcid:one/g/group1",
     )
     mgr.export_mcf_file(str(tmp_path), mcf_file_name="custom_nodes.mcf")
     got = (tmp_path / "custom_nodes.mcf").read_text()
@@ -112,7 +112,7 @@ def test_mcf_export_multi_entity(tmp_path):
         dcid="dcid:var/one",
         name="Test Var",
         description="Test var",
-        observationProperties=["dcid:originCountry", "dcid:destinationCountry"],
+        observation_properties=["dcid:originCountry", "dcid:destinationCountry"],
     )
 
     manager.export_mcf_file(str(tmp_path), mcf_file_name="custom_nodes.mcf")

--- a/tests/test_input_file_characterization.py
+++ b/tests/test_input_file_characterization.py
@@ -36,7 +36,11 @@ def _manager(file_name="input.csv", *, with_data=True):
         file_name=file_name,
         provenance="p1",
         data=df if with_data else None,
-        columnMappings={"observationAbout": "entity", "date": "Year", "value": "Value"},
+        column_mappings={
+            "observationAbout": "entity",
+            "date": "Year",
+            "value": "Value",
+        },
     )
     return mgr, df
 
@@ -56,16 +60,16 @@ def _make_cfg(
             filename=key,
             provenance=prov,
             columnMappings=ColumnMappings(
-                observationAbout="Country", date="Year", value="Val"
+                observation_about="Country", date="Year", value="Val"
             ),
         )
     ]
     return Config(
-        inputFiles=input_files,
-        includeInputSubdirs=include_subdirs,
-        customIdNamespace=custom_namespace,
-        customSvgPrefix=custom_svg_prefix,
-        svHierarchyPropsBlocklist=sv_blocklist,
+        input_files=input_files,
+        include_input_subdirs=include_subdirs,
+        custom_id_namespace=custom_namespace,
+        custom_svg_prefix=custom_svg_prefix,
+        sv_hierarchy_props_blocklist=sv_blocklist,
     )
 
 
@@ -78,12 +82,12 @@ def test_add_input_file_registers_in_config_and_data():
     """add_input_file registers file in config and data store."""
     manager, df = _manager()
 
-    entry = next(e for e in manager._config.inputFiles if e.filename == "input.csv")
+    entry = next(e for e in manager._config.input_files if e.filename == "input.csv")
     assert isinstance(entry, InputFile)
     assert entry.provenance == "dcid:provenance/p1"
-    assert entry.columnMappings.observationAbout == "entity"
-    assert entry.columnMappings.date == "Year"
-    assert entry.columnMappings.value == "Value"
+    assert entry.column_mappings.observation_about == "entity"
+    assert entry.column_mappings.date == "Year"
+    assert entry.column_mappings.value == "Value"
     assert entry.data_format == "variablePerRow"
 
     assert "input.csv" in manager._data
@@ -106,7 +110,11 @@ def test_add_input_file_override_and_duplicate_error():
         file_name="input.csv",
         provenance="p1",
         data=df_new,
-        columnMappings={"observationAbout": "entity", "date": "Year", "value": "Value"},
+        column_mappings={
+            "observationAbout": "entity",
+            "date": "Year",
+            "value": "Value",
+        },
         override=True,
     )
     pd.testing.assert_frame_equal(manager._data["input.csv"], df_new)
@@ -151,12 +159,12 @@ def test_export_config_round_trip(tmp_path):
     loaded = Config.from_json(str(config_file))
     assert isinstance(loaded, Config)
 
-    entry = next(e for e in loaded.inputFiles if e.filename == "input.csv")
-    mappings = entry.columnMappings
+    entry = next(e for e in loaded.input_files if e.filename == "input.csv")
+    mappings = entry.column_mappings
     assert mappings.model_dump(exclude_none=True) == {
-        "observationAbout": "entity",
-        "date": "Year",
-        "value": "Value",
+        "dcid:observationAbout": "entity",
+        "dcid:observationDate": "Year",
+        "dcid:value": "Value",
     }
     assert entry.data_format == "variablePerRow"
 
@@ -210,7 +218,7 @@ def test_input_file_default_format():
     entry = InputFile(
         filename="a.csv",
         provenance="p",
-        columnMappings=ColumnMappings(),
+        column_mappings=ColumnMappings(),
     )
 
     assert entry.data_format == "variablePerRow"
@@ -220,12 +228,12 @@ def test_input_file_default_format():
 def test_config_build_and_from_json_round_trip(tmp_path):
     """A Config with one InputFile survives a serialize → deserialize cycle."""
     cfg = Config(
-        inputFiles=[
+        input_files=[
             InputFile(
                 filename="a.csv",
                 provenance="p",
-                columnMappings=ColumnMappings(
-                    observationAbout="Country", date="Year", value="Val"
+                column_mappings=ColumnMappings(
+                    observation_about="Country", date="Year", value="Val"
                 ),
             )
         ],
@@ -265,7 +273,7 @@ def test_merge_configs_from_directory(tmp_path):
 
     manager = CustomDataManager.from_config_files_in_directory(tmp_path)
 
-    filenames = {e.filename for e in manager._config.inputFiles}
+    filenames = {e.filename for e in manager._config.input_files}
     assert filenames == {"a.csv", "b.csv"}
 
 
@@ -293,12 +301,12 @@ def test_get_unregistered_and_missing_csv_files():
     """get_unregistered_csv_files and get_missing_csv_files work with
     a Config that has one InputFile (they depend only on inputFiles)."""
     cfg = Config(
-        inputFiles=[
+        input_files=[
             InputFile(
                 filename="a.csv",
                 provenance="p",
-                columnMappings=ColumnMappings(
-                    observationAbout="Country", date="Year", value="Val"
+                column_mappings=ColumnMappings(
+                    observation_about="Country", date="Year", value="Val"
                 ),
             )
         ],
@@ -317,12 +325,12 @@ def test_get_unregistered_and_missing_csv_files():
     assert unregistered == ["extra.csv"]
 
     # --- get_missing_csv_files ---
-    cfg.inputFiles.append(
+    cfg.input_files.append(
         InputFile(
             filename="extra.csv",
             provenance="p",
-            columnMappings=ColumnMappings(
-                observationAbout="Country", date="Year", value="Val"
+            column_mappings=ColumnMappings(
+                observation_about="Country", date="Year", value="Val"
             ),
         )
     )

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -18,7 +18,7 @@ def test_config_validators_raise_on_invalid_input_files():
         InputFile(
             filename="data.txt",
             provenance="p1",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
 
 
@@ -28,7 +28,7 @@ def test_input_file_filename_pattern_xor():
     with pytest.raises(ValueError):
         InputFile(
             provenance="p1",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
 
     # Both provided
@@ -37,14 +37,14 @@ def test_input_file_filename_pattern_xor():
             filename="a.csv",
             pattern="a*",
             provenance="p1",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
 
     # filename only — valid
     by_filename = InputFile(
         filename="a.csv",
         provenance="p1",
-        columnMappings=ColumnMappings(),
+        column_mappings=ColumnMappings(),
     )
     assert by_filename.filename == "a.csv"
     assert by_filename.pattern is None
@@ -53,7 +53,7 @@ def test_input_file_filename_pattern_xor():
     by_pattern = InputFile(
         pattern="data_*",
         provenance="p1",
-        columnMappings=ColumnMappings(),
+        column_mappings=ColumnMappings(),
     )
     assert by_pattern.pattern == "data_*"
     assert by_pattern.filename is None
@@ -64,7 +64,7 @@ def test_input_file_provenance_minted():
     entry = InputFile(
         filename="a.csv",
         provenance="myProv",
-        columnMappings=ColumnMappings(),
+        column_mappings=ColumnMappings(),
     )
     assert entry.provenance == "dcid:provenance/myProv"
 
@@ -72,7 +72,7 @@ def test_input_file_provenance_minted():
     already_minted = InputFile(
         filename="b.csv",
         provenance="dcid:provenance/myProv",
-        columnMappings=ColumnMappings(),
+        column_mappings=ColumnMappings(),
     )
     assert already_minted.provenance == "dcid:provenance/myProv"
 
@@ -86,7 +86,7 @@ def test_config_round_trips_import_name(tmp_path):
         ' "format": "variablePerRow"}]}'
     )
     loaded = Config.from_json(str(config))
-    assert loaded.importName == "OECD_wage_data"
+    assert loaded.import_name == "OECD_wage_data"
     assert loaded.model_dump(exclude_none=True)["importName"] == "OECD_wage_data"
 
 
@@ -134,8 +134,8 @@ def test_config_accepts_data_download_url_and_vertical_specs_file(tmp_path):
     config_file.write_text(json.dumps(config_data))
 
     loaded = Config.from_json(str(config_file))
-    assert loaded.dataDownloadUrl == ["https://example.org/data.csv"]
-    assert loaded.verticalSpecsFile == "vert.json"
+    assert loaded.data_download_url == ["https://example.org/data.csv"]
+    assert loaded.vertical_specs_file == "vert.json"
 
     # Both fields survive a round-trip through model_dump
     dumped = loaded.model_dump(exclude_none=True, by_alias=True)
@@ -148,8 +148,8 @@ def test_input_file_observation_properties_roundtrip():
     entry = InputFile(
         filename="data.csv",
         provenance="prov1",
-        columnMappings=ColumnMappings(observationAbout="Country", date="Year"),
-        observationProperties=ObservationProperties(unit="USD", customProp="x"),
+        column_mappings=ColumnMappings(observation_about="Country", date="Year"),
+        observation_properties=ObservationProperties(unit="USD", customProp="x"),
     )
     dumped = entry.model_dump(exclude_none=True, by_alias=True)
     assert "observationProperties" in dumped
@@ -159,6 +159,6 @@ def test_input_file_observation_properties_roundtrip():
 
     # Reload from the dumped dict
     reloaded = InputFile.model_validate(dumped)
-    assert reloaded.observationProperties is not None
-    assert reloaded.observationProperties.unit == "USD"
-    assert reloaded.observationProperties.__pydantic_extra__["customProp"] == "x"
+    assert reloaded.observation_properties is not None
+    assert reloaded.observation_properties.unit == "USD"
+    assert reloaded.observation_properties.__pydantic_extra__["customProp"] == "x"

--- a/tests/test_models_mcf.py
+++ b/tests/test_models_mcf.py
@@ -13,7 +13,7 @@ def test_node_mcf_output_order_and_formatting():
     """
     node = Node(
         name='"My Name"',
-        typeOf="dcid:TypeA",
+        type_of="dcid:TypeA",
         description='"Desc"',
         dcid="dcid:TestNode",
     )
@@ -32,7 +32,7 @@ def test_node_typeof_accepts_list_and_serializes(type_of):
     """
     Accepts a list of DCIDs for typeOf and serializes as CSV.
     """
-    node = Node(dcid="dcid:TestNode", name='"My Name"', typeOf=type_of)
+    node = Node(dcid="dcid:TestNode", name='"My Name"', type_of=type_of)
     assert node.to_mcf() == (
         'Node: dcid:TestNode\nname: "My Name"\ntypeOf: dcid:TypeA, dcid:TypeB\n\n'
     )
@@ -42,7 +42,7 @@ def test_node_allows_missing_name_and_serializes_without_it():
     """
     `name` is optional; when omitted it should not appear in MCF output.
     """
-    node = Node(dcid="dcid:NoNameNode", typeOf="dcid:TypeA")
+    node = Node(dcid="dcid:NoNameNode", type_of="dcid:TypeA")
     assert node.to_mcf() == ("Node: dcid:NoNameNode\ntypeOf: dcid:TypeA\n\n")
 
 
@@ -50,7 +50,7 @@ def test_node_strips_linebreaks_and_trailing_spaces():
     node = Node(
         dcid="dcid:TestNode \n",  # newline and trailing space
         name="My name\n ",
-        typeOf="dcid:TypeA \n",
+        type_of="dcid:TypeA \n",
     )
     assert node.to_mcf() == (
         'Node: dcid:TestNode\nname: "My name"\ntypeOf: dcid:TypeA\n\n'
@@ -78,18 +78,18 @@ def test_nodes_load_from_file_without_name(tmp_path):
     first = nodes.nodes[0]
     assert first.dcid == "dcid:NoName"
     assert getattr(first, "name", None) is None
-    assert first.typeOf == "dcid:TypeA"
+    assert first.type_of == "dcid:TypeA"
 
 
 def test_node_typeof_normalizes_bare_token():
     """typeOf is DcidOrListDcid; a bare token is minted to dcid:<token> (regression for #126)."""
-    node = Node(dcid="dcid:TestNode", typeOf="TypeA")
-    assert node.typeOf == "dcid:TypeA"
+    node = Node(dcid="dcid:TestNode", type_of="TypeA")
+    assert node.type_of == "dcid:TypeA"
 
 
 def test_node_typeof_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        Node(dcid="dcid:TestNode", typeOf="has space")
+        Node(dcid="dcid:TestNode", type_of="has space")
 
 
 def test_nodes_add_override_and_remove():
@@ -97,12 +97,12 @@ def test_nodes_add_override_and_remove():
     Tests adding nodes, override behavior, and removal from Nodes.
     """
     nodes = Nodes()
-    node1 = Node(dcid="dcid:n1", name='"First"', typeOf="dcid:T1")
+    node1 = Node(dcid="dcid:n1", name='"First"', type_of="dcid:T1")
     nodes.add(node1)
     assert nodes._expect_present("dcid:n1") == 0
 
     # Adding same node without override should error
-    node1b = Node(dcid="dcid:n1", name='"Second"', typeOf="dcid:T1")
+    node1b = Node(dcid="dcid:n1", name='"Second"', type_of="dcid:T1")
     with pytest.raises(ValueError):
         nodes.add(node1b, override=False)
 
@@ -126,9 +126,9 @@ def test_nodes_add_override_and_remove():
 def test_node_assignment_is_validated():
     """An invalid value assigned to a pattern-constrained field raises, the same as
     construction would."""
-    node = Node(dcid="dcid:n1", typeOf="dcid:T1")
+    node = Node(dcid="dcid:n1", type_of="dcid:T1")
     with pytest.raises(ValidationError):
-        node.typeOf = "has space"
+        node.type_of = "has space"
 
 
 def test_node_assignment_cleans_the_assigned_value():
@@ -136,7 +136,7 @@ def test_node_assignment_cleans_the_assigned_value():
     way construction cleans it, for declared fields and for the extra keys that carry
     arbitrary MCF properties. An uncleaned value would emit a line break mid-node and
     break the MCF file (the bug fixed in v0.0.7, for construction only)."""
-    node = Node(dcid="dcid:n1", typeOf="dcid:T1")
+    node = Node(dcid="dcid:n1", type_of="dcid:T1")
 
     node.name = "text\nwith newline  "
     assert node.name == "textwith newline"
@@ -155,12 +155,12 @@ def test_stat_type_survives_assignment():
     assignment. `_clean_value` now keeps an Enum member that cleaning would not
     change."""
     sv = StatVarNode(dcid="dcid:v1")
-    assert isinstance(sv.statType, StatType)
+    assert isinstance(sv.stat_type, StatType)
 
     sv.name = "Var"
 
-    assert isinstance(sv.statType, StatType)
-    assert sv.statType == StatType.MEASURED_VALUE
+    assert isinstance(sv.stat_type, StatType)
+    assert sv.stat_type == StatType.MEASURED_VALUE
 
 
 def test_enum_carrying_a_line_break_is_still_cleaned():
@@ -172,7 +172,7 @@ def test_enum_carrying_a_line_break_is_still_cleaned():
     class Dirty(StrEnum):
         BAD = "line\nbreak  "
 
-    node = Node(dcid="dcid:n1", typeOf="dcid:T1", custom=Dirty.BAD)
+    node = Node(dcid="dcid:n1", type_of="dcid:T1", custom=Dirty.BAD)
 
     assert node.custom == "linebreak"
     assert "custom: linebreak\n" in node.to_mcf()
@@ -183,7 +183,7 @@ def test_nodes_rename_rejected_leaves_index_intact():
     node and the lookup index exactly as they were (assignment happens before
     `_pos` is mutated)."""
     nodes = Nodes()
-    nodes.add(Node(dcid="dcid:n1", typeOf="dcid:T1"))
+    nodes.add(Node(dcid="dcid:n1", type_of="dcid:T1"))
 
     with pytest.raises(ValidationError):
         nodes.rename("dcid:n1", "not-a-dcid")

--- a/tests/test_models_schema_nodes.py
+++ b/tests/test_models_schema_nodes.py
@@ -14,7 +14,7 @@ from dcp_tools.custom_data.models.schema_nodes import (
 
 def test_entity_type_default_typeof():
     node = EntityTypeNode(dcid="dcid:MyClass", name="My Class")
-    assert node.typeOf == "dcid:Class"
+    assert node.type_of == "dcid:Class"
     assert "typeOf: dcid:Class" in node.to_mcf()
 
 
@@ -22,7 +22,7 @@ def test_entity_type_accepts_included_in_list():
     node = EntityTypeNode(
         dcid="dcid:MyClass",
         name="My Class",
-        includedIn=["dcid:provenance/p", "dcid:source/s"],
+        included_in=["dcid:provenance/p", "dcid:source/s"],
     )
     assert "includedIn: dcid:provenance/p, dcid:source/s" in node.to_mcf()
 
@@ -35,8 +35,8 @@ def test_entity_type_rejects_malformed_node():
 
 def test_entity_type_included_in_normalizes_bare_token():
     """includedIn is DcidOrListDcid; a bare token is minted (regression for #126)."""
-    node = EntityTypeNode(dcid="dcid:MyClass", name="My Class", includedIn="p")
-    assert node.includedIn == "dcid:p"
+    node = EntityTypeNode(dcid="dcid:MyClass", name="My Class", included_in="p")
+    assert node.included_in == "dcid:p"
 
 
 # --- EventTypeNode ---
@@ -44,24 +44,24 @@ def test_entity_type_included_in_normalizes_bare_token():
 
 def test_event_type_default_typeof_and_subclassof():
     node = EventTypeNode(dcid="dcid:MyEvent", name="My Event")
-    assert node.typeOf == "dcid:Class"
-    assert node.subClassOf == "dcid:Event"
+    assert node.type_of == "dcid:Class"
+    assert node.sub_class_of == "dcid:Event"
 
 
 def test_event_type_subclassof_override():
     node = EventTypeNode(
-        dcid="dcid:MyEvent", name="My Event", subClassOf="dcid:DisasterEvent"
+        dcid="dcid:MyEvent", name="My Event", sub_class_of="dcid:DisasterEvent"
     )
-    assert node.subClassOf == "dcid:DisasterEvent"
+    assert node.sub_class_of == "dcid:DisasterEvent"
     assert "subClassOf: dcid:DisasterEvent" in node.to_mcf()
 
 
 def test_event_type_subclassof_normalizes_bare_token():
     """subClassOf is DcidOrListDcid; a bare token is minted (regression for #126)."""
     node = EventTypeNode(
-        dcid="dcid:MyEvent", name="My Event", subClassOf="DisasterEvent"
+        dcid="dcid:MyEvent", name="My Event", sub_class_of="DisasterEvent"
     )
-    assert node.subClassOf == "dcid:DisasterEvent"
+    assert node.sub_class_of == "dcid:DisasterEvent"
 
 
 # --- PropertyNode ---
@@ -69,16 +69,16 @@ def test_event_type_subclassof_normalizes_bare_token():
 
 def test_property_default_typeof():
     node = PropertyNode(dcid="dcid:myProp", name="My Prop")
-    assert node.typeOf == "dcid:Property"
+    assert node.type_of == "dcid:Property"
 
 
 def test_property_optional_refs_serialize():
     node = PropertyNode(
         dcid="dcid:myProp",
         name="My Prop",
-        domainIncludes="dcid:Person",
-        rangeIncludes="dcid:Number",
-        subPropertyOf="dcid:baseProp",
+        domain_includes="dcid:Person",
+        range_includes="dcid:Number",
+        sub_property_of="dcid:baseProp",
     )
     assert "domainIncludes: dcid:Person" in node.to_mcf()
     assert "rangeIncludes: dcid:Number" in node.to_mcf()
@@ -89,25 +89,25 @@ def test_property_model_normalizes_bare_ref():
     """DcidOrListDcid now runs ensure_dcid via a BeforeValidator (regression for #126), so
     domainIncludes/rangeIncludes/subPropertyOf are normalized at the model layer too, not
     just by the builder (add_property). A bare token is minted to dcid:<token>."""
-    node = PropertyNode(dcid="dcid:myProp", domainIncludes="Person")
-    assert node.domainIncludes == "dcid:Person"
+    node = PropertyNode(dcid="dcid:myProp", domain_includes="Person")
+    assert node.domain_includes == "dcid:Person"
 
 
 def test_property_model_rejects_whitespace_bearing_ref():
     with pytest.raises(ValidationError):
-        PropertyNode(dcid="dcid:myProp", domainIncludes="has space")
+        PropertyNode(dcid="dcid:myProp", domain_includes="has space")
 
 
 def test_property_model_normalizes_bare_ref_list():
     node = PropertyNode(
         dcid="dcid:myProp",
-        domainIncludes=["Person", "Household"],
-        rangeIncludes=["Number"],
-        subPropertyOf=["baseProp"],
+        domain_includes=["Person", "Household"],
+        range_includes=["Number"],
+        sub_property_of=["baseProp"],
     )
-    assert node.domainIncludes == ["dcid:Person", "dcid:Household"]
-    assert node.rangeIncludes == ["dcid:Number"]
-    assert node.subPropertyOf == ["dcid:baseProp"]
+    assert node.domain_includes == ["dcid:Person", "dcid:Household"]
+    assert node.range_includes == ["dcid:Number"]
+    assert node.sub_property_of == ["dcid:baseProp"]
 
 
 # --- UnitOfMeasureNode ---
@@ -115,19 +115,19 @@ def test_property_model_normalizes_bare_ref_list():
 
 def test_unit_default_typeof():
     node = UnitOfMeasureNode(dcid="dcid:MyUnit", name="My Unit")
-    assert node.typeOf == "dcid:UnitOfMeasure"
+    assert node.type_of == "dcid:UnitOfMeasure"
 
 
 def test_unit_typeof_override_validates():
     node = UnitOfMeasureNode(
-        dcid="dcid:USD", name="US Dollar", typeOf="dcid:CurrencyUnitOfMeasure"
+        dcid="dcid:USD", name="US Dollar", type_of="dcid:CurrencyUnitOfMeasure"
     )
-    assert node.typeOf == "dcid:CurrencyUnitOfMeasure"
+    assert node.type_of == "dcid:CurrencyUnitOfMeasure"
     assert "typeOf: dcid:CurrencyUnitOfMeasure" in node.to_mcf()
 
 
 def test_unit_inherits_short_display_name():
-    node = UnitOfMeasureNode(dcid="dcid:USD", name="US Dollar", shortDisplayName="$")
+    node = UnitOfMeasureNode(dcid="dcid:USD", name="US Dollar", short_display_name="$")
     assert 'shortDisplayName: "$"' in node.to_mcf()
 
 
@@ -136,12 +136,12 @@ def test_unit_inherits_short_display_name():
 
 def test_measurement_method_default_typeof():
     node = MeasurementMethodNode(dcid="dcid:MyMethod")
-    assert node.typeOf == "dcid:MeasurementMethodEnum"
+    assert node.type_of == "dcid:MeasurementMethodEnum"
 
 
 def test_measurement_method_typeof_override_validates():
-    node = MeasurementMethodNode(dcid="dcid:MyCensus", typeOf="dcid:CensusSurveyEnum")
-    assert node.typeOf == "dcid:CensusSurveyEnum"
+    node = MeasurementMethodNode(dcid="dcid:MyCensus", type_of="dcid:CensusSurveyEnum")
+    assert node.type_of == "dcid:CensusSurveyEnum"
     assert "typeOf: dcid:CensusSurveyEnum" in node.to_mcf()
 
 

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -10,17 +10,17 @@ from dcp_tools.custom_data.schema_tools import _rows_to_stat_var_nodes
 
 
 def test_search_description_serialization_str_and_list():
-    sv_str = StatVarNode(dcid="dcid:n1", name="Var", searchDescription="A")
+    sv_str = StatVarNode(dcid="dcid:n1", name="Var", search_description="A")
     assert 'searchDescription: "A"' in sv_str.to_mcf()
 
     sv_str = StatVarNode(
         dcid="dcid:n1",
         name="Var",
-        searchDescription=["A string, or not", "B string, other"],
+        search_description=["A string, or not", "B string, other"],
     )
     assert 'searchDescription: "A string, or not","B string, other"' in sv_str.to_mcf()
 
-    sv_list = StatVarNode(dcid="dcid:n2", name="Var", searchDescription=["A", "B"])
+    sv_list = StatVarNode(dcid="dcid:n2", name="Var", search_description=["A", "B"])
     assert 'searchDescription: "A","B"' in sv_list.to_mcf()
 
 
@@ -28,11 +28,11 @@ def test_statvarnode_strips_whitespace_and_linebreaks():
     sv = StatVarNode(
         dcid="dcid:n1\n",
         name="Var \n",
-        searchDescription=["First line\n", "Second line "],
+        search_description=["First line\n", "Second line "],
     )
     assert sv.dcid == "dcid:n1"
     assert sv.name == "Var"
-    assert sv.searchDescription == ["First line", "Second line"]
+    assert sv.search_description == ["First line", "Second line"]
 
 
 def test_statvarnode_omits_observation_properties_by_default():
@@ -47,7 +47,7 @@ def test_statvarnode_serializes_observation_properties_multi_entity():
     sv = StatVarNode(
         dcid="dcid:n1",
         name="Var",
-        observationProperties=["dcid:source", "dcid:destination"],
+        observation_properties=["dcid:source", "dcid:destination"],
     )
     assert "observationProperties: dcid:source, dcid:destination" in sv.to_mcf()
 
@@ -94,15 +94,15 @@ def test_rows_to_stat_var_nodes_parses_spreadsheet_lists_no_quotes():
 
 
 def test_observation_properties_normalizes_bare_scalar_and_list():
-    sv = StatVarNode(dcid="dcid:n1", name="Var", observationProperties="originCountry")
-    assert sv.observationProperties == "dcid:originCountry"
+    sv = StatVarNode(dcid="dcid:n1", name="Var", observation_properties="originCountry")
+    assert sv.observation_properties == "dcid:originCountry"
 
     sv_list = StatVarNode(
         dcid="dcid:n1",
         name="Var",
-        observationProperties=["originCountry", "destinationCountry"],
+        observation_properties=["originCountry", "destinationCountry"],
     )
-    assert sv_list.observationProperties == [
+    assert sv_list.observation_properties == [
         "dcid:originCountry",
         "dcid:destinationCountry",
     ]
@@ -114,20 +114,20 @@ def test_observation_properties_normalizes_bare_scalar_and_list():
 
 def test_observation_properties_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarNode(dcid="dcid:n1", name="Var", observationProperties="has space")
+        StatVarNode(dcid="dcid:n1", name="Var", observation_properties="has space")
 
 
 def test_relevant_variable_normalizes_bare_scalar_and_list():
-    sv = StatVarNode(dcid="dcid:n1", name="Var", relevantVariable="otherVar")
-    assert sv.relevantVariable == "dcid:otherVar"
+    sv = StatVarNode(dcid="dcid:n1", name="Var", relevant_variable="otherVar")
+    assert sv.relevant_variable == "dcid:otherVar"
 
-    sv_list = StatVarNode(dcid="dcid:n1", name="Var", relevantVariable=["one", "two"])
-    assert sv_list.relevantVariable == ["dcid:one", "dcid:two"]
+    sv_list = StatVarNode(dcid="dcid:n1", name="Var", relevant_variable=["one", "two"])
+    assert sv_list.relevant_variable == ["dcid:one", "dcid:two"]
 
 
 def test_relevant_variable_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        StatVarNode(dcid="dcid:n1", name="Var", relevantVariable="has space")
+        StatVarNode(dcid="dcid:n1", name="Var", relevant_variable="has space")
 
 
 # --- member on StatVarPeerGroupNode is DcidOrListDcid, same normalization ---

--- a/tests/test_models_topics.py
+++ b/tests/test_models_topics.py
@@ -15,35 +15,35 @@ from dcp_tools.custom_data.schema_tools import csv_metadata_to_nodes
 def test_topic_relevant_variable_accepts_bare_statvar_dcid():
     """A bare token matches the plain-Dcid branch and is minted to a plain dcid
     (regression for #126: this used to pass through unvalidated)."""
-    node = TopicNode(dcid="dcid:topic/T", name="Topic", relevantVariable="myVariable")
-    assert node.relevantVariable == "dcid:myVariable"
+    node = TopicNode(dcid="dcid:topic/T", name="Topic", relevant_variable="myVariable")
+    assert node.relevant_variable == "dcid:myVariable"
 
 
 def test_topic_relevant_variable_accepts_group_dcid():
-    node = TopicNode(dcid="dcid:topic/T", name="Topic", relevantVariable="g/MyGroup")
-    assert node.relevantVariable == "dcid:g/MyGroup"
+    node = TopicNode(dcid="dcid:topic/T", name="Topic", relevant_variable="g/MyGroup")
+    assert node.relevant_variable == "dcid:g/MyGroup"
 
 
 def test_topic_relevant_variable_accepts_topic_dcid():
     node = TopicNode(
-        dcid="dcid:topic/T", name="Topic", relevantVariable="topic/OtherTopic"
+        dcid="dcid:topic/T", name="Topic", relevant_variable="topic/OtherTopic"
     )
-    assert node.relevantVariable == "dcid:topic/OtherTopic"
+    assert node.relevant_variable == "dcid:topic/OtherTopic"
 
 
 def test_topic_relevant_variable_accepts_list():
     node = TopicNode(
         dcid="dcid:topic/T",
         name="Topic",
-        relevantVariable=["varOne", "varTwo"],
+        relevant_variable=["varOne", "varTwo"],
     )
-    assert node.relevantVariable == ["dcid:varOne", "dcid:varTwo"]
+    assert node.relevant_variable == ["dcid:varOne", "dcid:varTwo"]
     assert "relevantVariable: dcid:varOne, dcid:varTwo" in node.to_mcf()
 
 
 def test_topic_node_rejects_missing_slug():
     with pytest.raises(ValidationError):
-        TopicNode(dcid="dcid:NotATopic", name="Topic", relevantVariable="var")
+        TopicNode(dcid="dcid:NotATopic", name="Topic", relevant_variable="var")
 
 
 def test_topic_node_rejects_missing_dcid_prefix():
@@ -51,17 +51,17 @@ def test_topic_node_rejects_missing_dcid_prefix():
     unprefixed, since the old hand-rolled pattern checked for the 'topic/' segment
     but never required the 'dcid:' prefix."""
     with pytest.raises(ValidationError):
-        TopicNode(dcid="topic/x", name="Topic", relevantVariable="var")
+        TopicNode(dcid="topic/x", name="Topic", relevant_variable="var")
 
 
 def test_topic_node_accepts_dcid_prefixed_slug():
-    node = TopicNode(dcid="dcid:topic/x", name="Topic", relevantVariable="var")
+    node = TopicNode(dcid="dcid:topic/x", name="Topic", relevant_variable="var")
     assert node.dcid == "dcid:topic/x"
 
 
 def test_topic_node_rejects_whitespace_bearing_token():
     with pytest.raises(ValidationError):
-        TopicNode(dcid="dcid:topic/ x", name="Topic", relevantVariable="var")
+        TopicNode(dcid="dcid:topic/ x", name="Topic", relevant_variable="var")
 
 
 def test_topic_csv_conversion_rejects_bare_node(tmp_path):
@@ -89,4 +89,4 @@ def test_topic_relevant_variable_rejects_whitespace_bearing_token():
     value DcidOrListDcid rejected could still validate via the more-permissive
     Group/Topic branches (which used PlainValidator and never enforced a pattern)."""
     with pytest.raises(ValidationError):
-        TopicNode(dcid="dcid:topic/T", name="Topic", relevantVariable="has space")
+        TopicNode(dcid="dcid:topic/T", name="Topic", relevant_variable="has space")

--- a/tests/test_models_vertical_specs.py
+++ b/tests/test_models_vertical_specs.py
@@ -6,15 +6,15 @@ from dcp_tools.custom_data.models.vertical_specs import VerticalSpec
 
 def test_vertical_spec_defaults():
     spec = VerticalSpec(verticals=["PersonCountVertical"])
-    assert spec.populationType == "Thing"
-    assert spec.measuredProperties == []
+    assert spec.population_type == "Thing"
+    assert spec.measured_properties == []
     assert spec.verticals == ["PersonCountVertical"]
 
 
 def test_vertical_spec_round_trips():
     spec = VerticalSpec(
-        populationType="Person",
-        measuredProperties=["count"],
+        population_type="Person",
+        measured_properties=["count"],
         verticals=["PersonCountVertical"],
     )
     dumped = spec.model_dump(mode="json")

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -8,7 +8,7 @@ from dcp_tools.custom_data.models.stat_vars import (
 from dcp_tools.custom_data.schema_tools import (
     csv_metadata_to_nodes,
     resolve_group_paths,
-    to_camelCase,
+    to_camel_case,
 )
 
 
@@ -34,7 +34,7 @@ def test_csv_metadata_to_nodes(tmp_path):
     mapping = {"extra": "searchDescription"}
     nodes_map = csv_metadata_to_nodes(str(csv_path), column_to_property_mapping=mapping)
     for node in nodes_map.nodes:
-        assert hasattr(node, "searchDescription")
+        assert hasattr(node, "search_description")
 
 
 def get_group_nodes(nodes: Nodes) -> list[StatVarGroupNode]:
@@ -56,7 +56,7 @@ def test_single_level_group():
     group = groups[0]
     assert group.dcid == "dcid:example.org/g/category"
     assert group.name == "Category"
-    assert group.specializationOf == "dcid:dc/g/Root"
+    assert group.specialization_of == "dcid:dc/g/Root"
 
     assert resolved["Category"] == group.dcid
 
@@ -68,9 +68,9 @@ def test_multi_level_group():
     slug_map = {g.dcid.split("/")[-1]: g for g in groups}
 
     # Check each group's parent linkage
-    assert slug_map["A"].specializationOf == "dcid:dc/g/Root"
-    assert slug_map["B"].specializationOf == "dcid:ns/g/A"
-    assert slug_map["C"].specializationOf == "dcid:ns/g/B"
+    assert slug_map["A"].specialization_of == "dcid:dc/g/Root"
+    assert slug_map["B"].specialization_of == "dcid:ns/g/A"
+    assert slug_map["C"].specialization_of == "dcid:ns/g/B"
 
     # Check the path resolves to the deepest group
     assert resolved["A/B/C"] == "dcid:ns/g/C"
@@ -117,8 +117,8 @@ def test_csv_metadata_to_nodes_parse_groups(tmp_path):
     ]
 
     statvars = get_statvar_nodes(nodes)
-    assert statvars[0].memberOf == "dcid:ns/g/employment"
-    assert statvars[1].memberOf == "dcid:ns/g/health"
+    assert statvars[0].member_of == "dcid:ns/g/employment"
+    assert statvars[1].member_of == "dcid:ns/g/health"
 
 
 def test_resolve_group_paths_cleans_raw_path():
@@ -193,8 +193,8 @@ def test_csv_metadata_to_nodes_parse_groups_leaves_missing_memberof_unset(tmp_pa
     )
     statvars = get_statvar_nodes(nodes)
 
-    assert statvars[0].memberOf == "dcid:ns/g/employment"
-    assert statvars[1].memberOf is None
+    assert statvars[0].member_of == "dcid:ns/g/employment"
+    assert statvars[1].member_of is None
 
 
 def test_csv_metadata_to_nodes_parse_groups_leaves_segmentless_memberof_unset(tmp_path):
@@ -218,9 +218,9 @@ def test_csv_metadata_to_nodes_parse_groups_leaves_segmentless_memberof_unset(tm
     )
     statvars = get_statvar_nodes(nodes)
 
-    assert statvars[0].memberOf is None
-    assert statvars[1].memberOf is None
-    assert statvars[2].memberOf == "dcid:ns/g/employment"
+    assert statvars[0].member_of is None
+    assert statvars[1].member_of is None
+    assert statvars[2].member_of == "dcid:ns/g/employment"
 
 
 def test_csv_metadata_to_nodes_parse_groups_remove_works_on_group_node(tmp_path):
@@ -247,19 +247,19 @@ def test_csv_metadata_to_nodes_parse_groups_remove_works_on_group_node(tmp_path)
 
 def test_to_camelcase_multi_word():
     assert (
-        to_camelCase("Official Development Assistance")
+        to_camel_case("Official Development Assistance")
         == "officialDevelopmentAssistance"
     )
 
 
 def test_to_camelcase_all_uppercase_preserved():
-    assert to_camelCase("ODA") == "ODA"
-    assert to_camelCase("DAC1") == "DAC1"
+    assert to_camel_case("ODA") == "ODA"
+    assert to_camel_case("DAC1") == "DAC1"
 
 
 def test_to_camelcase_returns_already_camel():
-    assert to_camelCase("alreadyCamel") == "alreadyCamel"
+    assert to_camel_case("alreadyCamel") == "alreadyCamel"
 
 
 def test_to_camelcase_colon_comma_replacement():
-    assert to_camelCase("GDP: PPP, Constant 2017 USD") == "gdp_Ppp_Constant2017Usd"
+    assert to_camel_case("GDP: PPP, Constant 2017 USD") == "gdp_Ppp_Constant2017Usd"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -22,11 +22,11 @@ from dcp_tools.gcp_utilities.storage import (
 
 def _minimal_config(key: str = "a.csv") -> Config:
     return Config(
-        inputFiles=[
+        input_files=[
             InputFile(
                 filename=key,
                 provenance="prov",
-                columnMappings=ColumnMappings(),
+                column_mappings=ColumnMappings(),
             )
         ]
     )
@@ -324,11 +324,11 @@ def test_get_unregistered_csv_files_honors_patterns():
     bucket.name = "my-bucket"
 
     cfg = Config(
-        inputFiles=[
+        input_files=[
             InputFile(
                 pattern="data_*.csv",
                 provenance="prov",
-                columnMappings=ColumnMappings(),
+                column_mappings=ColumnMappings(),
             )
         ]
     )
@@ -361,11 +361,11 @@ def test_get_missing_csv_files():
     bucket.list_blobs.return_value = [blob_a]
 
     cfg = _minimal_config()
-    cfg.inputFiles.append(
+    cfg.input_files.append(
         InputFile(
             filename="extra.csv",
             provenance="prov",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
     )
 
@@ -381,11 +381,11 @@ def test_get_missing_csv_files_with_prefix_added():
     bucket.list_blobs.return_value = [blob_a]
 
     cfg = _minimal_config("sub/a.csv")
-    cfg.inputFiles.append(
+    cfg.input_files.append(
         InputFile(
             filename="sub/b.csv",
             provenance="prov",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
     )
 
@@ -423,11 +423,11 @@ def test_get_missing_csv_files_per_import():
     bucket.name = "my-bucket"
 
     cfg = _minimal_config("a.csv")
-    cfg.inputFiles.append(
+    cfg.input_files.append(
         InputFile(
             filename="b.csv",
             provenance="prov",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
     )
 
@@ -446,11 +446,11 @@ def test_registration_checks_fresh_import_empty_prefix():
     bucket.name = "my-bucket"
 
     cfg = _minimal_config("a.csv")
-    cfg.inputFiles.append(
+    cfg.input_files.append(
         InputFile(
             filename="b.csv",
             provenance="prov",
-            columnMappings=ColumnMappings(),
+            column_mappings=ColumnMappings(),
         )
     )
 


### PR DESCRIPTION
Closes https://github.com/ONEcampaign/dcp-tools/issues/137, follow-up to https://github.com/ONEcampaign/dcp-tools/pull/144

- Refactors the project to use Python conventions of snake_case for properties and functions.
- Uses pydantic to handle the serialisation to camelCase
