### PR TITLE
Rename `ProvenanceNode.source_link` to `source`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ProvenanceNode.source_link` is renamed to `source`, so a provenance's parent
+  source now serializes as `source: dcid:source/<name>` (was `sourceLink:`), the property name
+  Data Commons ingestion preprocessing expects.
+
 ## [1.0.0a1] - 2026-07-27
 
 ### Added

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- **Breaking:** `ProvenanceNode.source_link` is renamed to `source`, so a provenance's parent
+  source now serializes as `source: dcid:source/<name>` (was `sourceLink:`), the property name
+  Data Commons ingestion preprocessing expects.
+
 ## v1.0.0a1 (2026-07-27)
 
 - First alpha of the `dcp-tools` package, the first release under the new name.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -92,7 +92,7 @@ url: "https://data.one.org"
 Node: dcid:provenance/ONEClimateFinance
 typeOf: dcid:Provenance
 url: "https://datacommons.one.org/data/climate-finance-files"
-sourceLink: dcid:source/ONEData
+source: dcid:source/ONEData
 ```
 
 ## Step 3: Register the input CSV file

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -49,14 +49,10 @@ DEFAULT_PROVENANCE_MCF_NAME: str = "provenance.mcf"
 DEFAULT_VERTICAL_SPECS_NAME: str = "vertical_specs.json"
 
 
-def _parse_kwargs_into_properties(
-    locals_dict: dict[str, Any], *, extra_exclude: set[str] | None = None
-) -> dict[str, Any]:
+def _parse_kwargs_into_properties(locals_dict: dict[str, Any]) -> dict[str, Any]:
     """Parse a dictionary of keyword arguments into a dictionary of properties"""
 
     exclude = {"self", "additional_properties", "override", "mcf_file_name"}
-    if extra_exclude:
-        exclude |= extra_exclude
 
     props = {k: v for k, v in locals_dict.items() if k not in exclude and v is not None}
 
@@ -511,9 +507,9 @@ class CustomDataManager:
 
         dcid = mint_dcid(prefix="provenance", token=dcid)
         url = str(url)
-        source_link = mint_dcid(prefix="source", token=source)
-        self._require_source_exists(source, source_link)
-        props = _parse_kwargs_into_properties(locals(), extra_exclude={"source"})
+        source = mint_dcid(prefix="source", token=source)
+        self._require_source_exists(source)
+        props = _parse_kwargs_into_properties(locals())
         node = ProvenanceNode(**props)
 
         mcf_name = validate_mcf_file_name(mcf_file_name)
@@ -1203,7 +1199,7 @@ class CustomDataManager:
 
         For each reference: mint to ``dcid:provenance/<name>``, require the Provenance node
         to exist, and emit includedIn for BOTH the provenance and its linked Source
