### PR TITLE
Update `export_all` default behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@
   serialized `config.json` and MCF wire format are unchanged: camelCase keys are preserved via
   pydantic aliases (`alias_generator=to_camel`). CSV column headers (e.g. `memberOf`) keep the
   Data Commons camelCase convention.
+- **`export_all` writes and overwrites the complete bundle.** It no longer takes `mcf_file_names`
+  or `override`. It writes `config.json`, the data CSVs, `vertical_specs.json` (when specs were
+  added), and every MCF file you've added nodes to, overwriting anything already in the directory.
+  Pass nothing for the full bundle; use `export_mcf_file` to write a single file.
+- **Renamed `override` to `overwrite` on the export helpers and flipped the default to `True`**
+  (overwrite). Affects `CustomDataManager.export_mcf_file`, `Nodes.export_to_mcf_file`, and
+  `csv_metadata_to_mcf_file`.
+- **Replaced `csv2mcf`'s `--override` flag with `--append`.** `csv2mcf` now overwrites the output
+  file by default; pass `--append` to add to an existing file instead (which can produce duplicate
+  `Node:` blocks on repeated runs).
 
 ### Fixed
 - `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
@@ -163,6 +173,12 @@
 - Convert builder keyword arguments, node/`Config` attributes and `set_*` methods to
   snake_case (`measuredProperty` → `measured_property`, `typeOf` → `type_of`, `set_importName`
   → `set_import_name`, and so on). The exported `config.json` and MCF are unchanged.
+- Drop `mcf_file_names` and `override` from `export_all` calls: pass nothing for the full bundle,
+  and use `export_mcf_file` for a single file. `export_all` now overwrites what's already there.
+- Rename `override=` → `overwrite=` on `export_mcf_file`, `Nodes.export_to_mcf_file` and
+  `csv_metadata_to_mcf_file` (all now overwrite by default).
+- Replace `csv2mcf --override` with the default (overwrite), or `--append` to add to an existing
+  file.
 
 ## [0.1.1] - 2026-02-19
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ manager.add_variable_to_mcf(
 
 out_dir = Path("export/climate_finance")
 out_dir.mkdir(parents=True, exist_ok=True)
-manager.export_all(out_dir, mcf_file_names=["provenance.mcf", "custom_nodes.mcf"])
+manager.export_all(out_dir)
 ```
 
-`export_all` writes `config.json`, the CSV, and both named MCF files under `out_dir`. Since we
+`export_all` writes `config.json`, the CSV, and both MCF files under `out_dir`. Since we
 never called `set_importName`, `config.json` defaults `importName` to the export directory's
 name, and column mappings and the provenance name are resolved to full dcids:
 
@@ -99,11 +99,6 @@ name, and column mappings and the provenance name are resolved to full dcids:
     ]
 }
 ```
-
-!!! warning "Heads up"
-    `provenance.mcf` (source and provenance nodes) is never exported by default. If an input
-    file references a provenance and its MCF file isn't in `mcf_file_names`, `export_all` raises
-    before writing anything, so you can't ship a bundle with a dangling reference.
 
 ## Loading it
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -102,6 +102,14 @@
 - **Breaking:** the Python API is snake_case throughout — node/`Config` attributes, builder
   keyword arguments and the `set_*` methods. Serialisation still uses camelCase using
   pydantic's `alias_generator=to_camel`.
+- **Breaking:** `export_all` writes and overwrites the complete bundle, and no longer takes
+  `mcf_file_names` or `override`. It writes `config.json`, the data CSVs, `vertical_specs.json`
+  (when specs were added), and every MCF file you've added nodes to, overwriting what's already
+  there. Pass nothing for the full bundle; use `export_mcf_file` for a single file.
+- **Breaking:** `override` is renamed to `overwrite` on `export_mcf_file`, `Nodes.export_to_mcf_file`
+  and `csv_metadata_to_mcf_file`, and now defaults to overwriting.
+- **Breaking:** `csv2mcf` replaces `--override` with `--append`. It overwrites the output file by
+  default; pass `--append` to add to an existing file instead.
 
 ## v0.1.0 (in development)
 - Initial release of the `dcp-tools` package for external preview and testing

--- a/docs/docs/cli-tools.md
+++ b/docs/docs/cli-tools.md
@@ -69,7 +69,7 @@ dcp-tools csv2mcf <CSV> <MCF>
                   [--column-mapping CSV_COL=MCF_PROP]
                   [--csv-option KEY=VALUE]
                   [--ignore-column COLUMN]
-                  [--override]
+                  [--append]
 ```
 
 **Arguments**
