### PR TITLE
Split `add_source`/`add_provenance` into `dcid`, `name`, `description`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@
 - **Replaced `csv2mcf`'s `--override` flag with `--append`.** `csv2mcf` now overwrites the output
   file by default; pass `--append` to add to an existing file instead (which can produce duplicate
   `Node:` blocks on repeated runs).
+- **`add_source` and `add_provenance` take separate `dcid`, `name`, and `description` parameters.**
+  `dcid` is the identifier (minted with the `source/`/`provenance/` slug prefix); `name` is an
+  optional human-readable label; `description` is optional longer text. Previously `name` was used
+  as the identifier and the node's own `name` property was never set.
 
 ### Fixed
 - `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
@@ -179,6 +183,8 @@
   `csv_metadata_to_mcf_file` (all now overwrite by default).
 - Replace `csv2mcf --override` with the default (overwrite), or `--append` to add to an existing
   file.
+- In `add_source`/`add_provenance` calls, pass the identifier as `dcid=` (was `name=`); optionally
+  pass `name=` for a human-readable label.
 
 ## [0.1.1] - 2026-02-19
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ import pandas as pd
 from dcp_tools import CustomDataManager
 
 manager = CustomDataManager()
-manager.add_source(name="ONEData", url="https://data.one.org")
+manager.add_source(dcid="ONEData", url="https://data.one.org")
 manager.add_provenance(
-    name="ONEClimateFinance",
+    dcid="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
     source="ONEData",
 )

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -110,6 +110,9 @@
   and `csv_metadata_to_mcf_file`, and now defaults to overwriting.
 - **Breaking:** `csv2mcf` replaces `--override` with `--append`. It overwrites the output file by
   default; pass `--append` to add to an existing file instead.
+- **Breaking:** `add_source` and `add_provenance` take separate `dcid` (identifier, minted with the
+  slug prefix), optional `name` (label), and `description` parameters. Previously `name` was the
+  identifier and no `name` property was set — pass the identifier as `dcid=` now.
 
 ## v0.1.0 (in development)
 - Initial release of the `dcp-tools` package for external preview and testing

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -47,9 +47,9 @@ from dcp_tools import CustomDataManager
 import pandas as pd
 
 manager = CustomDataManager()
-manager.add_source(name="ONEData", url="https://data.one.org")
+manager.add_source(dcid="ONEData", url="https://data.one.org")
 manager.add_provenance(
-    name="ONEClimateFinance",
+    dcid="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
     source="ONEData",
 )
@@ -160,7 +160,7 @@ names you pass to `add_entity_type`, `add_property`, `add_unit`, or `Node`/`popu
 on `add_variable_to_mcf`. Both rules turn a bare token into a `dcid:`-prefixed one, but only one
 of them inserts a namespace segment:
 
-- `add_source(name="ONEData", ...)` mints `dcid:source/ONEData`.
+- `add_source(dcid="ONEData", ...)` mints `dcid:source/ONEData`.
 - `add_property(dcid="providerCountry", ...)` mints `dcid:providerCountry`, no `property/`
   segment.
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -62,16 +62,16 @@ flags: importName=None, includeInputSubdirs=None, groupStatVarsByProperty=None, 
 Register where the data comes from: a Source (the publishing organization) and a Provenance (this specific dataset). Every input file you register later points back at a Provenance dcid, so it has to exist first.
 
 ```python
-manager.add_source(name="ONEData", url="https://data.one.org")
+manager.add_source(dcid="ONEData", url="https://data.one.org")
 manager.add_provenance(
-    name="ONEClimateFinance",
+    dcid="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
     source="ONEData",
 )
 ```
 
 !!! note