-        (``sourceLink``). Order is preserved and duplicate dcids are collapsed (so two
+        (``source``). Order is preserved and duplicate dcids are collapsed (so two
         provenances sharing a source emit that source once).
 
         Args:
@@ -1223,21 +1219,20 @@ class CustomDataManager:
         for ref in refs:
             prov_link = mint_dcid(prefix="provenance", token=ref)
             prov_node = self._require_provenance_exists(ref, prov_link)
-            for dcid in (prov_link, getattr(prov_node, "source_link", None)):
+            for dcid in (prov_link, getattr(prov_node, "source", None)):
                 if dcid is not None and dcid not in seen:
                     seen.add(dcid)
                     expanded.append(dcid)
         return expanded
 
-    def _require_source_exists(self, source: str, source_link: str) -> None:
-        """Raise ValueError if no Source MCF node with id ``source_link`` exists.
+    def _require_source_exists(self, source: str) -> None:
+        """Raise ValueError if no Source MCF node with id ``source`` exists.
 
         Args:
-            source: The bare user-facing source name (used in the error message).
-            source_link: The minted dcid for the source (used for the lookup).
+            source: The minted dcid for the source.
         """
         if not any(
-            n.type_of == "dcid:Source" and n.dcid == source_link
+            n.type_of == "dcid:Source" and n.dcid == source
             for nodes in self._mcf_nodes.values()
             for n in nodes.nodes
         ):

--- a/src/dcp_tools/custom_data/models/sources.py
+++ b/src/dcp_tools/custom_data/models/sources.py
@@ -38,7 +38,7 @@ class ProvenanceNode(Node):
         # Provenance-specific
         type_of: Fixed type indicating this is a Provenance (``dcid:Provenance``).
         url: URL of the provenance dataset.
-        source_link: DCID of the parent Source node.
+        source: DCID of the parent Source node.
         license: Optional license information.
         license_type: Optional license type.
         last_data_refresh_date: Optional date of last data refresh.
@@ -53,7 +53,7 @@ class ProvenanceNode(Node):
 
     type_of: Literal["dcid:Provenance"] = "dcid:Provenance"
     url: QuotedStr | None = None
-    source_link: Dcid | None = None
+    source: Dcid | None = None
     license: QuotedStr | None = None
     license_type: QuotedStr | None = None
     last_data_refresh_date: QuotedStr | None = None

--- a/tests/goldens/provenance.mcf
+++ b/tests/goldens/provenance.mcf
@@ -9,12 +9,12 @@ name: "Prov A"
 typeOf: dcid:Provenance
 description: "An example provenance."
 url: "http://prova"
-sourceLink: dcid:source/S1
+source: dcid:source/S1
 
 Node: dcid:provenance/provB
 name: "Prov B"
 typeOf: dcid:Provenance
 description: "Another example provenance."
 url: "http://provb"
-sourceLink: dcid:source/S1
+source: dcid:source/S1
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -42,7 +42,7 @@ def test_custom_data_manager_add_provenance_and_override():
     assert isinstance(prov_node, ProvenanceNode)
     assert source_node.dcid == "dcid:source/new_source"
     assert prov_node.dcid == "dcid:provenance/pA"
-    assert prov_node.source_link == "dcid:source/new_source"
+    assert prov_node.source == "dcid:source/new_source"
 
     # duplicate provenance without override raises
     with pytest.raises(ValueError):

--- a/tests/test_models_sources.py
+++ b/tests/test_models_sources.py
@@ -1,0 +1,63 @@
+from dcp_tools.custom_data.models.sources import ProvenanceNode, SourceNode
+
+
+def test_source_to_mcf():
+    node = SourceNode(
+        dcid="dcid:MySource",
+        name="My Source",
+        description="Description of My Source",
+        url="https://example.com",
+        license="https://example.com/license",
+        is_part_of="dcid:ParentSource",
+    )
+
+    assert node.to_mcf() == (
+        "Node: dcid:MySource\n"
+        'name: "My Source"\n'
+        "typeOf: dcid:Source\n"
+        'description: "Description of My Source"\n'
+        'url: "https://example.com"\n'
+        'license: "https://example.com/license"\n'
+        "isPartOf: dcid:ParentSource\n"
+        "\n"
+    )
+
+
+def test_provenance_to_mcf():
+    node = ProvenanceNode(
+        dcid="dcid:MyProvenance",
+        name="My Provenance",
+        description="Description of My Provenance",
+        url="https://example.com",
+        source="dcid:MySource",
+        license="https://example.com/license",
+        license_type="dcid:MyLicenseType",
+        last_data_refresh_date="2026-01-01",
+        next_data_refresh_date="2026-01-02",
+        next_source_release_date="2026-01-03",
+        source_release_frequency="P1Y",
+        earliest_observation_date="2026-01-04",
+        latest_observation_date="2026-01-05",
+        curator="dcid:MyOrganisation",
+        is_part_of="dcid:MyDataset",
+    )
+
+    assert node.to_mcf() == (
+        "Node: dcid:MyProvenance\n"
+        'name: "My Provenance"\n'
+        "typeOf: dcid:Provenance\n"
+        'description: "Description of My Provenance"\n'
+        'url: "https://example.com"\n'
+        "source: dcid:MySource\n"
+        'license: "https://example.com/license"\n'
+        'licenseType: "dcid:MyLicenseType"\n'
+        'lastDataRefreshDate: "2026-01-01"\n'
+        'nextDataRefreshDate: "2026-01-02"\n'
+        'nextSourceReleaseDate: "2026-01-03"\n'
+        'sourceReleaseFrequency: "P1Y"\n'
+        'earliestObservationDate: "2026-01-04"\n'
+        'latestObservationDate: "2026-01-05"\n'
+        'curator: "dcid:MyOrganisation"\n'
+        "isPartOf: dcid:MyDataset\n"
+        "\n"
+    )


### PR DESCRIPTION
Closes https://github.com/ONEcampaign/dcp-tools/issues/150

- Rename `ProvenanceNode.source_link` to `source` for consistency with actual graph node property, and fix serialisation that currently fails the DCP ingestion preprocessing job
- Added unit tests for `SourceNode` and `ProvenanceNode` happy path MCF serialization