### PR TITLE
fix(settings): accept field names as well as env aliases in KGSettings

### DIFF
--- a/docs/docs/loading-data.md
+++ b/docs/docs/loading-data.md
@@ -14,7 +14,7 @@ Upload an exported data bundle to Google Cloud Storage, then trigger the Data Co
   - `gcp_project_id` (`GCP_PROJECT_ID`): your GCP project ID.
   - `gcp_credentials` (`GCP_CREDENTIALS`, optional): GCP service account credentials as a JSON string. Leave unset to use Application Default Credentials (after `gcloud auth application-default login`).
   - `gcs_bucket_name` (`GCS_BUCKET_NAME`): the Cloud Storage bucket the DCP pipeline reads from.
-  - `gcs_input_folder_path` (`GCS_INPUT_FOLDER_PATH`): folder in that bucket to upload the bundle to.
+  - `gcs_input_folder_path` (`GCS_INPUT_FOLDER_PATH`, optional): folder in that bucket to upload the bundle to. Defaults to `ingestion/input`, the DCP Terraform default.
   - `gcs_output_folder_path` (`GCS_OUTPUT_FOLDER_PATH`): folder the pipeline writes its output to.
   - `load_job_region` (`LOAD_JOB_REGION`): region of the Cloud Run load job.
   - `load_job_name` (`LOAD_JOB_NAME`): name of the Cloud Run load job.
@@ -139,7 +139,7 @@ Ingestion itself runs as a Cloud Workflow execution (`ingestion_workflow_name` i
 
 ## Troubleshooting
 
-- **`KGSettings`/`get_kg_settings` raises a `pydantic.ValidationError` listing several fields as "Field required".** One or more required settings are missing from your `.env`/JSON file, or weren't passed to the constructor. Every field except `gcp_credentials` and `load_job_service_account` is required. Check the list under [Before you start](#before-you-start).
+- **`KGSettings`/`get_kg_settings` raises a `pydantic.ValidationError` listing several fields as "Field required".** One or more required settings are missing from your `.env`/JSON file, or weren't passed to the constructor. Every field except `gcp_credentials`, `gcs_input_folder_path`, and `load_job_service_account` is required. Check the list under [Before you start](#before-you-start).
 - **`GCP_CREDENTIALS` raises `Invalid JSON`.** `gcp_credentials` expects the *contents* of a service-account key as a JSON string, not a file path. Read the key file and pass its contents (`Path("key.json").read_text()`), or leave the setting unset to use Application Default Credentials.
 - **`get_missing_csv_files` reports every registered CSV as missing, even though the upload succeeded.** Both functions treat a `gcs_folder_name` that doesn't match anything in the bucket as an empty folder rather than raising: `get_missing_csv_files` then reports every `inputFiles` entry as missing, and `get_unregistered_csv_files` reports nothing (there's nothing to compare against). Check `gcs_input_folder_path` for a typo, or confirm the upload step ran first. Leading and trailing slashes are stripped automatically, so those aren't the issue.
 - **`run_data_load` raises `RuntimeError: Failed to start data load job: ...`.** The underlying `IngestionJobClient` call failed, most often from a wrong `ingestion_workflow_name`/`load_job_name`/`load_job_region`, or a `load_job_service_account` that isn't allowed to invoke the workflow.

--- a/src/dcp_tools/gcp_utilities/settings.py
+++ b/src/dcp_tools/gcp_utilities/settings.py
@@ -20,28 +20,33 @@ class KGSettings(BaseSettings):
         gcp_credentials: GCP credentials in JSON format. Optional; if not provided,
             Application Default Credentials (ADC) will be used.
         gcs_bucket_name: Google Cloud Storage bucket name.
