### PR TITLE
fix: allow consumers to declare MCF files in config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `add_mcf_file(file_name, provenance=...)` declares an MCF file in `config.json`'s `inputFiles`,
+  so the importer reads it. The importer skips MCF files that aren't declared.
+
+### Changed
+- `InputFile` represents both CSV and MCF entries. An entry targeting an `.mcf` file carries only
+  a `provenance` — no `columnMappings` and no `format`. CSV entries are unchanged.
+
 ### Fixed
 - `ProvenanceNode.source_link` is renamed to `source`, so a provenance's parent
   source now serializes as `source: dcid:source/<name>` (was `sourceLink:`), the property name

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ manager.add_variable_to_mcf(
     stat_type="dcid:measuredValue",
 )
 
+manager.add_mcf_file("*.mcf", provenance="ONEClimateFinance")
+
 out_dir = Path("export/climate_finance")
 out_dir.mkdir(parents=True, exist_ok=True)
 manager.export_all(out_dir)
@@ -103,6 +105,10 @@ name, and column mappings and the provenance name are resolved to full dcids:
             },
             "observationProperties": {"unit": "USDollar"},
             "format": "variablePerRow"
+        },
+        {
+            "pattern": "*.mcf",
+            "provenance": "dcid:provenance/ONEClimateFinance"
         }
     ]
 }

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,9 @@
 - **Breaking:** `ProvenanceNode.source_link` is renamed to `source`, so a provenance's parent
   source now serializes as `source: dcid:source/<name>` (was `sourceLink:`), the property name
   Data Commons ingestion preprocessing expects.
+- Added `add_mcf_file(file_name, provenance=...)` to declare an MCF file in `config.json`'s
+  `inputFiles`. `add_mcf_file("*.mcf", provenance=...)` covers them all in a single-provenance
+  import; declare each file separately when an import has more than one provenance.
 
 ## v1.0.0a1 (2026-07-27)
 

--- a/docs/docs/dc-schemas.md
+++ b/docs/docs/dc-schemas.md
@@ -38,9 +38,11 @@ predicate, and why the schema-defining nodes live in a separate file format.
 
 ### `config.json` declares column roles, not data
 
-Every entry in `config.json`'s `inputFiles` list points at a CSV and carries a `columnMappings`
-block. The block doesn't hold data. It holds a role assignment: which column in *this specific
-CSV* plays which part in *every* observation the importer will build from it.
+Every entry in `config.json`'s `inputFiles` list points at either a CSV of observations or an
+MCF file of node definitions. A CSV entry carries a `columnMappings` block. The block
+doesn't hold data. It holds a role assignment: which column in *this specific CSV* plays
+which part in *every* observation the importer will build from it. An MCF entry carries no
+mappings — there are no columns to assign — only the provenance its nodes belong to.
 
 ```python
 from dcp_tools import CustomDataManager
@@ -196,9 +198,9 @@ implicit" name itself. A contrast only needs a name when there's something to co
 
 ## Consequences
 
-Every input file dcp-tools writes is variable-per-row. You don't choose a format when calling
+Every CSV input file dcp-tools writes is variable-per-row. You don't choose a format when calling
 `add_input_file`. There's exactly one, so the question doesn't come up. `columnMappings` is
-always required (it's how the importer finds your columns at all), and it always uses
+always required on a CSV entry (it's how the importer finds your columns at all), and it always uses
 `observationAbout` for single-entity data or `custom:<name>` keys for multi-entity data, never a
 bare `entity` key. That field was renamed for the same reason, to stop implying entity and
 observationAbout were different things.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -183,7 +183,15 @@ measuredProperty: dcid:amount
 
 The `provenance` field here is the bare name you passed in, stored as a plain quoted string on the node, not the minted dcid you saw on the input file entry in Step 3.
 
-## Step 5: Export the bundle and verify it
+## Step 5: Declare the MCF files
+
+The importer only reads files listed in `config.json`'s `inputFiles`, so the MCF files written next to the config need an entry too, naming the provenance their nodes belong to. One glob covers both files in this import:
+
+```python
+manager.add_mcf_file("*.mcf", provenance="ONEClimateFinance")
+```
+
+## Step 6: Export the bundle and verify it
 
 `export_all` writes the config, the data, and any MCF files you've registered.
 
@@ -224,6 +232,10 @@ one_climate_finance/climate_finance/one_cf_provider_commitments.csv
                 "dcid:observationAbout": "country"
             },
             "format": "variablePerRow"
+        },
+        {
+            "pattern": "*.mcf",
+            "provenance": "dcid:provenance/ONEClimateFinance"
         }
     ]
 }
@@ -244,7 +256,7 @@ print(reloaded)
 
 ```
 <CustomDataManager config:
