### PR TITLE
feat(gcp_utilities)!: add support for DCP 1.1.1's ingestion workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `constraint_properties` on `StatVarNode` and as a parameter on
   `CustomDataManager.add_variable_to_mcf`, listing the DCID(s) of properties that constrain the
   StatisticalVariable. Bare tokens are minted to `dcid:<token>`.
+- **Breaking:** required `ingestion_workflow_name` (`INGESTION_WORKFLOW_NAME`) setting on
+  `KGSettings`, the name of the Cloud Workflow that runs ingestion. Every existing `.env`/settings
+  JSON needs this added before `KGSettings` will construct.
 
 ### Changed
 - `InputFile` represents both CSV and MCF entries. An entry targeting an `.mcf` file carries only
   a `provenance` — no `columnMappings` and no `format`. CSV entries are unchanged.
+- **Breaking:** bumped the `datacommons-admin` floor to `>=1.1.1`. `IngestionJobClient.start_job`
+  is gone in that release, replaced by `start_workflow`, which needs the new
+  `ingestion_workflow_name` setting above in addition to the existing `load_job_name`.
 
 ### Fixed
 - `ProvenanceNode.source_link` is renamed to `source`, so a provenance's parent
   source now serializes as `source: dcid:source/<name>` (was `sourceLink:`), the property name
   Data Commons ingestion preprocessing expects.
+- `run_data_load` (and the CLI's `dataload`/`pipeline` commands) stopped working against a Data
+  Commons Platform instance upgraded to 1.1.1, since the ingestion process moved from a directly
+  invoked Cloud Run job to a Cloud Workflow execution. See the breaking changes above.
 
 ## [1.0.0a1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `run_data_load` (and the CLI's `dataload`/`pipeline` commands) stopped working against a Data
   Commons Platform instance upgraded to 1.1.1, since the ingestion process moved from a directly
   invoked Cloud Run job to a Cloud Workflow execution. See the breaking changes above.
+- `run_data_load` (and the CLI's `dataload`/`pipeline` commands) now loads every import when
+  none are named.
 
 ## [1.0.0a1] - 2026-07-27
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -13,6 +13,8 @@
   to `dcid:<token>`.
 - **Breaking:** `datacommons-admin` was bumped to `>=1.1.1` and now required a
   `ingestion_workflow_name` (`INGESTION_WORKFLOW_NAME`) setting.
+- Fixed `run_data_load` and the `dataload`/`pipeline` commands not loading every import when
+  none are named.
 
 ## v1.0.0a1 (2026-07-27)
 

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -11,6 +11,8 @@
 - Added `constraint_properties` to `StatVarNode` and as a parameter on `add_variable_to_mcf`,
   for the DCID(s) of properties that constrain the StatisticalVariable. Bare tokens are minted
   to `dcid:<token>`.
+- **Breaking:** `datacommons-admin` was bumped to `>=1.1.1` and now required a
+  `ingestion_workflow_name` (`INGESTION_WORKFLOW_NAME`) setting.
 
 ## v1.0.0a1 (2026-07-27)
 

--- a/docs/docs/cli-tools.md
+++ b/docs/docs/cli-tools.md
@@ -32,7 +32,8 @@ settings are read from a `.env` file in the current directory.
   "GCS_INPUT_FOLDER_PATH": "climate-finance",
   "GCS_OUTPUT_FOLDER_PATH": "climate-finance/output",
   "LOAD_JOB_REGION": "us-central1",
-  "LOAD_JOB_NAME": "dcp-prep-job"
+  "LOAD_JOB_NAME": "dcp-prep-job",
+  "INGESTION_WORKFLOW_NAME": "dcp-prep-workflow"
 }
 ```
 
@@ -44,6 +45,7 @@ GCS_INPUT_FOLDER_PATH=climate-finance
 GCS_OUTPUT_FOLDER_PATH=climate-finance/output
 LOAD_JOB_REGION=us-central1
 LOAD_JOB_NAME=dcp-prep-job
+INGESTION_WORKFLOW_NAME=dcp-prep-workflow
 ```
 
 !!! note

--- a/docs/docs/loading-data.md
+++ b/docs/docs/loading-data.md
@@ -18,7 +18,8 @@ Upload an exported data bundle to Google Cloud Storage, then trigger the Data Co
   - `gcs_output_folder_path` (`GCS_OUTPUT_FOLDER_PATH`): folder the pipeline writes its output to.
   - `load_job_region` (`LOAD_JOB_REGION`): region of the Cloud Run load job.
   - `load_job_name` (`LOAD_JOB_NAME`): name of the Cloud Run load job.
-  - `load_job_service_account` (`LOAD_JOB_SERVICE_ACCOUNT`, optional): service account to impersonate when triggering the job. Leave unset to use your own credentials.
+  - `ingestion_workflow_name` (`INGESTION_WORKFLOW_NAME`): name of the Cloud Workflow that runs the ingestion.
+  - `load_job_service_account` (`LOAD_JOB_SERVICE_ACCOUNT`, optional): service account to impersonate when triggering the workflow. Leave unset to use your own credentials.
 
 ## Steps
 
@@ -46,7 +47,8 @@ Upload an exported data bundle to Google Cloud Storage, then trigger the Data Co
      "GCS_INPUT_FOLDER_PATH": "customdc/input",
      "GCS_OUTPUT_FOLDER_PATH": "customdc/output",
      "LOAD_JOB_REGION": "us-central1",
-     "LOAD_JOB_NAME": "dc-load-job"
+     "LOAD_JOB_NAME": "dc-load-job",
+     "INGESTION_WORKFLOW_NAME": "dc-load-workflow"
    }
    ```
 
@@ -63,6 +65,7 @@ Upload an exported data bundle to Google Cloud Storage, then trigger the Data Co
        GCS_OUTPUT_FOLDER_PATH="customdc/output",
        LOAD_JOB_REGION="us-central1",
        LOAD_JOB_NAME="dc-load-job",
+       INGESTION_WORKFLOW_NAME="dc-load-workflow",
    )
    ```
 