-        gcs_input_folder_path: Google Cloud Storage input folder path.
+        gcs_input_folder_path: Google Cloud Storage input folder path. Defaults to
+            "ingestion/input", the DCP Terraform default.
         gcs_output_folder_path: Google Cloud Storage output folder path.
         load_job_region: Cloud Run load job region.
         load_job_name: Cloud Run load job name.
         load_job_service_account: Cloud Run service account email to impersonate, optional.
     """
 
-    local_path: Path = Field(alias="LOCAL_PATH")
-    gcp_project_id: str = Field(alias="GCP_PROJECT_ID")
-    gcp_credentials: Json[dict] | None = Field(default=None, alias="GCP_CREDENTIALS")
+    local_path: Path = Field(validation_alias="LOCAL_PATH")
+    gcp_project_id: str = Field(validation_alias="GCP_PROJECT_ID")
+    gcp_credentials: Json[dict] | None = Field(
+        default=None, validation_alias="GCP_CREDENTIALS"
+    )
 
     # Cloud storage
-    gcs_bucket_name: str = Field(alias="GCS_BUCKET_NAME")
-    gcs_input_folder_path: str = Field(alias="GCS_INPUT_FOLDER_PATH")
-    gcs_output_folder_path: str = Field(alias="GCS_OUTPUT_FOLDER_PATH")
+    gcs_bucket_name: str = Field(validation_alias="GCS_BUCKET_NAME")
+    gcs_input_folder_path: str = Field(
+        default="ingestion/input", validation_alias="GCS_INPUT_FOLDER_PATH"
+    )
+    gcs_output_folder_path: str = Field(validation_alias="GCS_OUTPUT_FOLDER_PATH")
 
     # Cloud run
-    load_job_region: str = Field(alias="LOAD_JOB_REGION")
-    load_job_name: str = Field(alias="LOAD_JOB_NAME")
-    ingestion_workflow_name: str = Field(alias="INGESTION_WORKFLOW_NAME")
+    load_job_region: str = Field(validation_alias="LOAD_JOB_REGION")
+    load_job_name: str = Field(validation_alias="LOAD_JOB_NAME")
+    ingestion_workflow_name: str = Field(validation_alias="INGESTION_WORKFLOW_NAME")
     load_job_service_account: str | None = Field(
-        alias="LOAD_JOB_SERVICE_ACCOUNT", default=None
+        validation_alias="LOAD_JOB_SERVICE_ACCOUNT", default=None
     )
 
     @field_validator("gcs_input_folder_path", "gcs_output_folder_path")
@@ -60,7 +65,10 @@ class KGSettings(BaseSettings):
         return f"gs://{self.gcs_bucket_name}/{self.gcs_output_folder_path}"
 
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", case_sensitive=False
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        populate_by_name=True,
     )
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,121 @@
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from dcp_tools.gcp_utilities.settings import KGSettings, get_kg_settings
+
+RAW_SCREAMING = {
+    "LOCAL_PATH": "/tmp/data",
+    "GCP_PROJECT_ID": "proj",
+    "GCS_BUCKET_NAME": "bucket",
+    "GCS_INPUT_FOLDER_PATH": "ingestion/input/",
+    "GCS_OUTPUT_FOLDER_PATH": "/output/path/",
+    "LOAD_JOB_NAME": "job",
+    "INGESTION_WORKFLOW_NAME": "workflow",
+    "LOAD_JOB_REGION": "us-central1",
+    "LOAD_JOB_SERVICE_ACCOUNT": "test@example.com",
+}
+
+RAW_SNAKE = {
+    "local_path": "/tmp/data",
+    "gcp_project_id": "proj",
+    "gcs_bucket_name": "bucket",
+    "gcs_input_folder_path": "ingestion/input/",
+    "gcs_output_folder_path": "/output/path/",
+    "load_job_name": "job",
+    "ingestion_workflow_name": "workflow",
+    "load_job_region": "us-central1",
+    "load_job_service_account": "test@example.com",
+}
+
+
+def test_model_dump_round_trips_to_field_names() -> None:
+    """model_dump() must return snake_case field names callers expect, not aliases."""
+    settings = KGSettings(**RAW_SCREAMING)
+
+    dumped = settings.model_dump()
+
+    assert dumped["local_path"] == Path("/tmp/data")
+    assert dumped["gcp_project_id"] == "proj"
+    assert dumped["gcs_input_folder_path"] == "ingestion/input"
+    assert "LOCAL_PATH" not in dumped
+    assert "GCP_PROJECT_ID" not in dumped
+
+    # Round-trip: dumping and reloading by field name must reproduce the settings.
+    reloaded = KGSettings(**dumped)
+    assert reloaded == settings
+
+
+def test_constructor_accepts_snake_case_field_names() -> None:
+    """populate_by_name=True lets callers construct KGSettings with field names."""
+    settings = KGSettings(**RAW_SNAKE)
+
+    assert settings.local_path == Path("/tmp/data")
+    assert settings.gcp_project_id == "proj"
+    assert settings.gcs_input_folder_path == "ingestion/input"
+
+
+def test_constructor_still_accepts_screaming_snake_aliases() -> None:
+    """Backwards compatibility: the historic SCREAMING_SNAKE keys still work."""
+    settings = KGSettings(**RAW_SCREAMING)
+
+    assert settings.local_path == Path("/tmp/data")
+    assert settings.load_job_service_account == "test@example.com"
+
+
+def test_json_source_loads_screaming_snake_config(tmp_path: Path) -> None:
+    """The documented JSON config convention (SCREAMING_SNAKE keys) keeps working."""
+    config_file = tmp_path / "settings.json"
+    config_file.write_text(json.dumps(RAW_SCREAMING))
+
+    settings = get_kg_settings(source="json", file=config_file)
+
+    assert settings.local_path == Path("/tmp/data")
+    assert settings.gcs_input_folder_path == "ingestion/input"
+
+
+def test_json_source_loads_snake_case_config(tmp_path: Path) -> None:
+    """A JSON config using field names (snake_case) must also populate correctly."""
+    config_file = tmp_path / "settings.json"
+    config_file.write_text(json.dumps(RAW_SNAKE))
+
+    settings = get_kg_settings(source="json", file=config_file)
+
+    assert settings.local_path == Path("/tmp/data")
+    assert settings.gcp_project_id == "proj"
+    assert settings.gcs_input_folder_path == "ingestion/input"
+
+
+def test_json_source_rejects_unknown_keys(tmp_path: Path) -> None:
+    """A mismatched/typo'd key must fail loudly, not silently drop the field."""
+    raw = dict(RAW_SCREAMING)
+    del raw["GCS_INPUT_FOLDER_PATH"]
+    raw["GCS_INPUT_FOLDER_PATHH"] = "typo/oops"
+    config_file = tmp_path / "settings.json"
+    config_file.write_text(json.dumps(raw))
+
+    with pytest.raises(ValidationError):
+        get_kg_settings(source="json", file=config_file)
+
+
+def test_gcs_input_folder_path_defaults_to_ingestion_input() -> None:
+    """A standard DCP Terraform deployment shouldn't need to set this explicitly."""
+    raw = dict(RAW_SCREAMING)
+    del raw["GCS_INPUT_FOLDER_PATH"]
+
+    settings = KGSettings(**raw)
+
+    assert settings.gcs_input_folder_path == "ingestion/input"
+
+
+def test_env_source_still_accepts_screaming_snake(monkeypatch) -> None:
+    """Backwards compatibility: env vars keep using the SCREAMING_SNAKE convention."""
+    for key, value in RAW_SCREAMING.items():
+        monkeypatch.setenv(key, value)
+
+    settings = get_kg_settings(source="env")
+
+    assert settings.local_path == Path("/tmp/data")
+    assert settings.gcs_input_folder_path == "ingestion/input"


