### PR TITLE
Update stale camelCase references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ manager.export_all(out_dir)
 ```
 
 `export_all` writes `config.json`, the CSV, and both MCF files under `out_dir`. Since we
-never called `set_importName`, `config.json` defaults `importName` to the export directory's
+never called `set_import_name`, `config.json` defaults `importName` to the export directory's
 name, and column mappings and the provenance name are resolved to full dcids:
 
 ```json

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -206,7 +206,7 @@ one_climate_finance/provenance.mcf
 one_climate_finance/climate_finance/one_cf_provider_commitments.csv
 ```
 
-`config.json` now has an `importName`, defaulted from the export directory name since we never called `set_importName`:
+`config.json` now has an `importName`, defaulted from the export directory name since we never called `set_import_name`:
 
 ```json
 {

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -357,7 +357,7 @@ merged by `filename`/`pattern`. Everything else (`importName`, `customIdNamespac
     `export_config` defaults an unset `importName` to the export directory's name. If two configs
     were each exported without an explicit `importName`, merging them raises a conflict on
     `importName` (`"climate"` vs. `"health"`) even though neither config set it on purpose. Call
-    `set_importName` explicitly on configs you intend to merge later.
+    `set_import_name` explicitly on configs you intend to merge later.
 
 ## How to add vertical specs to guide the StatVar hierarchy
 
@@ -375,7 +375,7 @@ manager.add_vertical_spec(
 
 Each call appends one spec matching StatVars about `population_type` with the given
 `measured_properties` to `verticals`. The first call also sets the config's `verticalSpecsFile` to
-`"vertical_specs.json"`, unless you already set one with `set_verticalSpecsFile` or passed
+`"vertical_specs.json"`, unless you already set one with `set_vertical_specs_file` or passed
 `file_name=` here. `export_all` (or `export_vertical_specs` directly) writes the accumulated specs
 as `{"specs": [...]}` JSON. Exporting with no specs added raises `ValueError`.
 


### PR DESCRIPTION
Update docs for https://github.com/ONEcampaign/dcp-tools/issues/137, which I should have done as part of https://github.com/ONEcampaign/dcp-tools/pull/145.