### PR TITLE
Rename `remove_indicator` to `remove_variable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,9 @@
   `dcid` is the identifier (minted with the `source/`/`provenance/` slug prefix); `name` is an
   optional human-readable label; `description` is optional longer text. Previously `name` was used
   as the identifier and the node's own `name` property was never set.
+- **Renamed `CustomDataManager.remove_indicator` to `remove_variable`** (parameter `indicator_id`
+  → `dcid`), matching the `variable` terminology used elsewhere (`rename_variable`,
+  `add_variable_to_mcf`).
 
 ### Fixed
 - `rename_variable` left the `MCFNodes` lookup index keyed by the old name, so
@@ -185,6 +188,8 @@
   file.
 - In `add_source`/`add_provenance` calls, pass the identifier as `dcid=` (was `name=`); optionally
   pass `name=` for a human-readable label.
+- Rename `remove_indicator(...)` calls to `remove_variable(...)`; the positional id argument is
+  unchanged, and the keyword is now `dcid` (was `indicator_id`).
 
 ## [0.1.1] - 2026-02-19
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -113,6 +113,8 @@
 - **Breaking:** `add_source` and `add_provenance` take separate `dcid` (identifier, minted with the
   slug prefix), optional `name` (label), and `description` parameters. Previously `name` was the
   identifier and no `name` property was set — pass the identifier as `dcid=` now.
+- **Breaking:** `CustomDataManager.remove_indicator` is renamed to `remove_variable` (parameter
+  `indicator_id` → `dcid`), matching the `variable` terminology used elsewhere.
 
 ## v0.1.0 (in development)
 - Initial release of the `dcp-tools` package for external preview and testing

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -315,11 +315,8 @@ name isn't found or the new name is already taken. Scope the search to one file 
 `mcf_file_name=`. Omit it and all loaded MCF files are searched.
 
 ```python
-manager.remove_indicator("dcid:climateFinanceCommitmentsProvided")
+manager.remove_variable("dcid:climateFinanceCommitmentsProvided")
 ```
-
-!!! warning "Heads up"
-    There's no `remove_variable` method. The real name is `remove_indicator`.
 
 ## How to merge config files
 

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -1135,22 +1135,22 @@ class CustomDataManager:
 
         return self
 
-    def remove_indicator(
-        self, indicator_id: str, *, mcf_file_name: str | None = None
+    def remove_variable(
+        self, dcid: str, *, mcf_file_name: str | None = None
     ) -> CustomDataManager:
-        """Remove a single indicator from the manager.
+        """Remove a single variable from the manager.
 
-        This removes the indicator from any loaded MCF files. If
+        This removes the variable from any loaded MCF files. If
         ``mcf_file_name`` is provided, only that MCF file is searched;
         otherwise all MCF files will be inspected.
 
         Args:
-            indicator_id: Identifier of the indicator/StatVar to remove.
+            dcid: DCID of the StatVar to remove.
             mcf_file_name: Optional name of the MCF file from which to remove the
                 node. If omitted, all managed MCF files are searched.
 
         Raises:
-            ValueError: If the indicator is not found in any MCF file.
+            ValueError: If the variable is not found in any MCF file.
         """
 
         found = False
@@ -1171,13 +1171,13 @@ class CustomDataManager:
             if not nodes:
                 continue
             try:
-                nodes.remove(indicator_id)
+                nodes.remove(dcid)
                 found = True
             except ValueError:
                 pass
 
         if not found:
-            raise ValueError(f"Indicator '{indicator_id}' not found")
+            raise ValueError(f"Statistical variable '{dcid}' not found")
 
         return self
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -357,7 +357,7 @@ def test_export_all_overwrites_correctly(tmp_path):
         "statType: dcid:measuredValue\n\n"
     )
 
-    manager.remove_indicator("dcid:MyVariable")
+    manager.remove_variable("dcid:MyVariable")
     manager.export_all(tmp_path)
     assert (tmp_path / "custom_nodes.mcf").read_text() == ""
 
@@ -461,7 +461,7 @@ def test_custom_data_manager_repr():
     assert "1 variables" in r
 
 
-def test_remove_indicator():
+def test_remove_variable():
     manager = CustomDataManager()
     manager.add_source(dcid="s1", url="http://src")
     manager.add_provenance(dcid="p1", url="http://prov", source="s1")
@@ -475,12 +475,12 @@ def test_remove_indicator():
     )
     manager.add_variable_to_mcf(dcid="dcid:sv1", name="Var", provenance="p1")
 
-    manager.remove_indicator("dcid:sv1")
+    manager.remove_variable("dcid:sv1")
     for nodes in manager._mcf_nodes.values():
         assert all(n.dcid != "dcid:sv1" for n in nodes.nodes)
 
     with pytest.raises(ValueError):
-        manager.remove_indicator("missing")
+        manager.remove_variable("missing")
 
 
 def _make_cfg(
@@ -817,10 +817,10 @@ def test_rename_variable_keeps_lookup_index_consistent():
 
     # The old name no longer resolves...
     with pytest.raises(ValueError):
-        manager.remove_indicator("dcid:v1")
+        manager.remove_variable("dcid:v1")
 
     # ...and the new one does.
-    manager.remove_indicator("dcid:v2")
+    manager.remove_variable("dcid:v2")
     for nodes in manager._mcf_nodes.values():
         assert all(n.dcid not in {"dcid:v1", "dcid:v2"} for n in nodes.nodes)
 


### PR DESCRIPTION
Closes https://github.com/ONEcampaign/dcp-tools/issues/141

- Renames `CustomDataManager.remove_indicator` to `remove_variable` (parameter `indicator_id` → `dcid`), for consistency with the `variable` terminology Data Commons uses (and that `rename_variable`/`add_variable_to_mcf` already use).