### PR DESCRIPTION
Closes #119

`KGSettings` declared its fields with `Field(alias=...)`, which in pydantic v2 makes the SCREAMING_SNAKE environment name the only accepted input key. A caller passing the snake_case field names was rejected, a JSON config file had to be written in SCREAMING_SNAKE, and `KGSettings(**settings.model_dump())` could not round-trip because `model_dump()` emits field names. Switching every field to `validation_alias` and setting `populate_by_name=True` makes both key styles valid through every entry point, including the constructor, `model_validate`, `.env` files and environment variables. Existing SCREAMING_SNAKE input keeps working unchanged.

The issue proposed constructing the JSON branch through `KGSettings(**raw)` instead of `model_validate`. That turned out to be unnecessary, since `populate_by_name` fixes alias resolution for both entry points, and it would route a JSON-sourced config through the full `BaseSettings` pipeline, letting ambient environment variables and `.env` contents leak into what is meant to be a self-contained file. The JSON branch stays on `model_validate`.

Two corrections to the issue as filed, since they change what a reader should expect. `model_dump()` already returned snake_case field names under the old code, because pydantic v2 only applies `alias` on serialization when `by_alias=True` is passed, and nothing here passes it. The described failure was also never silent: `BaseSettings` defaults to `extra="forbid"`, so a snake_case JSON file raised a `ValidationError`. The contract problem the issue identifies is real, but it sits on the input side rather than in `model_dump`.

One public-surface change worth naming. `model_dump(by_alias=True)` now returns snake_case field names where it previously returned the SCREAMING_SNAKE aliases, because `validation_alias` does not affect serialization and no `serialization_alias` is set. Nothing in the package or its docs calls it that way, so this is inert today.

Per the folded-in scope in the issue comments, `gcs_input_folder_path` now defaults to `ingestion/input`, the DCP Terraform default. This is the one deliberate contract change: a deployment that previously failed loudly on a missing `GCS_INPUT_FOLDER_PATH` now takes the default instead, so a deployment using a different input prefix must set it explicitly. The docs are updated in both the field list and the troubleshooting entry that enumerates the required fields.

Testing: `uv run pytest` goes from 235 to 243 passing, with 8 new tests in `tests/test_settings.py`. Four of them fail against the unmodified `settings.py`, confirmed by reverting it and re-running. `ruff check`, `ruff format --check` and `ty check` are clean.