@@ -86,7 +89,7 @@ Upload an exported data bundle to Google Cloud Storage, then trigger the Data Co
    dcp-tools upload --env-file customDC.env --sync
    ```
 
-1. **Trigger ingestion.** This starts the DCP prep job against whatever is currently in `gcs_input_folder_path`.
+1. **Trigger ingestion.** This starts the DCP ingestion workflow against whatever is currently in `gcs_input_folder_path`.
 
    ```python
    from dcp_tools.gcp_utilities import run_data_load
@@ -107,7 +110,7 @@ Upload an exported data bundle to Google Cloud Storage, then trigger the Data Co
 
    `pipeline` always loads every import. It has no `--imports` flag. If you need to load a subset, run `upload` then `dataload --imports=...` separately.
 
-`run_data_load` returns as soon as the job starts. It doesn't wait for the job to finish. Under the hood it calls `datacommons-admin`'s `IngestionJobClient`, which starts the DCP prep job. That job ingests the uploaded data and serves it automatically. There's nothing further to trigger from `dcp-tools`.
+`run_data_load` returns as soon as the workflow execution starts. It doesn't wait for it to finish. Under the hood it calls `datacommons-admin`'s `IngestionJobClient`, which starts the Cloud Workflow (`ingestion_workflow_name`) that ingests the uploaded data and serves it automatically. There's nothing further to trigger from `dcp-tools`.
 
 !!! note
     Older versions of this package required a separate `redeploy` call after the load job, plus a set of `CLOUD_SQL_*` settings to reach the underlying database. Both are gone. The DCP prep job now owns the restart, and there's no Cloud SQL in the current architecture.