-    `name` becomes part of the node's dcid, so it can't contain spaces. `add_source` turns `"ONEData"` into `dcid:source/ONEData`. If you want a spaced-out label, put it in `description` instead.
+    `dcid` is the node's identifier, so it can't contain spaces — `add_source` mints `"ONEData"` into `dcid:source/ONEData`. For a human-readable label (spaces allowed), pass `name`; it's optional.
 
 Both calls add MCF nodes in memory. Export them to see what they'll look like on disk:
 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -43,11 +43,11 @@ from dcp_tools import CustomDataManager
 manager = CustomDataManager()
 
 manager.add_source(
-    name="ONEData",
+    dcid="ONEData",
     url="https://data.one.org",
 )
 manager.add_provenance(
-    name="ONEClimateFinance",
+    dcid="ONEClimateFinance",
     url="https://datacommons.one.org/data/climate-finance-files",
     source="ONEData",
 )
@@ -58,11 +58,10 @@ node at `dcid:source/ONEData`, and a `dcid:Provenance` node at `dcid:provenance/
 linking to it. `add_provenance` raises `ValueError` if `source` isn't registered yet.
 
 !!! note
-    `name` mints part of a dcid. A bare name becomes `dcid:source/<name>` or
-    `dcid:provenance/<name>`. An already `dcid:`-prefixed name is used as-is. Names can't
-    contain whitespace (`"ONEData"`, not `"ONE Data"`). Put a whitespace-friendly display string
-    in `description=` instead. See [Why config.json and MCF](dc-schemas.md) for why the importer
-    needs dcids shaped this way.
+    `dcid` is the node's identifier and gets minted: a bare token becomes `dcid:source/<token>`
+    or `dcid:provenance/<token>` (an already `dcid:`-prefixed value is used as-is), so it can't
+    contain whitespace. `name` is the optional human-readable label, where spaces are fine. See
+    [Why config.json and MCF](dc-schemas.md) for why the importer needs dcids shaped this way.
 
 Both methods take `description`, `license`, and `isPartOf`. `add_provenance` additionally takes
 `licenseType`, `lastDataRefreshDate`, `nextDataRefreshDate`, `nextSourceReleaseDate`,

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -86,15 +86,16 @@ class CustomDataManager:
 
     To add a Source and Provenance (emitted as MCF nodes to ``provenance.mcf`` by default),
     use the ``add_source`` and ``add_provenance`` methods:
-    >>> dc_manager.add_source(name="ONE Data", url="https://data.one.org")
+    >>> dc_manager.add_source(dcid="ONEData", name="ONE Data", url="https://data.one.org")
     >>> dc_manager.add_provenance(
+    >>>     dcid="ONEClimateFinance",
     >>>     name="ONE Climate Finance",
     >>>     url="https://datacommons.one.org/data/climate-finance-files",
-    >>>     source="ONE Data",
+    >>>     source="ONEData",
     >>> )
 
     To add a variable for export to an MCF file, use the add_variable_to_mcf method.
-    ``Node`` accepts a bare or ``dcid:``-prefixed token, as the schema-node builders below do:
+    ``dcid`` accepts a bare or ``dcid:``-prefixed token, as the schema-node builders below do:
     >>> dc_manager.add_variable_to_mcf(
     >>>    dcid="StatVar",
     >>>    name="Variable Name",
@@ -106,8 +107,8 @@ class CustomDataManager:
 
     To add custom schema nodes (entity types, event types, properties, units, and
     measurement methods), use the five typed builders. All five accept bare or
-    ``dcid:``-prefixed ``Node`` tokens. Note: ``add_measurement_method`` is the only
-    builder where ``name`` is optional — only ``Node`` is required.
+    ``dcid:``-prefixed ``dcid`` tokens. Note: ``add_measurement_method`` is the only
+    builder where ``name`` is optional — only ``dcid`` is required.
     >>> dc_manager.add_entity_type(dcid="MyClass", name="My Class")
     >>> dc_manager.add_event_type(dcid="MyEvent", name="My Event")
     >>> dc_manager.add_property(
@@ -160,8 +161,8 @@ class CustomDataManager:
     Note: To add data, the input file must already be registered in the config file
     >>> dc_manager.add_data(<data>, "input_file.csv")
 
-    To set the includeInputSubdirs and the groupStatVarsByProperty fields of the config, use
-    the set_includeInputSubdirs and set_groupStatVarsByProperty methods
+    To set the ``include_input_subdirs`` and ``group_stat_vars_by_property`` config fields, use
+    the set_include_input_subdirs and set_group_stat_vars_by_property methods
     >>> dc_manager.set_include_input_subdirs(True)
     >>> dc_manager.set_group_stat_vars_by_property(True)
 
@@ -397,8 +398,9 @@ class CustomDataManager:
     def add_source(
         self,
         *,
-        name: str,
+        dcid: str,
         url: str,
+        name: str | None = None,
         description: str | None = None,
         license: str | None = None,
         is_part_of: str | None = None,
@@ -409,13 +411,15 @@ class CustomDataManager:
         """Add a Source MCF node.
 
         Emits a ``dcid:Source`` node to the MCF collection (default: ``provenance.mcf``).
-        The node is referenced by ``add_provenance`` via the same bare ``name``.
+        The node is referenced by ``add_provenance`` via the same bare ``dcid`` token
+        (passed to its ``source`` argument).
 
         Args:
-            name: Bare name for the source. Minting rule: bare name →
-                ``dcid:source/<name>``; pass an already ``dcid:``-prefixed value to use
-                it verbatim. Names must be valid dcid tokens (no whitespace).
+            dcid: Identifier for the source node. Minting rule: bare token →
+                ``dcid:source/<token>``; pass an already ``dcid:``-prefixed value to use
+                it verbatim. Must be a valid dcid token (no whitespace).
             url: URL of the data source.
+            name: Optional human-readable name of the source. (Optional)
             description: Optional human-readable description. (Optional)
             license: Optional license information. (Optional)
             is_part_of: Optional DCID of a parent source. (Optional)
@@ -429,13 +433,13 @@ class CustomDataManager:
             CustomDataManager object
 
         Raises:
-            ValueError: If the name contains whitespace, if a node with the same id
-                already exists and ``override`` is False, or if the file name is invalid.
+            ValueError: If the ``dcid`` token contains whitespace, if a node with the same
+                id already exists and ``override`` is False, or if the file name is invalid.
         """
 
-        dcid = mint_dcid(prefix="source", name=name)
+        dcid = mint_dcid(prefix="source", token=dcid)
         url = str(url)
-        props = _parse_kwargs_into_properties(locals(), extra_exclude={"name"})
+        props = _parse_kwargs_into_properties(locals())
         node = SourceNode(**props)
 
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -446,9 +450,10 @@ class CustomDataManager:
     def add_provenance(
         self,
         *,
-        name: str,
+        dcid: str,
         url: str,
         source: str,
+        name: str | None = None,
         description: str | None = None,
         license: str | None = None,
         license_type: str | None = None,
@@ -470,13 +475,14 @@ class CustomDataManager:
         The corresponding Source must already be registered via ``add_source``.
 
         Args:
-            name: Bare name for the provenance. Minting rule: bare name →
-                ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
-                use it verbatim. Names must be valid dcid tokens (no whitespace).
+            dcid: Identifier for the provenance node. Minting rule: bare token →
+                ``dcid:provenance/<token>``; pass an already ``dcid:``-prefixed value to
+                use it verbatim. Must be a valid dcid token (no whitespace).
             url: URL of the provenance dataset.
             source: Bare name of the parent Source (must already have been added via
                 ``add_source``). The same minting rule applies: bare name →
                 ``dcid:source/<source>``; ``dcid:``-prefixed → verbatim.
+            name: Optional human-readable name of the provenance. (Optional)
             description: Optional human-readable description. (Optional)
             license: Optional license information. (Optional)
             license_type: Optional license type. (Optional)
@@ -498,18 +504,16 @@ class CustomDataManager:
             CustomDataManager object
 
         Raises:
-            ValueError: If the ``source`` has not been added yet, if either name
-                contains whitespace, if a node with the same id already exists and
-                ``override`` is False, or if the file name is invalid.
+            ValueError: If the ``source`` has not been added yet, if the ``dcid`` or
+                ``source`` token contains whitespace, if a node with the same id already
+                exists and ``override`` is False, or if the file name is invalid.
         """
 
-        dcid = mint_dcid(prefix="provenance", name=name)
+        dcid = mint_dcid(prefix="provenance", token=dcid)
         url = str(url)
-        source_link = mint_dcid(prefix="source", name=source)
+        source_link = mint_dcid(prefix="source", token=source)
         self._require_source_exists(source, source_link)
-        props = _parse_kwargs_into_properties(
-            locals(), extra_exclude={"name", "source"}
-        )
+        props = _parse_kwargs_into_properties(locals(), extra_exclude={"source"})
         node = ProvenanceNode(**props)
 
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -1190,7 +1194,7 @@ class CustomDataManager:
                     return n
         raise ValueError(
             f"Provenance '{provenance}' not found. "
-            f"Call add_provenance(name={provenance!r}, url=..., source=...) "
+            f"Call add_provenance(dcid={provenance!r}, url=..., source=...) "
             f"before referencing it in includedIn."
         )
 
@@ -1217,7 +1221,7 @@ class CustomDataManager:
         expanded: list[str] = []
         seen: set[str] = set()
         for ref in refs:
-            prov_link = mint_dcid(prefix="provenance", name=ref)
+            prov_link = mint_dcid(prefix="provenance", token=ref)
             prov_node = self._require_provenance_exists(ref, prov_link)
             for dcid in (prov_link, getattr(prov_node, "source_link", None)):
                 if dcid is not None and dcid not in seen:
@@ -1239,7 +1243,7 @@ class CustomDataManager:
         ):
             raise ValueError(
                 f"Source '{source}' not found. "
-                f"Call add_source(name={source!r}, url=...) before add_provenance()."
+                f"Call add_source(dcid={source!r}, url=...) before add_provenance()."
             )
 
     def _validate_provenances(self) -> None:
@@ -1260,7 +1264,7 @@ class CustomDataManager:
                 raise ValueError(
                     f"Input file references unknown provenance '{bare}' "
                     f"('{entry.provenance}'). "
-                    f"Call add_provenance(name={bare!r}, url=..., source=...) first."
+                    f"Call add_provenance(dcid={bare!r}, url=..., source=...) first."
                 )
 
     def export_config(self, dir_path: str | PathLike[str]) -> None:

--- a/src/dcp_tools/custom_data/models/common.py
+++ b/src/dcp_tools/custom_data/models/common.py
@@ -216,35 +216,35 @@ def ensure_dcid(value: str | list[str]) -> str | list[str]:
     return f"dcid:{value}"
 
 
-def mint_dcid(*, prefix: str, name: str) -> str:
+def mint_dcid(*, prefix: str, token: str) -> str:
     """Mint a dcid for a source/provenance node id or reference.
 
     Three-way minting rule (canonical):
-        Bare name                     -> ``dcid:<prefix>/<name>``
+        Bare token                     -> ``dcid:<prefix>/<token>``
                                          e.g. ``'CustomSource'`` -> ``'dcid:source/CustomSource'``
         Already ``dcid:``-prefixed    -> returned verbatim (power-user escape hatch)
                                          e.g. ``'dcid:bio/y'`` -> ``'dcid:bio/y'``
         Contains ``/`` (no ``dcid:``) -> prepended with ``dcid:``
                                          e.g. ``'source/Foo'`` -> ``'dcid:source/Foo'``
-        Whitespace or empty name      -> ``ValueError`` (strict contract; no slugify)
+        Whitespace or empty token      -> ``ValueError`` (strict contract; no slugify)
 
     Args:
         prefix: Namespace prefix used when minting a bare name (e.g. ``'source'``,
             ``'provenance'``).
-        name: The bare name, partially-qualified path, or already-minted dcid.
+        token: The bare token, partially-qualified path, or already-minted dcid.
 
     Returns:
         A fully-qualified dcid string.
 
     Raises:
-        ValueError: If *name* is empty or contains any whitespace character.
+        ValueError: If *token* is empty or contains any whitespace character.
     """
-    if not name or any(c.isspace() for c in name):
+    if not token or any(c.isspace() for c in token):
         raise ValueError(
-            f"mint_dcid: name must be a non-empty token with no whitespace; got {name!r}"
+            f"mint_dcid: token must be non-empty with no whitespace; got {token!r}"
         )
-    if name.startswith("dcid:"):
-        return name
-    if "/" in name:
-        return f"dcid:{name}"
-    return f"dcid:{prefix}/{name}"
+    if token.startswith("dcid:"):
+        return token
+    if "/" in token:
+        return f"dcid:{token}"
+    return f"dcid:{prefix}/{token}"

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -180,7 +180,7 @@ class InputFile(BaseModel):
     @field_validator("provenance", mode="after")
     @classmethod
     def _mint_provenance(cls, value: str) -> str:
-        return mint_dcid(prefix="provenance", name=value)
+        return mint_dcid(prefix="provenance", token=value)
 
     @model_validator(mode="after")
     def _validate_filename_or_pattern(self) -> "InputFile":

--- a/tests/goldens/provenance.mcf
+++ b/tests/goldens/provenance.mcf
@@ -1,14 +1,20 @@
 Node: dcid:source/S1
+name: "S 1"
 typeOf: dcid:Source
+description: "A source that publishes data."
 url: "http://source1"
 
 Node: dcid:provenance/provA
+name: "Prov A"
 typeOf: dcid:Provenance
+description: "An example provenance."
 url: "http://prova"
 sourceLink: dcid:source/S1
 
 Node: dcid:provenance/provB
+name: "Prov B"
 typeOf: dcid:Provenance
+description: "Another example provenance."
 url: "http://provb"
 sourceLink: dcid:source/S1
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -29,11 +29,11 @@ def test_custom_data_manager_add_provenance_and_override():
 
     # add_provenance without a prior add_source must raise
     with pytest.raises(ValueError):
-        manager.add_provenance(name="pA", url="http://prov", source="new_source")
+        manager.add_provenance(dcid="pA", url="http://prov", source="new_source")
 
     # add_source then add_provenance succeeds
-    manager.add_source(name="new_source", url="http://src")
-    manager.add_provenance(name="pA", url="http://prov", source="new_source")
+    manager.add_source(dcid="new_source", url="http://src")
+    manager.add_provenance(dcid="pA", url="http://prov", source="new_source")
 
     prov_nodes = manager._mcf_nodes["provenance.mcf"].nodes
     source_node = next(n for n in prov_nodes if n.type_of == "dcid:Source")
@@ -46,11 +46,11 @@ def test_custom_data_manager_add_provenance_and_override():
 
     # duplicate provenance without override raises
     with pytest.raises(ValueError):
-        manager.add_provenance(name="pA", url="http://prov2", source="new_source")
+        manager.add_provenance(dcid="pA", url="http://prov2", source="new_source")
 
     # override replaces the node
     manager.add_provenance(
-        name="pA", url="http://prov2", source="new_source", override=True
+        dcid="pA", url="http://prov2", source="new_source", override=True
     )
     updated_prov = next(
         n
@@ -66,14 +66,17 @@ def test_add_source_metadata_lands_on_node():
     """Metadata kwargs on add_source are stored on the Source node."""
     manager = CustomDataManager()
     manager.add_source(
-        name="MySource",
+        dcid="MySource",
+        name="My Source",
         url="http://mysource.org",
         description="A test source",
         license="CC-BY-4.0",
     )
     nodes = manager._mcf_nodes["provenance.mcf"].nodes
     node = next(n for n in nodes if n.type_of == "dcid:Source")
+    assert isinstance(node, SourceNode)
     assert node.dcid == "dcid:source/MySource"
+    assert node.name == "My Source"
     # QuotedStr fields are stored raw; quotes applied at serialization
     assert node.description == "A test source"
     assert node.license == "CC-BY-4.0"
@@ -82,9 +85,10 @@ def test_add_source_metadata_lands_on_node():
 def test_add_provenance_metadata_lands_on_node():
     """Metadata kwargs on add_provenance are stored on the Provenance node."""
     manager = CustomDataManager()
-    manager.add_source(name="SrcX", url="http://srcx.org")
+    manager.add_source(dcid="SrcX", url="http://srcx.org")
     manager.add_provenance(
-        name="ProvX",
+        dcid="ProvX",
+        name="Prov X",
         url="http://provx.org",
         source="SrcX",
         description="Prov desc",
@@ -94,6 +98,8 @@ def test_add_provenance_metadata_lands_on_node():
     prov_node = next(n for n in nodes if n.type_of == "dcid:Provenance")
     assert isinstance(prov_node, ProvenanceNode)
     # QuotedStr fields are stored raw; quotes applied at serialization
+    assert prov_node.dcid == "dcid:provenance/ProvX"
+    assert prov_node.name == "Prov X"
     assert prov_node.description == "Prov desc"
     assert prov_node.last_data_refresh_date == "2024-01-01"
 
@@ -171,8 +177,8 @@ def test_add_input_file_registration_and_override(tmp_path):
     and override/error behaviors.
     """
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
 
     df3 = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
     manager.add_input_file(
@@ -211,8 +217,8 @@ def test_add_input_file_registration_and_override(tmp_path):
 def test_add_input_file_without_column_mappings():
     """Ensure missing columnMappings defaults to empty dict without error."""
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1]})
     manager.add_input_file(file_name="input.csv", provenance="p1", data=df)
@@ -226,8 +232,8 @@ def test_add_input_file_without_column_mappings():
 def test_add_input_file_pattern_xor_filename():
     """add_input_file raises when neither or both of file_name/pattern are given."""
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
 
     with pytest.raises(ValueError, match="Exactly one"):
         manager.add_input_file(provenance="p1")
@@ -241,8 +247,8 @@ def test_export_methods(tmp_path):
     Exercises export_config, export_data, and export_mcf_file.
     """
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"A": [1]})
     manager.add_input_file(
         file_name="data.csv",
@@ -271,8 +277,8 @@ def test_export_methods(tmp_path):
 def test_export_data_creates_missing_subdirectory(tmp_path):
     """export_data creates the parent directory for a nested file_name."""
     manager = CustomDataManager()
-    manager.add_source(name="S", url="http://s")
-    manager.add_provenance(name="P", url="http://p", source="S")
+    manager.add_source(dcid="S", url="http://s")
+    manager.add_provenance(dcid="P", url="http://p", source="S")
     manager.set_include_input_subdirs(True)
     manager.add_input_file(
         file_name="sub/gdp.csv",
@@ -314,8 +320,8 @@ def test_export_all_writes_full_bundle_for_subdirectory_input_file(tmp_path):
     """export_all writes the complete bundle when a file_name nests in a subdirectory."""
     manager = CustomDataManager()
     manager.set_include_input_subdirs(True)
-    manager.add_source(name="S", url="http://s")
-    manager.add_provenance(name="P", url="http://p", source="S")
+    manager.add_source(dcid="S", url="http://s")
+    manager.add_provenance(dcid="P", url="http://p", source="S")
     manager.add_entity_type(
         dcid="MyEntityType",
         name="My Entity Type",
@@ -437,8 +443,8 @@ def test_custom_data_manager_repr():
     Sanity-check CustomDataManager.__repr__ for correct counts.
     """
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"A": [1]})
     manager.add_input_file(
         file_name="f.csv",
@@ -457,8 +463,8 @@ def test_custom_data_manager_repr():
 
 def test_remove_indicator():
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1]})
     manager.add_input_file(
@@ -834,8 +840,8 @@ def test_rename_variable_frees_the_old_name_for_reuse():
 def test_validate_all_input_files_have_data(tmp_path):
     """Verify the optional data-completeness validation on export_all and the standalone method."""
     manager = CustomDataManager()
-    manager.add_source(name="s1", url="http://src")
-    manager.add_provenance(name="p1", url="http://prov", source="s1")
+    manager.add_source(dcid="s1", url="http://src")
+    manager.add_provenance(dcid="p1", url="http://prov", source="s1")
 
     df = pd.DataFrame({"A": [1, 2]})
 
@@ -1124,8 +1130,8 @@ def test_add_measurement_method_lands_node_and_typeof_override():
 def test_included_in_expands_to_provenance_and_source():
     """includedIn expands to both the provenance dcid and its linked source dcid."""
     manager = CustomDataManager()
-    manager.add_source(name="src", url="http://s")
-    manager.add_provenance(name="prov", url="http://p", source="src")
+    manager.add_source(dcid="src", url="http://s")
+    manager.add_provenance(dcid="prov", url="http://p", source="src")
     manager.add_entity_type(dcid="T", name="T", included_in="prov")
 
     entity_node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
@@ -1140,10 +1146,10 @@ def test_included_in_expands_to_provenance_and_source():
 def test_included_in_accepts_list_of_provenances():
     """A list of provenance names expands all four dcids in order."""
     manager = CustomDataManager()
-    manager.add_source(name="srcA", url="http://a")
-    manager.add_source(name="srcB", url="http://b")
-    manager.add_provenance(name="provA", url="http://pa", source="srcA")
-    manager.add_provenance(name="provB", url="http://pb", source="srcB")
+    manager.add_source(dcid="srcA", url="http://a")
+    manager.add_source(dcid="srcB", url="http://b")
+    manager.add_provenance(dcid="provA", url="http://pa", source="srcA")
+    manager.add_provenance(dcid="provB", url="http://pb", source="srcB")
     manager.add_entity_type(dcid="T", name="T", included_in=["provA", "provB"])
 
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]
@@ -1159,9 +1165,9 @@ def test_included_in_accepts_list_of_provenances():
 def test_included_in_dedups_shared_source():
     """Two provenances sharing a source emit that source exactly once."""
     manager = CustomDataManager()
-    manager.add_source(name="src", url="http://s")
-    manager.add_provenance(name="provA", url="http://pa", source="src")
-    manager.add_provenance(name="provB", url="http://pb", source="src")
+    manager.add_source(dcid="src", url="http://s")
+    manager.add_provenance(dcid="provA", url="http://pa", source="src")
+    manager.add_provenance(dcid="provB", url="http://pb", source="src")
     manager.add_entity_type(dcid="T", name="T", included_in=["provA", "provB"])
 
     node = manager._mcf_nodes["custom_nodes.mcf"].nodes[0]

--- a/tests/test_golden_serialization.py
+++ b/tests/test_golden_serialization.py
@@ -31,9 +31,9 @@ def test_config_json_snapshot(tmp_path):
     manager.set_import_name("test_import")
     manager.set_include_input_subdirs(True).set_group_stat_vars_by_property(False)
 
-    manager.add_source(name="S1", url="http://source1")
-    manager.add_provenance(name="provA", url="http://prova", source="S1")
-    manager.add_provenance(name="provB", url="http://provb", source="S1")
+    manager.add_source(dcid="S1", name="S 1", url="http://source1")
+    manager.add_provenance(dcid="provA", name="Prov A", url="http://prova", source="S1")
+    manager.add_provenance(dcid="provB", name="Prov B", url="http://provb", source="S1")
 
     manager.add_input_file(
         "a.csv",
@@ -57,8 +57,8 @@ def test_config_json_snapshot(tmp_path):
 def test_config_json_snapshot_multi_entity(tmp_path):
     manager = CustomDataManager()
     manager.set_import_name("test_import_multi_entity")
-    manager.add_source(name="S1", url="http://source1")
-    manager.add_provenance(name="provC", url="http://provc", source="S1")
+    manager.add_source(dcid="S1", name="S 1", url="http://source1")
+    manager.add_provenance(dcid="provC", name="Prov C", url="http://provc", source="S1")
     manager.add_input_file(
         "c.csv",
         provenance="provC",
@@ -79,9 +79,26 @@ def test_config_json_snapshot_multi_entity(tmp_path):
 
 def test_provenance_mcf_snapshot(tmp_path):
     manager = CustomDataManager()
-    manager.add_source(name="S1", url="http://source1")
-    manager.add_provenance(name="provA", url="http://prova", source="S1")
-    manager.add_provenance(name="provB", url="http://provb", source="S1")
+    manager.add_source(
+        dcid="S1",
+        name="S 1",
+        description="A source that publishes data.",
+        url="http://source1",
+    )
+    manager.add_provenance(
+        dcid="provA",
+        name="Prov A",
+        description="An example provenance.",
+        url="http://prova",
+        source="S1",
+    )
+    manager.add_provenance(
+        dcid="provB",
+        name="Prov B",
+        description="Another example provenance.",
+        url="http://provb",
+        source="S1",
+    )
 
     manager.export_mcf_file(str(tmp_path), mcf_file_name="provenance.mcf")
     got = (tmp_path / "provenance.mcf").read_text()

--- a/tests/test_input_file_characterization.py
+++ b/tests/test_input_file_characterization.py
@@ -29,8 +29,8 @@ from dcp_tools.gcp_utilities.storage import (
 def _manager(file_name="input.csv", *, with_data=True):
     """Manager with one source + one input file (optionally with data)."""
     mgr = CustomDataManager()
-    mgr.add_source(name="s1", url="http://src")
-    mgr.add_provenance(name="p1", url="http://prov", source="s1")
+    mgr.add_source(dcid="s1", url="http://src")
+    mgr.add_provenance(dcid="p1", url="http://prov", source="s1")
     df = pd.DataFrame({"entity": ["e1"], "Year": [2020], "Value": [100]})
     mgr.add_input_file(
         file_name=file_name,

--- a/tests/test_models_common.py
+++ b/tests/test_models_common.py
@@ -99,27 +99,29 @@ def test_ensure_dcid_maps_over_list():
 def test_mint_dcid_three_way_rule():
     """Covers each branch of the canonical minting rule."""
     # Bare name -> dcid:<prefix>/<name> (the real source/provenance callers)
-    assert mint_dcid(prefix="source", name="CustomSource") == "dcid:source/CustomSource"
     assert (
-        mint_dcid(prefix="provenance", name="CustomProv")
+        mint_dcid(prefix="source", token="CustomSource") == "dcid:source/CustomSource"
+    )
+    assert (
+        mint_dcid(prefix="provenance", token="CustomProv")
         == "dcid:provenance/CustomProv"
     )
     # Already dcid:-prefixed -> returned verbatim (escape hatch)
-    assert mint_dcid(prefix="source", name="dcid:bio/y") == "dcid:bio/y"
+    assert mint_dcid(prefix="source", token="dcid:bio/y") == "dcid:bio/y"
     # Contains "/" but no dcid: -> prepended with dcid:
-    assert mint_dcid(prefix="source", name="source/Foo") == "dcid:source/Foo"
+    assert mint_dcid(prefix="source", token="source/Foo") == "dcid:source/Foo"
 
 
 def test_mint_dcid_rejects_empty_or_whitespace_names():
     """Empty or whitespace-bearing names violate the strict contract."""
     with pytest.raises(ValueError):
-        mint_dcid(prefix="source", name="")
+        mint_dcid(prefix="source", token="")
     with pytest.raises(ValueError):
-        mint_dcid(prefix="source", name="has space")
+        mint_dcid(prefix="source", token="has space")
     with pytest.raises(ValueError):
-        mint_dcid(prefix="source", name="  leading")
+        mint_dcid(prefix="source", token="  leading")
     with pytest.raises(ValueError):
-        mint_dcid(prefix="source", name="trailing\t")
+        mint_dcid(prefix="source", token="trailing\t")
 
 
 # --- DcidOrListDcid and friends (regression test for #126) ---


### PR DESCRIPTION
Closes https://github.com/ONEcampaign/dcp-tools/issues/139

- `add_source` and `add_provenance` now take separate `dcid` (identifier, minted with the source/provenance slug prefix), optional `name` (human-readable label), and `description` parameters. Previously `name` was used as the identifier and the node's own `name` property was never set.