-1 inputFiles, with 0 containing data
+2 inputFiles, with 0 containing data
 1 sources
 1 provenances
 1 variables
@@ -252,13 +264,14 @@ print(reloaded)
 flags: importName=one_climate_finance, includeInputSubdirs=None, groupStatVarsByProperty=None, defaultCustomRootStatVarGroupName=None, customIdNamespace=None, customSvgPrefix=None, svHierarchyPropsBlocklist=None, dataDownloadUrl=None, verticalSpecsFile=None>
 ```
 
-1 input file, 1 source, 1 provenance, 1 variable. `with 0 containing data` is expected. Reloading from `config_file`/`mcf_files` restores the config and MCF nodes, not the CSV data. That data lives in the CSV file on disk, never in `config.json`.
+2 input files (the CSV and the `*.mcf` declaration), 1 source, 1 provenance, 1 variable. `with 0 containing data` is expected. Reloading from `config_file`/`mcf_files` restores the config and MCF nodes, not the CSV data. That data lives in the CSV file on disk, never in `config.json`.
 
 ## What you learned
 
 - You registered a source and a provenance as MCF nodes
 - You registered an input CSV file with column mappings
 - You declared a StatVar for a data file
+- You declared the MCF files so the importer reads them
 - You exported a complete bundle with `export_all`
 - You verified an exported bundle by loading it back
 

--- a/docs/docs/preparing-data.md
+++ b/docs/docs/preparing-data.md
@@ -375,6 +375,38 @@ Each call appends one spec matching StatVars about `population_type` with the gi
 `file_name=` here. `export_all` (or `export_vertical_specs` directly) writes the accumulated specs
 as `{"specs": [...]}` JSON. Exporting with no specs added raises `ValueError`.
 
+## How to declare MCF files for the importer
+
+The importer only reads files listed in `config.json`'s `inputFiles`, so every MCF file in the
+bundle needs an entry naming the provenance its nodes belong to. With a single provenance, one
+glob covers every MCF file:
+
+```python
+manager.add_mcf_file("*.mcf", provenance="MyProvenance")
+```
+
+The entry carries no `columnMappings` and no `format` — there are no columns to map.
+
+With more than one provenance, a single glob would attribute every node to the same one. Write
+nodes to per-provenance files with `mcf_file_name`, then declare each file against its own
+provenance:
+
+```python
+manager.add_provenance(
+    dcid="ProvB", url="https://source.org/b", source="MySource",
+    mcf_file_name="provenance_b.mcf",
+)
+manager.add_variable_to_mcf(dcid="dcid:VarB", name="Var B", mcf_file_name="nodes_b.mcf")
+
+manager.add_mcf_file("provenance.mcf", provenance="ProvA")
+manager.add_mcf_file("custom_nodes.mcf", provenance="ProvA")
+manager.add_mcf_file("provenance_b.mcf", provenance="ProvB")
+manager.add_mcf_file("nodes_b.mcf", provenance="ProvB")
+```
+
+Nothing checks that you declared every MCF file you wrote, so a file you forget is simply absent
+from the bundle the importer sees.
+
 ## How to validate and export the bundle
 
 Validate without writing anything:

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -1015,7 +1015,11 @@ class CustomDataManager:
             filename=file_name,
             pattern=pattern,
             provenance=provenance,
-            column_mappings=ColumnMappings.model_validate(column_mappings or {}),
+            column_mappings=(
+                ColumnMappings.model_validate(column_mappings)
+                if column_mappings is not None
+                else None
+            ),
             observation_properties=(
                 ObservationProperties(**observation_properties)
                 if observation_properties is not None
@@ -1053,6 +1057,44 @@ class CustomDataManager:
             self._data[file_name] = data
 
         return self
+
+    def add_mcf_file(
+        self,
+        file_name: str,
+        *,
+        provenance: str,
+        override: bool = False,
+    ) -> CustomDataManager:
+        """Declare an MCF file in the config's ``inputFiles`` list.
+
+        The importer only reads files listed in ``inputFiles``, and attributes an MCF
+        file's nodes to the provenance declared alongside it, so every MCF file needs an
+        entry. A glob is accepted: ``add_mcf_file("*.mcf", provenance=...)`` covers every
+        MCF file in an import with one provenance. With several, write nodes to
+        per-provenance files (via each builder's ``mcf_file_name``) and declare each here.
+
+        Args:
+            file_name: Name of the MCF file, or a glob matching several (must end
+                in .mcf).
+            provenance: Provenance name for the nodes in the file. Bare name → minted
+                as ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed
+                value to use it verbatim.
+            override: If True, replace an existing entry for the same file. Defaults
+                to False.
+
+        Returns:
+            CustomDataManager object
+
+        Raises:
+            ValueError: If the file name is invalid, or an entry for it already exists
+                and ``override`` is False.
+        """
+
+        return self.add_input_file(
+            pattern=validate_mcf_file_name(file_name),
+            provenance=provenance,
+            override=override,
+        )
 
     def add_data(
         self, data: pd.DataFrame, file_name: str, override: bool = False
@@ -1403,7 +1445,7 @@ class CustomDataManager:
         dir_path: str | PathLike[str],
         validate_data: bool = False,
     ) -> None:
-        """Export the config, MCF file, and data to a directory
+        """Export the config, MCF files, and data to a directory
 
         ``export_all`` overwrites the complete bundle. To export only the config
         (deferring MCF export), use ``export_config`` directly. To export a single MCF

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -145,24 +145,33 @@ class InputFile(BaseModel):
     observation per row) or an MCF file of node definitions. Both need a ``provenance``;
     only CSV entries need column mappings and a format.
 
-    Exactly one of ``filename`` or ``pattern`` must be set. The extension check
-    applies to ``filename`` only; ``pattern`` entries are exempt.
+    Exactly one of ``filename`` or ``pattern`` must be set, and ``filename`` always names
+    a CSV (enforced by the ``.csv`` extension check below). An MCF entry can only be
+    expressed via ``pattern`` — see ``CustomDataManager.add_mcf_file``, which always uses
+    it, even for an exact filename (a literal name is a valid glob). This isn't an
+    arbitrary restriction: ``add_data``, ``export_data``, and
+    ``validate_all_input_files_have_data`` all treat any entry with ``filename`` set as a
+    data-bearing CSV target, with no awareness of ``is_mcf``. Letting ``filename`` end in
+    ``.mcf`` would let those silently treat an MCF declaration as a CSV.
 
     Attributes:
-        filename: Exact file name (mutually exclusive with ``pattern``).
+        filename: Exact CSV file name (mutually exclusive with ``pattern``; always
+            requires a ``.csv`` extension, never ``.mcf``).
         pattern: Glob pattern matching one or more input files (mutually exclusive
             with ``filename``). Pattern entries are config-only: ``data=`` is not
-            accepted with ``pattern=``.
+            accepted with ``pattern=``. The only way to declare an MCF file; no
+            extension check applies here.
         provenance: Provenance name for the data. Bare name is minted as
             ``dcid:provenance/<name>``; pass an already ``dcid:``-prefixed value to
             use it verbatim. Names must be valid dcid tokens (no whitespace).
         ignore_columns: List of columns to ignore.
         column_mappings: If headings in the CSV file do not use the default names,
-            the equivalent names for each column.
+            the equivalent names for each column. Absent for MCF entries.
         observation_properties: File-level constant observation properties applied to every
-            observation (constants such as unit or measurementMethod). Optional.
+            observation (constants such as unit or measurementMethod). Optional; absent
+            for MCF entries.
         data_format: Format of the data (variable per row, one observation per row).
-            This attribute is represented as "format" in the JSON.
+            This attribute is represented as "format" in the JSON. Absent for MCF entries.
     """
 
     filename: str | None = None
@@ -181,7 +190,12 @@ class InputFile(BaseModel):
 
     @property
     def is_mcf(self) -> bool:
-        """Whether this entry declares an MCF file rather than a CSV."""
+        """Whether this entry declares an MCF file rather than a CSV.
+
+        Checks both ``filename`` and ``pattern`` for symmetry, but ``filename`` can never
+        actually end in ``.mcf`` on a validated instance (see the class docstring), so in
+        practice this is only ever true for a ``pattern`` entry.
+        """
         return (self.filename or self.pattern or "").lower().endswith(".mcf")
 
     @field_validator("provenance", mode="after")
@@ -193,12 +207,12 @@ class InputFile(BaseModel):
     def _validate_entry(self) -> "InputFile":
         if (self.filename is None) == (self.pattern is None):
             raise ValueError("Exactly one of 'filename' or 'pattern' must be set.")
+        if self.filename is not None and not self.filename.lower().endswith(".csv"):
+            raise ValueError(f'filename "{self.filename}" must have a .csv extension.')
         if self.is_mcf:
             # An MCF file holds node definitions, not observations, so none of the
             # observation settings below apply.
             return self
-        if self.filename is not None and not self.filename.lower().endswith(".csv"):
-            raise ValueError(f'filename "{self.filename}" must have a .csv extension.')
         if self.column_mappings is None:
             self.column_mappings = ColumnMappings()
         if self.data_format is None:

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -145,18 +145,14 @@ class InputFile(BaseModel):
     observation per row) or an MCF file of node definitions. Both need a ``provenance``;
     only CSV entries need column mappings and a format.
 
-    Exactly one of ``filename`` or ``pattern`` must be set, and ``filename`` always names
-    a CSV (enforced by the ``.csv`` extension check below). An MCF entry can only be
-    expressed via ``pattern`` — see ``CustomDataManager.add_mcf_file``, which always uses
-    it, even for an exact filename (a literal name is a valid glob). This isn't an
-    arbitrary restriction: ``add_data``, ``export_data``, and
-    ``validate_all_input_files_have_data`` all treat any entry with ``filename`` set as a
-    data-bearing CSV target, with no awareness of ``is_mcf``. Letting ``filename`` end in
-    ``.mcf`` would let those silently treat an MCF declaration as a CSV.
+    Exactly one of ``filename`` or ``pattern`` must be set:
+    - ``filename`` names one CSV file and must end in ``.csv``.
+    - ``pattern`` is a glob matching one or more files, and is the only way to declare
+      an MCF file. An exact file name works too, since a literal name is a valid glob.
 
     Attributes:
-        filename: Exact CSV file name (mutually exclusive with ``pattern``; always
-            requires a ``.csv`` extension, never ``.mcf``).
+        filename: Exact CSV file name (mutually exclusive with ``pattern``; must have a
+            ``.csv`` extension).
         pattern: Glob pattern matching one or more input files (mutually exclusive
             with ``filename``). Pattern entries are config-only: ``data=`` is not
             accepted with ``pattern=``. The only way to declare an MCF file; no
@@ -192,9 +188,9 @@ class InputFile(BaseModel):
     def is_mcf(self) -> bool:
         """Whether this entry declares an MCF file rather than a CSV.
 
-        Checks both ``filename`` and ``pattern`` for symmetry, but ``filename`` can never
-        actually end in ``.mcf`` on a validated instance (see the class docstring), so in
-        practice this is only ever true for a ``pattern`` entry.
+        Checks both ``filename`` and ``pattern`` for symmetry, but a validated instance
+        can never have a ``.mcf`` ``filename``, so in practice this is only true for
+        ``pattern`` entries.
         """
         return (self.filename or self.pattern or "").lower().endswith(".mcf")
 
@@ -207,6 +203,10 @@ class InputFile(BaseModel):
     def _validate_entry(self) -> "InputFile":
         if (self.filename is None) == (self.pattern is None):
             raise ValueError("Exactly one of 'filename' or 'pattern' must be set.")
+        # `filename` is CSV-only because add_data, export_data, and
+        # validate_all_input_files_have_data treat every filename entry as a
+        # data-bearing CSV target, without checking `is_mcf`. A `.mcf` filename would
+        # let them silently handle an MCF declaration as a CSV.
         if self.filename is not None and not self.filename.lower().endswith(".csv"):
             raise ValueError(f'filename "{self.filename}" must have a .csv extension.')
         if self.is_mcf:

--- a/src/dcp_tools/custom_data/models/data_files.py
+++ b/src/dcp_tools/custom_data/models/data_files.py
@@ -139,13 +139,17 @@ class ObservationProperties(BaseModel):
 
 
 class InputFile(BaseModel):
-    """Representation of an input file in variable-per-row form (one observation per row).
+    """Representation of an entry in the config's ``inputFiles`` list.
 
-    Exactly one of ``filename`` or ``pattern`` must be set. The ``.csv``-suffix
-    check applies to ``filename`` only; ``pattern`` entries are exempt.
+    An entry declares either a CSV file of observations in variable-per-row form (one
+    observation per row) or an MCF file of node definitions. Both need a ``provenance``;
+    only CSV entries need column mappings and a format.
+
+    Exactly one of ``filename`` or ``pattern`` must be set. The extension check
+    applies to ``filename`` only; ``pattern`` entries are exempt.
 
     Attributes:
-        filename: Exact CSV file name (mutually exclusive with ``pattern``).
+        filename: Exact file name (mutually exclusive with ``pattern``).
         pattern: Glob pattern matching one or more input files (mutually exclusive
             with ``filename``). Pattern entries are config-only: ``data=`` is not
             accepted with ``pattern=``.
@@ -165,11 +169,9 @@ class InputFile(BaseModel):
     pattern: str | None = None
     provenance: str
     ignore_columns: list[str] | None = None
-    column_mappings: ColumnMappings
+    column_mappings: ColumnMappings | None = None
     observation_properties: ObservationProperties | None = None
-    data_format: Literal["variablePerRow"] = Field(
-        default="variablePerRow", alias="format"
-    )
+    data_format: Literal["variablePerRow"] | None = Field(default=None, alias="format")
 
     model_config = ConfigDict(
         alias_generator=to_camel,
@@ -177,15 +179,28 @@ class InputFile(BaseModel):
         populate_by_name=True,
     )
 
+    @property
+    def is_mcf(self) -> bool:
+        """Whether this entry declares an MCF file rather than a CSV."""
+        return (self.filename or self.pattern or "").lower().endswith(".mcf")
+
     @field_validator("provenance", mode="after")
     @classmethod
     def _mint_provenance(cls, value: str) -> str:
         return mint_dcid(prefix="provenance", token=value)
 
     @model_validator(mode="after")
-    def _validate_filename_or_pattern(self) -> "InputFile":
+    def _validate_entry(self) -> "InputFile":
         if (self.filename is None) == (self.pattern is None):
             raise ValueError("Exactly one of 'filename' or 'pattern' must be set.")
+        if self.is_mcf:
+            # An MCF file holds node definitions, not observations, so none of the
+            # observation settings below apply.
+            return self
         if self.filename is not None and not self.filename.lower().endswith(".csv"):
             raise ValueError(f'filename "{self.filename}" must have a .csv extension.')
+        if self.column_mappings is None:
+            self.column_mappings = ColumnMappings()
+        if self.data_format is None:
+            self.data_format = "variablePerRow"
         return self

--- a/tests/goldens/multi_entity_import/config.json
+++ b/tests/goldens/multi_entity_import/config.json
@@ -12,6 +12,10 @@
                 "custom:destinationCountry": "Destination"
             },
             "format": "variablePerRow"
+        },
+        {
+            "pattern": "*.mcf",
+            "provenance": "dcid:provenance/MyProvenance"
         }
     ]
 }

--- a/tests/goldens/multi_provenance_import/config.json
+++ b/tests/goldens/multi_provenance_import/config.json
@@ -1,0 +1,32 @@
+{
+    "importName": "multi_provenance_import",
+    "inputFiles": [
+        {
+            "pattern": "provenance.mcf",
+            "provenance": "dcid:provenance/ProvA"
+        },
+        {
+            "pattern": "custom_nodes.mcf",
+            "provenance": "dcid:provenance/ProvA"
+        },
+        {
+            "pattern": "provenance_b.mcf",
+            "provenance": "dcid:provenance/ProvB"
+        },
+        {
+            "pattern": "nodes_b.mcf",
+            "provenance": "dcid:provenance/ProvB"
+        },
+        {
+            "filename": "data_a.csv",
+            "provenance": "dcid:provenance/ProvA",
+            "columnMappings": {
+                "dcid:variableMeasured": "Var",
+                "dcid:observationDate": "Year",
+                "dcid:value": "Val",
+                "dcid:observationAbout": "Country"
+            },
+            "format": "variablePerRow"
+        }
+    ]
+}

--- a/tests/goldens/multi_provenance_import/custom_nodes.mcf
+++ b/tests/goldens/multi_provenance_import/custom_nodes.mcf
@@ -1,0 +1,5 @@
+Node: dcid:VarA
+name: "Var A"
+typeOf: dcid:StatisticalVariable
+statType: dcid:measuredValue
+

--- a/tests/goldens/multi_provenance_import/data_a.csv
+++ b/tests/goldens/multi_provenance_import/data_a.csv
@@ -1,0 +1,2 @@
+Var,Country,Year,Val
+dcid:VarA,country/FRA,2026,1.0

--- a/tests/goldens/multi_provenance_import/nodes_b.mcf
+++ b/tests/goldens/multi_provenance_import/nodes_b.mcf
@@ -1,0 +1,5 @@
+Node: dcid:VarB
+name: "Var B"
+typeOf: dcid:StatisticalVariable
+statType: dcid:measuredValue
+

--- a/tests/goldens/multi_provenance_import/provenance.mcf
+++ b/tests/goldens/multi_provenance_import/provenance.mcf
@@ -1,0 +1,11 @@
+Node: dcid:source/MySource
+name: "My Source"
+typeOf: dcid:Source
+url: "https://mysource.com"
+
+Node: dcid:provenance/ProvA
+name: "Prov A"
+typeOf: dcid:Provenance
+url: "https://mysource.com/a"
+source: dcid:source/MySource
+

--- a/tests/goldens/multi_provenance_import/provenance_b.mcf
+++ b/tests/goldens/multi_provenance_import/provenance_b.mcf
@@ -1,0 +1,6 @@
+Node: dcid:provenance/ProvB
+name: "Prov B"
+typeOf: dcid:Provenance
+url: "https://mysource.com/b"
+source: dcid:source/MySource
+

--- a/tests/goldens/single_entity_import/config.json
+++ b/tests/goldens/single_entity_import/config.json
@@ -23,6 +23,10 @@
                 "customProp": "customValue"
             },
             "format": "variablePerRow"
+        },
+        {
+            "pattern": "*.mcf",
+            "provenance": "dcid:provenance/MyProvenance"
         }
     ]
 }

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -242,6 +242,14 @@ def test_add_input_file_pattern_xor_filename():
         manager.add_input_file(file_name="a.csv", pattern="a*", provenance="p1")
 
 
+def test_add_mcf_file_requires_mcf_extension():
+    """add_mcf_file rejects a name that is not an MCF file."""
+    manager = CustomDataManager()
+
+    with pytest.raises(ValueError, match=r"should match pattern"):
+        manager.add_mcf_file("nodes.csv", provenance="p1")
+
+
 def test_export_methods(tmp_path):
     """
     Exercises export_config, export_data, and export_mcf_file.

--- a/tests/test_export_bundles.py
+++ b/tests/test_export_bundles.py
@@ -85,6 +85,64 @@ def test_export_bundle_single_entity(tmp_path):
             "customProp": "customValue",
         },
     )
+    manager.add_mcf_file("*.mcf", provenance="MyProvenance")
+
+    output_dir = tmp_path / import_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manager.export_all(output_dir)
+
+    assert_bundle_equal((GOLDEN_DIR / import_name), (tmp_path / import_name))
+
+
+def test_export_bundle_multi_provenance(tmp_path):
+    import_name = "multi_provenance_import"
+    manager = CustomDataManager()
+    manager.set_import_name(import_name)
+    manager.add_source(
+        dcid="MySource",
+        name="My Source",
+        url="https://mysource.com",
+    )
+    manager.add_mcf_file("provenance.mcf", provenance="ProvA")
+    manager.add_mcf_file("custom_nodes.mcf", provenance="ProvA")
+    manager.add_mcf_file("provenance_b.mcf", provenance="ProvB")
+    manager.add_mcf_file("nodes_b.mcf", provenance="ProvB")
+    manager.add_provenance(
+        dcid="ProvA",
+        name="Prov A",
+        url="https://mysource.com/a",
+        source="MySource",
+    )
+    manager.add_provenance(
+        dcid="ProvB",
+        name="Prov B",
+        url="https://mysource.com/b",
+        source="MySource",
+        mcf_file_name="provenance_b.mcf",
+    )
+    manager.add_variable_to_mcf(dcid="dcid:VarA", name="Var A")
+    manager.add_variable_to_mcf(
+        dcid="dcid:VarB", name="Var B", mcf_file_name="nodes_b.mcf"
+    )
+
+    manager.add_input_file(
+        "data_a.csv",
+        provenance="ProvA",
+        data=pd.DataFrame(
+            {
+                "Var": ["dcid:VarA"],
+                "Country": ["country/FRA"],
+                "Year": [2026],
+                "Val": [1.0],
+            }
+        ),
+        column_mappings={
+            "variable": "Var",
+            "observationAbout": "Country",
+            "date": "Year",
+            "value": "Val",
+        },
+    )
 
     output_dir = tmp_path / import_name
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -144,6 +202,7 @@ def test_export_bundle_multi_entity(tmp_path):
             "custom:destinationCountry": "Destination",
         },
     )
+    manager.add_mcf_file("*.mcf", provenance="MyProvenance")
 
     output_dir = tmp_path / import_name
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -80,9 +80,24 @@ def test_input_file_provenance_minted():
     assert already_minted.provenance == "dcid:provenance/myProv"
 
 
+def test_mcf_input_file_carries_only_provenance():
+    """An .mcf entry needs no columnMappings and emits no format."""
+    entry = InputFile(pattern="*.mcf", provenance="myProv")
+
+    assert entry.is_mcf
+    assert entry.model_dump(exclude_none=True, by_alias=True) == {
+        "pattern": "*.mcf",
+        "provenance": "dcid:provenance/myProv",
+    }
+
+
 @pytest.mark.parametrize(
     "golden_file",
-    ["single_entity_import/config.json", "multi_entity_import/config.json"],
+    [
+        "single_entity_import/config.json",
+        "multi_entity_import/config.json",
+        "multi_provenance_import/config.json",
+    ],
 )
 def test_config_round_trips_from_json(tmp_path, golden_file):
     data = json.loads((GOLDEN_DIR / golden_file).read_text())

--- a/tests/test_models_config_file.py
+++ b/tests/test_models_config_file.py
@@ -62,6 +62,14 @@ def test_input_file_filename_pattern_xor():
     assert by_pattern.filename is None
 
 
+def test_input_file_rejects_mcf_filename():
+    """`filename` entries are treated as data-bearing CSV targets, so a `.mcf` filename
+    would silently be handled as a CSV.
+    """
+    with pytest.raises(ValueError, match="csv extension"):
+        InputFile(filename="nodes.mcf", provenance="p1")
+
+
 def test_input_file_provenance_minted():
     """InputFile mints the provenance to dcid:provenance/<name>."""
     entry = InputFile(


### PR DESCRIPTION
## What and Why

- Updates `InputFile` to represent any `inputFiles` entry in the `config.json` which can be CSV or MCF (previously only supported CSVs)
- Adds `CustomDataManager.add_mcf_file(file_name, provenance=...)` to declare an MCF file in the `config.json`

Closes https://github.com/ONEcampaign/dcp-tools/issues/153

## Example

The new workflow is:

```python
manager.add_mcf_file("*.mcf", provenance="MyProvenance")
manager.export_all("output_dir")
```

Resulting in the following entry in the `config.json` file:

```json
"inputFiles": [
    {
        "pattern": "*.mcf",
        "provenance": "dcid:provenance/MyProvenance"
    },
```

## Notes for the reviewer

I chose to make this an additive change which required explicit registering for the user, as this required the least amount of immediate refactoring to unblock downstream usage, but we could create a follow-up task to add MCF files to the config.json automatically, as noted in https://github.com/ONEcampaign/dcp-tools/issues/153.