@@ -132,14 +135,14 @@ print(get_unregistered_csv_files(bucket, config, gcs_folder_name=settings.gcs_in
 
 Both should return `[]`. A non-empty `get_missing_csv_files` result means a file the config expects never made it to GCS (upload failed, or it ran against the wrong folder). A non-empty `get_unregistered_csv_files` result means there's a stray CSV in the bucket that no `inputFiles` entry points at.
 
-The load job itself runs as a Cloud Run job (`load_job_name` in `load_job_region`). Its run history and logs are visible in the Google Cloud Console under Cloud Run > Jobs, not through `dcp-tools`.
+Ingestion itself runs as a Cloud Workflow execution (`ingestion_workflow_name` in `load_job_region`). Its run history and logs are visible in the Google Cloud Console under Workflows, not through `dcp-tools`.
 
 ## Troubleshooting
 
 - **`KGSettings`/`get_kg_settings` raises a `pydantic.ValidationError` listing several fields as "Field required".** One or more required settings are missing from your `.env`/JSON file, or weren't passed to the constructor. Every field except `gcp_credentials` and `load_job_service_account` is required. Check the list under [Before you start](#before-you-start).
 - **`GCP_CREDENTIALS` raises `Invalid JSON`.** `gcp_credentials` expects the *contents* of a service-account key as a JSON string, not a file path. Read the key file and pass its contents (`Path("key.json").read_text()`), or leave the setting unset to use Application Default Credentials.
 - **`get_missing_csv_files` reports every registered CSV as missing, even though the upload succeeded.** Both functions treat a `gcs_folder_name` that doesn't match anything in the bucket as an empty folder rather than raising: `get_missing_csv_files` then reports every `inputFiles` entry as missing, and `get_unregistered_csv_files` reports nothing (there's nothing to compare against). Check `gcs_input_folder_path` for a typo, or confirm the upload step ran first. Leading and trailing slashes are stripped automatically, so those aren't the issue.
-- **`run_data_load` raises `RuntimeError: Failed to start data load job: ...`.** The underlying `IngestionJobClient` call failed, most often from a wrong `load_job_name`/`load_job_region`, or a `load_job_service_account` that isn't allowed to invoke the job.
+- **`run_data_load` raises `RuntimeError: Failed to start data load job: ...`.** The underlying `IngestionJobClient` call failed, most often from a wrong `ingestion_workflow_name`/`load_job_name`/`load_job_region`, or a `load_job_service_account` that isn't allowed to invoke the workflow.
 
 ## See also
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas>=2.2.3,<4.0.0",
     "pydantic-settings>=2.9.1,<3.0.0",
     "google-cloud-storage>=3.1.0,<4.0.0",
-    "datacommons-admin>=1.1.0",
+    "datacommons-admin>=1.1.1",
 ]
 keywords = ["data-commons", "datacommons", "dcp", "etl", "statistics"]
 classifiers = [

--- a/src/dcp_tools/gcp_utilities/jobs.py
+++ b/src/dcp_tools/gcp_utilities/jobs.py
@@ -1,4 +1,4 @@
-"""This module contains functions to run the Cloud Run data load job."""
+"""This module contains functions to run the data ingestion workflow."""
 
 from datacommons_admin.ingestion_job_client import IngestionJobClient
 
@@ -9,23 +9,30 @@ from dcp_tools.logger import logger
 def run_data_load_job(
     settings: KGSettings, *, imports: str | None = "ALL_IMPORTS"
 ) -> None:
-    """Trigger a Cloud Run job to load data.
+    """Trigger the ingestion workflow to load data into the knowledge graph.
 
     Args:
-        settings (KGSettings): Settings for the job.
+        settings (KGSettings): Settings for the workflow.
         imports (str | None): Comma-separated list of imports to load. Defaults to "ALL_IMPORTS".
     """
-    logger.info(f"Starting data load job '{settings.load_job_name}'")
+    logger.info(
+        f"Starting data ingestion workflow '{settings.ingestion_workflow_name}'"
+    )
     try:
         client = IngestionJobClient(
             job_name=settings.load_job_name,
+            workflow_name=settings.ingestion_workflow_name,
             # datacommons-admin annotates service_account_email as `str` but defaults it
             # to None and handles None at runtime; the annotation should be `str | None`.
             service_account_email=settings.load_job_service_account,  # ty: ignore[invalid-argument-type]
             project_id=settings.gcp_project_id,
             location=settings.load_job_region,
         )
-        client.start_job(imports=imports)
-        logger.info(f"Started job '{client.full_job_name}'")
+        result = client.start_workflow(imports=imports)
+        workflow_execution_id = result.get("name")
+        if workflow_execution_id:
+            logger.info(f"Started workflow execution '{workflow_execution_id}'")
+        else:
+            logger.warning("Failed to retrieve workflow execution id")
     except Exception as e:
         raise RuntimeError(f"Failed to start data load job: {e}") from e

--- a/src/dcp_tools/gcp_utilities/jobs.py
+++ b/src/dcp_tools/gcp_utilities/jobs.py
@@ -6,14 +6,12 @@ from dcp_tools.gcp_utilities.settings import KGSettings
 from dcp_tools.logger import logger
 
 
-def run_data_load_job(
-    settings: KGSettings, *, imports: str | None = "ALL_IMPORTS"
-) -> None:
+def run_data_load_job(settings: KGSettings, *, imports: str | None = None) -> None:
     """Trigger the ingestion workflow to load data into the knowledge graph.
 
     Args:
         settings (KGSettings): Settings for the workflow.
-        imports (str | None): Comma-separated list of imports to load. Defaults to "ALL_IMPORTS".
+        imports (str | None): Comma-separated list of imports to load. All imports are loaded if omitted.
     """
     logger.info(
         f"Starting data ingestion workflow '{settings.ingestion_workflow_name}'"
@@ -28,7 +26,7 @@ def run_data_load_job(
             project_id=settings.gcp_project_id,
             location=settings.load_job_region,
         )
-        result = client.start_workflow(imports=imports)
+        result = client.start_workflow(imports=imports or "ALL_IMPORTS")
         workflow_execution_id = result.get("name")
         if workflow_execution_id:
             logger.info(f"Started workflow execution '{workflow_execution_id}'")

--- a/src/dcp_tools/gcp_utilities/settings.py
+++ b/src/dcp_tools/gcp_utilities/settings.py
@@ -39,6 +39,7 @@ class KGSettings(BaseSettings):
     # Cloud run
     load_job_region: str = Field(alias="LOAD_JOB_REGION")
     load_job_name: str = Field(alias="LOAD_JOB_NAME")
+    ingestion_workflow_name: str = Field(alias="INGESTION_WORKFLOW_NAME")
     load_job_service_account: str | None = Field(
         alias="LOAD_JOB_SERVICE_ACCOUNT", default=None
     )

--- a/tests/test_cli_gcp.py
+++ b/tests/test_cli_gcp.py
@@ -35,7 +35,20 @@ def test_dataload_command_invokes_pipeline() -> None:
         run.assert_called_once_with(settings=get.return_value, imports=None)
 
 
-def test_dataload_command_invokes_pipeline_with_imports() -> None:
+def test_dataload_command_defaults_to_all_imports() -> None:
+    with (
+        patch("dcp_tools.cli.common.get_kg_settings") as get,
+        patch("dcp_tools.gcp_utilities.jobs.IngestionJobClient") as client,
+    ):
+        get.return_value = Mock()
+        exit_code = main(["dataload", "--env-file", "e"])
+        assert exit_code == 0
+        client.return_value.start_workflow.assert_called_once_with(
+            imports="ALL_IMPORTS"
+        )
+
+
+def test_dataload_command_invokes_pipeline_with_names_imports() -> None:
     with (
         patch("dcp_tools.cli.common.get_kg_settings") as get,
         patch("dcp_tools.cli.data_load.run_data_load") as run,

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -13,6 +13,7 @@ TEST_SETTINGS = KGSettings(
     GCS_INPUT_FOLDER_PATH="ingestion/input/",
     GCS_OUTPUT_FOLDER_PATH="/output/path/",
     LOAD_JOB_NAME="test_job",
+    INGESTION_WORKFLOW_NAME="test_workflow",
     LOAD_JOB_REGION="test_region",
     LOAD_JOB_SERVICE_ACCOUNT="test@example.com",
 )
@@ -24,11 +25,12 @@ def test_run_data_load_job() -> None:
 
         patch_client.assert_called_once_with(
             job_name="test_job",
+            workflow_name="test_workflow",
             service_account_email="test@example.com",
             project_id="test_proj",
             location="test_region",
         )
-        patch_client.return_value.start_job.assert_called_once_with(
+        patch_client.return_value.start_workflow.assert_called_once_with(
             imports="test_import_a,test_import_b"
         )
 
@@ -39,19 +41,33 @@ def test_run_data_load_job_no_imports() -> None:
 
         patch_client.assert_called_once_with(
             job_name="test_job",
+            workflow_name="test_workflow",
             service_account_email="test@example.com",
             project_id="test_proj",
             location="test_region",
         )
-        patch_client.return_value.start_job.assert_called_once_with(
+        patch_client.return_value.start_workflow.assert_called_once_with(
             imports="ALL_IMPORTS"
+        )
+
+
+def test_run_data_ingestion_workflow_warns_when_execution_id_missing() -> None:
+    """A response with no 'name' key logs a warning instead of raising."""
+    with (
+        patch("dcp_tools.gcp_utilities.jobs.IngestionJobClient") as patch_client,
+        patch("dcp_tools.gcp_utilities.jobs.logger") as mock_logger,
+    ):
+        patch_client.return_value.start_workflow.return_value = {}
+        run_data_load_job(TEST_SETTINGS)
+        mock_logger.warning.assert_called_once_with(
+            "Failed to retrieve workflow execution id"
         )
 
 
 def test_run_data_load_job_wraps_errors() -> None:
     with patch("dcp_tools.gcp_utilities.jobs.IngestionJobClient") as patch_client:
         original_exception = Exception("Test exception")
-        patch_client.return_value.start_job.side_effect = original_exception
+        patch_client.return_value.start_workflow.side_effect = original_exception
         with pytest.raises(RuntimeError, match="Test exception") as exc_info:
             run_data_load_job(TEST_SETTINGS)
         assert exc_info.value.__cause__ == original_exception

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -474,6 +474,7 @@ def test_gcs_input_folder_path_strips_slashes(monkeypatch):
         "GCS_INPUT_FOLDER_PATH": "ingestion/input/",
         "GCS_OUTPUT_FOLDER_PATH": "/output/path/",
         "LOAD_JOB_NAME": "job",
+        "INGESTION_WORKFLOW_NAME": "workflow",
         "LOAD_JOB_REGION": "us-central1",
         "LOAD_JOB_SERVICE_ACCOUNT": "test@example.com",
     }

--- a/uv.lock
+++ b/uv.lock
@@ -288,16 +288,16 @@ wheels = [
 
 [[package]]
 name = "datacommons-admin"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "google-cloud-storage" },
     { name = "pyopenssl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/b4/704c4b918a740c46b8f931e9daed31cee7ff103be8785c3c6c264045fd83/datacommons_admin-1.1.0.tar.gz", hash = "sha256:c624b614acaf8f9e45343354fc9272b675bae81f2f93e64bd80d85bda1c1b95e", size = 15458, upload-time = "2026-06-23T11:37:35.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/f2/e412c77578eaf460a0247963da00928c793c0c49e657a87c0ae6e2857f2a/datacommons_admin-1.1.1.tar.gz", hash = "sha256:a4364dab421bd0f2f7ef8f9dff40d9a6d4630e17ddf254860863b68481b61050", size = 16193, upload-time = "2026-07-29T03:09:45.227Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/26/ccb1d290abb6523ffdb3ef5abee1821f359fbf61e261cc925140f48d8b20/datacommons_admin-1.1.0-py3-none-any.whl", hash = "sha256:9e91d84ddf6ec465429479cee0436f46c34a0bbede8c7b8567f3bd07bbe47b52", size = 17207, upload-time = "2026-06-23T11:37:34.443Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1e/880c1fe612b4cc0894bb06fac2f910bddea62d7a25ea155e290a55465d8d/datacommons_admin-1.1.1-py3-none-any.whl", hash = "sha256:1032649638e3d793ffa87679acbd9d4091d20e21fd826e127eb27b85eaad31e7", size = 17593, upload-time = "2026-07-29T03:09:44.319Z" },
 ]
 
 [[package]]
@@ -324,7 +324,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "datacommons-admin", specifier = ">=1.1.0" },
+    { name = "datacommons-admin", specifier = ">=1.1.1" },
     { name = "google-cloud-storage", specifier = ">=3.1.0,<4.0.0" },
     { name = "pandas", specifier = ">=2.2.3,<4.0.0" },
     { name = "pydantic", specifier = ">=2.11.3,<3.0.0" },


### PR DESCRIPTION
## What and why

Starting in DCP 1.1.1, we trigger the Cloud Workflow rather than the Cloud Run preprocessing job, so `datacommons-admin`'s `IngestionJobClient.start_job` was changed to `start_workflow`. This change reflects that as well as requiring a new setting `INGESTION_WORKFLOW_NAME` to pass to `start_workflow`.

**Breaking:** Consumers must set new `INGESTION_WORKFLOW_NAME` setting.

Closes https://github.com/ONEcampaign/dcp-tools/issues/155

## Notes for the reviewer

I've kept this change the minimum to unblock ingestion, but I recommend a follow-up task to rename some of the settings, functions, and CLI command to bring them in line with the terminology used by the new DCP version, before the next major version release. Opened https://github.com/ONEcampaign/dcp-tools/issues/160 to track this.