### PR TITLE
feat: add `constraint_properties` to `StatVarNode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `add_mcf_file(file_name, provenance=...)` declares an MCF file in `config.json`'s `inputFiles`,
   so the importer reads it. The importer skips MCF files that aren't declared.
+- `constraint_properties` on `StatVarNode` and as a parameter on
+  `CustomDataManager.add_variable_to_mcf`, listing the DCID(s) of properties that constrain the
+  StatisticalVariable. Bare tokens are minted to `dcid:<token>`.
 
 ### Changed
 - `InputFile` represents both CSV and MCF entries. An entry targeting an `.mcf` file carries only

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -8,6 +8,9 @@
 - Added `add_mcf_file(file_name, provenance=...)` to declare an MCF file in `config.json`'s
   `inputFiles`. `add_mcf_file("*.mcf", provenance=...)` covers them all in a single-provenance
   import; declare each file separately when an import has more than one provenance.
+- Added `constraint_properties` to `StatVarNode` and as a parameter on `add_variable_to_mcf`,
+  for the DCID(s) of properties that constrain the StatisticalVariable. Bare tokens are minted
+  to `dcid:<token>`.
 
 ## v1.0.0a1 (2026-07-27)
 

--- a/src/dcp_tools/custom_data/data_management.py
+++ b/src/dcp_tools/custom_data/data_management.py
@@ -530,6 +530,7 @@ class CustomDataManager:
         provenance: str | None = None,
         population_type: str | None = None,
         measured_property: str | None = None,
+        constraint_properties: list[str] | None = None,
         measurement_qualifier: str | None = None,
         measurement_denominator: str | None = None,
         observation_properties: list[str] | None = None,
@@ -554,6 +555,8 @@ class CustomDataManager:
             provenance: Provenance of the variable (Optional)
             population_type: Population type of the variable (Optional)
             measured_property: Measured property of the variable (Optional)
+            constraint_properties: DCID(s) of the properties that constrain the
+                StatisticalVariable. Bare tokens are minted to ``dcid:<token>`` (Optional)
             measurement_qualifier: Measurement qualifier of the variable (Optional)
             measurement_denominator: Measurement denominator of the variable (Optional)
             observation_properties: For multi-entity data, the list of dcid:-prefixed properties

--- a/src/dcp_tools/custom_data/models/stat_vars.py
+++ b/src/dcp_tools/custom_data/models/stat_vars.py
@@ -46,6 +46,7 @@ class StatVarNode(Node):
         search_description: Optional descriptions enhancing NL search capabilities.
         population_type: Optional DCID of the population entity type being measured.
         measured_property: Optional DCID of the property being measured.
+        constraint_properties: Optional DCID(s) of the properties that constrain the StatisticalVariable.
         measurement_qualifier: Optional qualifier describing measurement specifics.
         measurement_denominator: Optional denominator for ratio-type statistical measures.
         footnote: Optional footnotes providing additional context or information.
@@ -59,6 +60,7 @@ class StatVarNode(Node):
     search_description: QuotedStrListOrStr | None = None
     population_type: Dcid | None = None
     measured_property: Dcid | None = None
+    constraint_properties: DcidOrListDcid | None = None
     measurement_qualifier: Dcid | None = None
     measurement_denominator: Dcid | None = None
     footnote: QuotedStrListOrStr | None = None

--- a/tests/goldens/single_entity_import/custom_nodes.mcf
+++ b/tests/goldens/single_entity_import/custom_nodes.mcf
@@ -4,4 +4,5 @@ typeOf: dcid:StatisticalVariable
 description: "Description for Test Var."
 statType: dcid:measuredValue
 memberOf: dcid:one/g/group1
+constraintProperties: dcid:age, dcid:gender
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -1016,6 +1016,19 @@ def test_add_variable_to_mcf_passes_prefixed_reference_fields_through():
     assert node.measured_property == "dcid:count"
 
 
+def test_add_variable_to_mcf_accepts_constraint_properties():
+    """constraint_properties is forwarded to the StatVarNode and bare tokens are minted."""
+    manager = CustomDataManager()
+    manager.add_variable_to_mcf(
+        dcid="StatVar",
+        name="Variable Name",
+        constraint_properties=["age", "gender"],
+    )
+    node = manager._mcf_nodes[DEFAULT_STATVAR_MCF_NAME].nodes[0]
+    assert isinstance(node, StatVarNode)
+    assert node.constraint_properties == ["dcid:age", "dcid:gender"]
+
+
 def test_add_entity_type_lands_node():
     """add_entity_type normalizes bare Node to dcid: and sets typeOf."""
     manager = CustomDataManager()

--- a/tests/test_export_bundles.py
+++ b/tests/test_export_bundles.py
@@ -61,6 +61,7 @@ def test_export_bundle_single_entity(tmp_path):
         name="Test Var",
         description="Description for Test Var.",
         member_of="dcid:one/g/group1",
+        constraint_properties=["age", "gender"],
     )
     manager.add_input_file(
         "subdir/data.csv",

--- a/tests/test_models_stat_vars.py
+++ b/tests/test_models_stat_vars.py
@@ -117,6 +117,22 @@ def test_observation_properties_rejects_whitespace_bearing_token():
         StatVarNode(dcid="dcid:n1", name="Var", observation_properties="has space")
 
 
+def test_constraint_properties_normalizes_bare_scalar_and_list():
+    sv = StatVarNode(dcid="dcid:n1", name="Var", constraint_properties="age")
+    assert sv.constraint_properties == "dcid:age"
+
+    sv_list = StatVarNode(
+        dcid="dcid:n1", name="Var", constraint_properties=["age", "gender"]
+    )
+    assert sv_list.constraint_properties == ["dcid:age", "dcid:gender"]
+    assert "constraintProperties: dcid:age, dcid:gender" in sv_list.to_mcf()
+
+
+def test_constraint_properties_rejects_whitespace_bearing_token():
+    with pytest.raises(ValidationError):
+        StatVarNode(dcid="dcid:n1", name="Var", constraint_properties="has space")
+
+
 def test_relevant_variable_normalizes_bare_scalar_and_list():
     sv = StatVarNode(dcid="dcid:n1", name="Var", relevant_variable="otherVar")
     assert sv.relevant_variable == "dcid:otherVar"


### PR DESCRIPTION
Closes https://github.com/ONEcampaign/dcp-tools/issues/151

- Adds `constraint_properties` to `StatVarNode`
- Adds `constraint_properties` to `CustomDataManager.add_variable_to_mcf`
- Updates tests and docs