@@ -89,8 +89,8 @@ dcp-tools csv2mcf <CSV> <MCF>
   `pandas.read_csv`, e.g. `--csv-option delimiter=";"`.
 - **`--ignore-column COLUMN`** (repeatable) — drop a CSV column before building nodes. Pass the
   flag once per column.
-- **`--override`** — controls how `<MCF>` is written when it already exists. Without it, new nodes
-  are appended to the file. With it, the file is truncated and written fresh.
+- **`--append`** — append to `<MCF>` if it already exists instead of overwriting it. Without this
+  flag, `csv2mcf` overwrites the file (or creates it if it doesn't exist).
 
 CSV values that map to a `dcid:`-typed field (`Node`, `populationType`, `measuredProperty`,
 `measurementQualifier`, `measurementDenominator`) must already carry the `dcid:` prefix. `csv2mcf`
@@ -102,11 +102,6 @@ does not mint the prefix for you. A bare value such as `climateFinanceProvidedCo
 is minted to `dcid:<value>` automatically; for the other four node types it defaults to a fixed
 value (`dcid:StatisticalVariable`, `dcid:StatVarGroup`, `dcid:Topic`, `dcid:StatVarPeerGroup`) that
 a CSV `typeOf` column doesn't need to repeat.
-
-!!! warning "Heads up"
-    Without `--override`, `csv2mcf` appends to `<MCF>` if it already exists rather than replacing
-    it. Running the same command twice against the same output path writes duplicate `Node:`
-    blocks. Pass `--override` to truncate the file first, or write to a fresh path each run.
 
 **Example**
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -183,19 +183,10 @@ The `provenance` field here is the bare name you passed in, stored as a plain qu
 
 ## Step 5: Export the bundle and verify it
 
-`export_all` writes the config, the data, and any MCF files you name, in one call. It doesn't export MCF files unless you list them.
-
-!!! warning "Heads up"
-    `mcf_file_names` defaults to `None`, which exports no MCF at all. Since the input file from Step 3 references the provenance node in `provenance.mcf`, leaving it off `mcf_file_names` makes `export_all` raise a `ValueError` before writing anything, rather than shipping a config with a dangling reference.
-
-Steps 2 and 4 already wrote `provenance.mcf` and `custom_nodes.mcf` once each as checkpoints, so this final call needs `override=True` to overwrite them instead of appending:
+`export_all` writes the config, the data, and any MCF files you've registered.
 
 ```python
-manager.export_all(
-    "one_climate_finance",
-    mcf_file_names=["provenance.mcf", "custom_nodes.mcf"],
-    override=True,
-)
+manager.export_all("one_climate_finance")
 ```
 
 List the directory to confirm the full bundle landed:

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -70,18 +70,6 @@ Both methods take `description`, `license`, and `isPartOf`. `add_provenance` add
 `additional_properties={"someProperty": "value"}` for anything else. Pass `override=True` to
 replace a node that's already registered under the same name.
 
-!!! warning "Heads up"
-    `provenance.mcf` isn't exported automatically. List it explicitly when you export:
-
-    ```python
-    manager.export_all("output", mcf_file_names=["provenance.mcf"])
-    ```
-
-    If a registered input file references a provenance whose MCF file isn't in
-    `mcf_file_names`, `export_all` raises before writing anything, rather than shipping a
-    `config.json` with a dangling reference. See
-    [How to validate and export the bundle](#how-to-validate-and-export-the-bundle).
-
 ## How to register a single-entity input file
 
 Use this when each row of data is about one entity (a country, a facility, a person).
@@ -405,32 +393,19 @@ input file references a provenance that was never registered.
 Export everything in one call:
 
 ```python
-manager.export_all(
-    "output_directory",
-    mcf_file_names=["provenance.mcf", "custom_nodes.mcf", "custom_groups.mcf"],
-)
+manager.export_all("output_directory")
 ```
 
-`export_all` writes `config.json` always, data CSVs if any DataFrames are registered,
-`vertical_specs.json` if any specs were added, and each file in `mcf_file_names`. `mcf_file_names`
-defaults to `None`, which exports **no MCF file at all**. Omitting it is the most common way to
-end up with a `config.json` that references StatVars and provenances nobody wrote to disk.
+`export_all` writes the full bundle, overwriting anything already in the directory: `config.json`
+always, the data CSVs for any registered DataFrames, `vertical_specs.json` if any specs were added,
+and every MCF file you've added nodes to. To write only part of the bundle, use the individual
+`export_*` methods below.
 
-Before writing anything, `export_all` checks that every provenance an input file references (and
-that provenance's linked source) lives in one of the MCF files you're exporting. If not, it raises
-rather than shipping an incomplete bundle:
-
-```text
-ValueError: export_all() would write a config.json referencing source/provenance node(s)
-defined in MCF file(s) not being exported: ['provenance.mcf']. Add them to mcf_file_names
-(e.g. mcf_file_names=['provenance.mcf']) so the bundle is complete.
-```
-
-Pass `validate_data=True` to also raise if any declared input file has no registered DataFrame
+Pass `validate_data=True` to raise if any declared input file has no registered DataFrame
 (pattern entries are exempt, since they carry no local data by design):
 
 ```python
-manager.export_all("output_directory", mcf_file_names=["provenance.mcf"], validate_data=True)
+manager.export_all("output_directory", validate_data=True)
 ```
 
 To export pieces individually instead of all at once:

--- a/src/dcp_tools/cli/csv2mcf.py
+++ b/src/dcp_tools/cli/csv2mcf.py
@@ -68,9 +68,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     parser.add_argument(
-        "--override",
-        action="store_true",
-        help="Overwrite the output file if it exists",
+        "--append", action="store_true", help="Append to the output file if it exists."
     )
 
     parser.set_defaults(func=run)
@@ -88,6 +86,6 @@ def run(args: argparse.Namespace) -> int:
         column_to_property_mapping=column_mapping,
         csv_options=csv_options,
         ignore_columns=args.ignore_column,
-        override=args.override,
+        overwrite=not args.append,
     )
     return 0

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -1263,54 +1263,6 @@ class CustomDataManager:
                     f"Call add_provenance(name={bare!r}, url=..., source=...) first."
                 )
 
-    def _validate_provenance_files_exported(self, exported_mcf: set[str]) -> None:
-        """Raise if an inputFile references a provenance — or its linked Source —
-        defined in an MCF file that is not being exported.
-
-        ``export_all`` writes a complete bundle, so every provenance an input file
-        references must be defined in an exported MCF file, and so must the Source it
-        links to via ``sourceLink``. Without this check a forgotten
-        ``mcf_file_names=["provenance.mcf"]`` (or a Source kept in a separate, unexported
-        MCF file) would write a config.json pointing at nodes absent from the bundle —
-        references the DCP importer rejects. Unknown provenances (no node at all) are
-        left to ``_validate_provenances``.
-        """
-        prov_file: dict[str, str] = {}
-        prov_source: dict[str, str | None] = {}
-        source_file: dict[str, str] = {}
-        for fname, nodes in self._mcf_nodes.items():
-            for n in nodes.nodes:
-                node_type = n.type_of
-                if node_type == "dcid:Provenance":
-                    prov_file[n.dcid] = fname
-                    prov_source[n.dcid] = getattr(n, "source_link", None)
-                elif node_type == "dcid:Source":
-                    source_file[n.dcid] = fname
-
-        missing: dict[str, str] = {}
-        for entry in self._config.input_files:
-            ref = entry.provenance
-            owning = prov_file.get(ref)
-            if owning is None:
-                continue  # unknown provenance -> _validate_provenances reports it
-            if owning not in exported_mcf:
-                missing.setdefault(owning, ref)
-                continue
-            # The provenance is exported; the Source it links to must be too.
-            link = prov_source.get(ref)
-            if link is not None:
-                src_owner = source_file.get(link)
-                if src_owner is not None and src_owner not in exported_mcf:
-                    missing.setdefault(src_owner, link)
-
-        if missing:
-            files = sorted(missing)
-            raise ValueError(
-                f"export_all() would write a config.json referencing source/provenance "
-                f"node(s) defined in MCF file(s) not being exported: {files}. Add them to "
-                f"mcf_file_names (e.g. mcf_file_names={files!r}) so the bundle is complete."
-            )
-
     def export_config(self, dir_path: str | PathLike[str]) -> None:
         """Export the config to a JSON file
 
@@ -1342,14 +1294,14 @@ class CustomDataManager:
         self,
         dir_path: str | PathLike[str],
         mcf_file_name: str = DEFAULT_STATVAR_MCF_NAME,
-        override: bool = False,
+        overwrite: bool = True,
     ) -> None:
         """Export the MCF file to a file
 
         Args:
             dir_path: Path to the directory where the MCF file will be exported.
             mcf_file_name: Name of the MCF file (must end in .mcf). Defaults to "custom_nodes.mcf".
-            override: If True, overwrite the file if it exists. Defaults to False.
+            overwrite: If True, overwrite the file if it exists. Defaults to True.
         """
         mcf_file_name = validate_mcf_file_name(mcf_file_name)
 
@@ -1360,7 +1312,7 @@ class CustomDataManager:
             raise ValueError(f"No data available for '{mcf_file_name}'")
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        nodes.export_to_mcf_file(file_path=output_path, override=override)
+        nodes.export_to_mcf_file(file_path=output_path, overwrite=overwrite)
 
     def config_to_dict(self) -> dict:
         """Export the config to a dictionary
@@ -1450,41 +1402,26 @@ class CustomDataManager:
     def export_all(
         self,
         dir_path: str | PathLike[str],
-        override: bool = False,
-        mcf_file_names: str | list[str] | None = None,
         validate_data: bool = False,
     ) -> None:
         """Export the config, MCF file, and data to a directory
 
-        ``export_all`` writes a complete bundle and enforces it: if an input file
-        references a provenance whose MCF file is not listed in ``mcf_file_names``,
-        it raises before writing anything (so no partial bundle lands on disk). To
-        export only the config (deferring MCF export), use ``export_config`` directly.
+        ``export_all`` overwrites the complete bundle. To export only the config
+        (deferring MCF export), use ``export_config`` directly. To export a single MCF
+        file, use `export_mcf_file`.
 
         Args:
             dir_path: Path to the directory where the config and data will be exported.
-            override: If True, overwrite the files if they exist. Defaults to False.
-            mcf_file_names: Name of the MCF file(s) to export (must end in .mcf).
-                Defaults to None, which means no MCF file will be exported.
-                Source and Provenance nodes live in ``provenance.mcf`` by default and
-                must be listed here to be written (e.g.
-                ``mcf_file_names=["provenance.mcf"]``).
             validate_data: If True, raise a ValueError before exporting if any input
                 file declared in the config does not have a corresponding data entry.
                 Defaults to False.
 
         Raises:
-            ValueError: If an input file references a provenance defined in an MCF
-                file not included in ``mcf_file_names`` (the bundle would be incomplete).
+            ValueError: If an input file has no data entry.
         """
-
-        if isinstance(mcf_file_names, str):
-            mcf_file_names = [mcf_file_names]
 
         if validate_data:
             self.validate_all_input_files_have_data()
-
-        self._validate_provenance_files_exported(set(mcf_file_names or ()))
 
         self.export_config(dir_path)
 
@@ -1494,9 +1431,9 @@ class CustomDataManager:
         if self._vertical_specs:
             self.export_vertical_specs(dir_path)
 
-        for mcf_file_name in mcf_file_names or ():
+        for mcf_file_name in self._mcf_nodes:
             self.export_mcf_file(
-                dir_path=dir_path, mcf_file_name=mcf_file_name, override=override
+                dir_path=dir_path, mcf_file_name=mcf_file_name, overwrite=True
             )
 
     def validate_config(self) -> CustomDataManager:

--- a/src/dcp_tools/custom_data/models/mcf.py
+++ b/src/dcp_tools/custom_data/models/mcf.py
@@ -246,15 +246,15 @@ class Nodes(BaseModel):
         return self
 
     def export_to_mcf_file(
-        self, file_path: str | PathLike, *, override: bool = True
+        self, file_path: str | PathLike, *, overwrite: bool = True
     ) -> Nodes:
         """Exports the MCF nodes to a file.
 
         Args:
             file_path: The path of the file to which to export.
-            override: If True, overwrite the file if it exists. If False, append to the file.
+            overwrite: If True, overwrite the file if it exists. If False, append to the file.
         """
-        mode = "w" if override else "a"
+        mode = "w" if overwrite else "a"
 
         with open(file_path, mode) as f:
             for node in self.nodes:

--- a/src/dcp_tools/custom_data/schema_tools.py
+++ b/src/dcp_tools/custom_data/schema_tools.py
@@ -268,7 +268,7 @@ def csv_metadata_to_mcf_file(
     column_to_property_mapping: dict[str, str] | None = None,
     csv_options: dict[str, Any] | None = None,
     ignore_columns: list[str] | None = None,
-    override: bool = False,
+    overwrite: bool = True,
 ) -> None:
     """Convert a CSV of Node metadata to an MCF file.
 
@@ -279,7 +279,7 @@ def csv_metadata_to_mcf_file(
         column_to_property_mapping: Optional mapping from CSV columns to MCF properties.
         csv_options: Extra options for reading the CSV file.
         ignore_columns: List of columns to ignore when reading the CSV.
-        override: If True, overwrite the output file if it exists.
+        overwrite: If True, overwrite the output file if it exists.
 
     """
 
@@ -294,4 +294,4 @@ def csv_metadata_to_mcf_file(
         ignore_columns=ignore_columns,
     )
 
-    nodes.export_to_mcf_file(file_path=mcf_path, override=override)
+    nodes.export_to_mcf_file(file_path=mcf_path, overwrite=overwrite)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,18 +63,18 @@ def test_csv2mcf_node_type_statvar_group(tmp_path: Path) -> None:
     assert "specializationOf: dcid:dc/g/Root" in content
 
 
-def test_csv2mcf_append_and_override(tmp_path: Path) -> None:
+def test_csv2mcf_append_then_overwrite(tmp_path: Path) -> None:
     csv1 = tmp_path / "first.csv"
     csv1.write_text("Node,name,typeOf\ndcid:sv1,SV1,dcid:StatisticalVariable\n")
     csv2 = tmp_path / "second.csv"
     csv2.write_text("Node,name,typeOf\ndcid:sv2,SV2,dcid:StatisticalVariable\n")
     out_mcf = tmp_path / "out_append.mcf"
-    main(["csv2mcf", str(csv1), str(out_mcf)])
-    main(["csv2mcf", str(csv2), str(out_mcf)])
+    main(["csv2mcf", str(csv1), str(out_mcf), "--append"])
+    main(["csv2mcf", str(csv2), str(out_mcf), "--append"])
     content = out_mcf.read_text()
     assert content.count("Node: dcid:sv1") == 1
     assert content.count("Node: dcid:sv2") == 1
-    main(["csv2mcf", str(csv1), str(out_mcf), "--override"])
+    main(["csv2mcf", str(csv1), str(out_mcf)])
     content_over = out_mcf.read_text()
     assert "Node: dcid:sv1" in content_over
     assert "Node: dcid:sv2" not in content_over

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -316,6 +316,10 @@ def test_export_all_writes_full_bundle_for_subdirectory_input_file(tmp_path):
     manager.set_include_input_subdirs(True)
     manager.add_source(name="S", url="http://s")
     manager.add_provenance(name="P", url="http://p", source="S")
+    manager.add_entity_type(
+        dcid="MyEntityType",
+        name="My Entity Type",
+    )
     manager.add_input_file(
         file_name="sub/gdp.csv",
         provenance="P",
@@ -323,11 +327,33 @@ def test_export_all_writes_full_bundle_for_subdirectory_input_file(tmp_path):
         column_mappings={"value": "a"},
     )
 
-    manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
+    manager.export_all(tmp_path)
 
     assert (tmp_path / "sub" / "gdp.csv").exists()
     assert (tmp_path / "config.json").exists()
     assert (tmp_path / "provenance.mcf").exists()
+    assert (tmp_path / "custom_nodes.mcf").exists()
+
+
+def test_export_all_overwrites_correctly(tmp_path):
+    """export_all overwrites correctly."""
+    manager = CustomDataManager()
+
+    manager.add_variable_to_mcf(
+        dcid="MyVariable",
+        name="My Variable",
+    )
+    manager.export_all(tmp_path)
+    assert (tmp_path / "custom_nodes.mcf").read_text() == (
+        "Node: dcid:MyVariable\n"
+        'name: "My Variable"\n'
+        "typeOf: dcid:StatisticalVariable\n"
+        "statType: dcid:measuredValue\n\n"
+    )
+
+    manager.remove_indicator("dcid:MyVariable")
+    manager.export_all(tmp_path)
+    assert (tmp_path / "custom_nodes.mcf").read_text() == ""
 
 
 def test_add_variable_group_to_mcf_and_override():
@@ -829,7 +855,7 @@ def test_validate_all_input_files_have_data(tmp_path):
         manager.validate_all_input_files_have_data()
 
     # validate_data=False does not surface the missing-data error
-    manager.export_all(tmp_path, validate_data=False, mcf_file_names=["provenance.mcf"])
+    manager.export_all(tmp_path, validate_data=False)
 
     # export_all with validate_data=True should raise before writing anything
     with pytest.raises(ValueError, match=r"no_data\.csv"):
@@ -839,52 +865,10 @@ def test_validate_all_input_files_have_data(tmp_path):
     manager.add_data(df, "no_data.csv")
     manager.validate_all_input_files_have_data()  # should not raise
 
-    manager.export_all(
-        tmp_path, validate_data=True, mcf_file_names=["provenance.mcf"]
-    )  # should not raise
+    manager.export_all(tmp_path, validate_data=True)  # should not raise
     assert (tmp_path / "config.json").exists()
     assert (tmp_path / "with_data.csv").exists()
     assert (tmp_path / "no_data.csv").exists()
-
-
-def test_export_all_requires_provenance_mcf(tmp_path):
-    """export_all raises (before writing) if a referenced provenance's MCF file is omitted."""
-    manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
-    manager.add_input_file(
-        file_name="data.csv", provenance="p1", data=pd.DataFrame({"A": [1]})
-    )
-
-    # Omitting mcf_file_names would ship a config.json referencing a node not on disk.
-    with pytest.raises(ValueError, match=r"provenance\.mcf"):
-        manager.export_all(tmp_path)
-    assert not (tmp_path / "config.json").exists(), "must not write a partial bundle"
-
-    # Listing the provenance MCF file makes the bundle complete.
-    manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
-    assert (tmp_path / "config.json").exists()
-    assert (tmp_path / "provenance.mcf").exists()
-
-
-def test_export_all_requires_linked_source_mcf(tmp_path):
-    """The guard follows sourceLink: a Source kept in a separate MCF file must be exported too."""
-    manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src", mcf_file_name="sources.mcf")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
-    manager.add_input_file(
-        file_name="data.csv", provenance="p1", data=pd.DataFrame({"A": [1]})
-    )
-
-    # Exporting only provenance.mcf leaves the sourceLink dangling -> raises, names sources.mcf.
-    with pytest.raises(ValueError, match=r"sources\.mcf"):
-        manager.export_all(tmp_path, mcf_file_names=["provenance.mcf"])
-    assert not (tmp_path / "config.json").exists(), "must not write a partial bundle"
-
-    # Exporting both the provenance and its source file makes the bundle complete.
-    manager.export_all(tmp_path, mcf_file_names=["provenance.mcf", "sources.mcf"])
-    assert (tmp_path / "provenance.mcf").exists()
-    assert (tmp_path / "sources.mcf").exists()
 
 
 def test_loading_legacy_variable_per_column_config_raises_with_message():


### PR DESCRIPTION
Closes https://github.com/ONEcampaign/dcp-tools/issues/138

- Method `export_all` now writes and overwrites the full bundle by default, parameters `mcf_file_names` and `override` are removed, use `export_mcf_file` for a single file
- Parameter `override` renamed to `overwrite` in `export_mcf_file`, `Nodes.export_to_mcf_file`, and `csv_metadata_to_mcf_file`, defaulting to overwrite
- Replaces `csv2mcf`'s `--override` with `--append` (overwrites by default; `--append` opts into appending)